### PR TITLE
Made delete object delay configurable

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -154,7 +154,7 @@ func main() {
 	dataCleanupRepository := &datacleanup.Repository{DB: db}
 
 	notificationHistoryRepo := &repo.NotificationHistoryRepository{DB: db}
-	queueRepo := &repo.QueueRepository{DB: db}
+	queueRepo := &repo.QueueRepository{DB: db, DeleteObjectDelay: viper.GetString("internal.delete-object-delay")}
 	objectRepo := &repo.ObjectRepository{DB: db, QueueRepo: queueRepo}
 	objectCleanupRepo := &repo.ObjectCleanupRepository{DB: db}
 	objectCopiesRepo := &repo.ObjectCopiesRepository{DB: db}

--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -282,6 +282,8 @@ internal:
     #     local-domain-value: 123456
     # List of user IDs that can use the admin API endpoints.
     admins: []
+    # Cleanup delay of S3/MinIO objects in minutes (default: 45 days = 64800 minutes)
+    # delete-object-delay: 64800
 
 # Replication config
 #

--- a/server/configurations/local.yaml
+++ b/server/configurations/local.yaml
@@ -283,6 +283,8 @@ internal:
     # List of user IDs that can use the admin API endpoints.
     admins: []
     # Cleanup delay of S3/MinIO objects in minutes (default: 45 days = 64800 minutes)
+    # WARNING: Only change this value when you know what you're doing, since this can cause things to break if configured incorrectly.
+    # For example, if replication is enabled then this value should be such that the deletion is never attempted before compliance lock passes.
     # delete-object-delay: 64800
 
 # Replication config


### PR DESCRIPTION
## Description

For self hosting purposes I converted the hardcoded delay of 45 days (before deletion of MinIO/S3 objects) to a configurable parameter (internal.delete-object-delay), via the already used yaml file.