### PR TITLE
[docs] update troubleshooting for desktop and object storage

### DIFF
--- a/docs/docs/photos/faq/desktop.md
+++ b/docs/docs/photos/faq/desktop.md
@@ -37,17 +37,3 @@ be specific to your distro (e.g. `xdg-desktop-menu forceupdate`).
 >
 > If you're using an AppImage and not seeing the icon, you'll need to
 > [enable AppImage desktop integration](/photos/troubleshooting/desktop-install/#appimage-desktop-integration).
-
-### Application reporting offline despite Internet connectivity
-
-Due to unreliability of usage of `navigator.onLine` in Linux, the app may report that you are offline, even though the internet connection is functional.
-
-You can resolve the issue by adding a dummy network interface using the following command:
-
-```shell
-ip link add dummy0 type dummy
-ip addr add 10.10.10.1/24 dev dummy0
-ip link set dummy0 up
-```
-
-Once the interface is up, Ente correctly detects that the system is online.

--- a/docs/docs/photos/faq/desktop.md
+++ b/docs/docs/photos/faq/desktop.md
@@ -37,3 +37,17 @@ be specific to your distro (e.g. `xdg-desktop-menu forceupdate`).
 >
 > If you're using an AppImage and not seeing the icon, you'll need to
 > [enable AppImage desktop integration](/photos/troubleshooting/desktop-install/#appimage-desktop-integration).
+
+### Application reporting offline despite Internet connectivity
+
+Due to unreliability of usage of `navigator.onLine` in Linux, the app may report that you are offline, even though the internet connection is functional.
+
+You can resolve the issue by adding a dummy network interface using the following command:
+
+```shell
+ip link add dummy0 type dummy
+ip addr add 10.10.10.1/24 dev dummy0
+ip link set dummy0 up
+```
+
+Once the interface is up, Ente correctly detects that the system is online.

--- a/docs/docs/photos/troubleshooting/desktop-install/index.md
+++ b/docs/docs/photos/troubleshooting/desktop-install/index.md
@@ -99,3 +99,17 @@ If you do want to run it from the command line, you can do so by passing the
 
 For more details, see this upstream issue on
 [electron](https://github.com/electron/electron/issues/17972).
+
+### Application reporting offline despite Internet connectivity
+
+Due to unreliability of usage of `navigator.onLine` in Linux, the app may report that you are offline, even though the internet connection is functional.
+
+You can resolve the issue by adding a dummy network interface using the following command:
+
+```shell
+ip link add dummy0 type dummy
+ip addr add 10.10.10.1/24 dev dummy0
+ip link set dummy0 up
+```
+
+Once the interface is up, Ente correctly detects that the system is online.

--- a/docs/docs/self-hosting/administration/object-storage.md
+++ b/docs/docs/self-hosting/administration/object-storage.md
@@ -63,17 +63,11 @@ It has no relation to Backblaze, Wasabi or Scaleway.
 Each bucket's endpoint, region, key and secret should be configured accordingly
 if using an external bucket.
 
-Additionally, you can enable SSL and path-style URL for specific buckets, which
-provides flexibility for storage. If this is not configured, top level
-configuration (`s3.are_local_buckets` and `s3.use_path_style_urls`) is used.
-
 A sample configuration for `b2-eu-cen` is provided, which can be used for other
 2 buckets as well:
 
 ```yaml
 b2-eu-cen:
-    are_local_buckets: true
-    use_path_style_urls: true
     key: <key>
     secret: <secret>
     endpoint: localhost:3200

--- a/docs/docs/self-hosting/troubleshooting/docker.md
+++ b/docs/docs/self-hosting/troubleshooting/docker.md
@@ -134,8 +134,7 @@ There are 2 possibilities:
 
 ## MinIO provisioning error
 
-You may encounter similar logs while trying to start the cluster if you are
-using the older command (provided by default in `quickstart.sh`):
+If you encounter similar logs while starting your Docker Compose cluster
 
 ```
 my-ente-minio-1 ->  | Waiting for minio...

--- a/server/config/example.yaml
+++ b/server/config/example.yaml
@@ -23,19 +23,12 @@ s3:
     # Only path-style URL works if disabling are_local_buckets with MinIO
     use_path_style_urls: true
     b2-eu-cen:
-      # You can uncomment the below 2 lines of configuration to 
-      # configure SSL and URL style per bucket.
-      # If not configured, top-level configuration is used.
-      # are_local_buckets: true
-      # use_path_style_urls: true
       key: <key>
       secret: <secret>
       endpoint: localhost:3200
       region: eu-central-2
       bucket: b2-eu-cen
     wasabi-eu-central-2-v3:
-      # are_local_buckets: true
-      # use_path_style_urls: true
       key: <key>
       secret: <secret>
       endpoint: localhost:3200
@@ -43,8 +36,6 @@ s3:
       bucket: wasabi-eu-central-2-v3
       compliance: false
     scw-eu-fr-v3:
-      # are_local_buckets: true
-      # use_path_style_urls: true
       key: <key>
       secret: <secret>
       endpoint: localhost:3200


### PR DESCRIPTION
## Description

This PR updates docs for network status reporting in Ente Desktop on Linux and removes documentation for object storage configuration which will only be available in latest server image to reduce confusion.
