### PR TITLE
[web][photos] fixed-double-click-for-viewing-images-safari-mobile

### DIFF
--- a/web/apps/photos/src/components/FileList.tsx
+++ b/web/apps/photos/src/components/FileList.tsx
@@ -1110,6 +1110,12 @@ const Check = styled("input")<{ $active: boolean }>(
         transform-origin: center;
     }
 
+    @media (pointer: fine) {
+        &::after {
+            border-width: 0 2.5px 2.5px 0;
+        }
+    }
+
     /* checkmark background (filled circle) */
     &:checked::before {
         background-color: ${theme.vars.palette.accent.main};

--- a/web/apps/photos/src/components/FileList.tsx
+++ b/web/apps/photos/src/components/FileList.tsx
@@ -1049,14 +1049,16 @@ const FileThumbnail_ = styled("div")<{ disabled: boolean }>`
         pointer-events: none;
     }
 
-    &:hover {
-        input[type="checkbox"] {
-            visibility: visible;
-            opacity: 0.5;
-        }
+    @media (pointer: fine) {
+        &:hover {
+            input[type="checkbox"] {
+                visibility: visible;
+                opacity: 0.5;
+            }
 
-        .preview-card-hover-overlay {
-            opacity: 1;
+            .preview-card-hover-overlay {
+                opacity: 1;
+            }
         }
     }
 

--- a/web/apps/photos/src/components/FileList.tsx
+++ b/web/apps/photos/src/components/FileList.tsx
@@ -1091,7 +1091,7 @@ const Check = styled("input")<{ $active: boolean }>(
         background-color: #ddd;
         border-radius: 50%;
         margin: 6px;
-        transition: background-color 0.3s ease;
+        transition: background-color 0.3s ease, opacity 0.3s ease;
         position: relative; /* Important for Safari */
     }
     
@@ -1105,33 +1105,41 @@ const Check = styled("input")<{ $active: boolean }>(
         height: 11px;
         border: solid #333;
         border-width: 0 2px 2px 0;
-        transform: translate(-50%, -60%) rotate(45deg) scale(0);
-        transition: transform 0.3s ease;
+        transform: translate(-50%, -60%) rotate(45deg);
+        transition: border-color 0.3s ease, opacity 0.3s ease;
         transform-origin: center;
     }
 
-    @media (pointer: fine) {
-        &::after {
-            border-width: 0 2.5px 2.5px 0;
-        }
+    /* Default state - hide both */
+    visibility: hidden;
+    
+    /* When $active - show both with reduced opacity */
+    ${
+        $active &&
+        `
+        visibility: visible;
+        opacity: 0.5;
+    `
+    };
+    
+    /* Hover state - show both */
+    &:hover {
+        visibility: visible;
+        opacity: 0.7;
     }
-
-    /* checkmark background (filled circle) */
+    
+    /* Checked state - show both with full opacity and colored */
+    &:checked {
+        visibility: visible;
+        opacity: 1 !important;
+    }
+    
     &:checked::before {
         background-color: ${theme.vars.palette.accent.main};
     }
     
-    /* checkmark foreground (tick) - show it */
     &:checked::after {
         border-color: #ddd;
-        transform: translate(-50%, -60%) rotate(45deg) scale(1);
-    }
-    
-    visibility: hidden;
-    ${$active && "visibility: visible; opacity: 0.5;"};
-    &:checked {
-        visibility: visible;
-        opacity: 1 !important;
     }
 `,
 );

--- a/web/apps/photos/src/components/FileList.tsx
+++ b/web/apps/photos/src/components/FileList.tsx
@@ -1068,54 +1068,59 @@ const FileThumbnail_ = styled("div")<{ disabled: boolean }>`
 const Check = styled("input")<{ $active: boolean }>(
     ({ theme, $active }) => `
     appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
     position: absolute;
-    /* Increase z-index in stacking order to capture clicks */
     z-index: 1;
     left: 0;
     outline: none;
     cursor: pointer;
+    width: 31px;
+    height: 31px;
+    box-sizing: border-box;
+    
     @media (pointer: coarse) {
         pointer-events: none;
     }
 
     &::before {
         content: "";
+        display: block; /* Critical for Safari */
         width: 19px;
         height: 19px;
         background-color: #ddd;
-        display: inline-block;
         border-radius: 50%;
-        vertical-align: bottom;
-        margin: 6px 6px;
+        margin: 6px;
         transition: background-color 0.3s ease;
-        pointer-events: inherit;
-
+        position: relative; /* Important for Safari */
     }
+    
     &::after {
         content: "";
+        display: block; /* Critical for Safari */
         position: absolute;
+        top: 50%;
+        left: 50%;
         width: 5px;
         height: 11px;
-        border-right: 2px solid #333;
-        border-bottom: 2px solid #333;
+        border: solid #333;
+        border-width: 0 2px 2px 0;
+        transform: translate(-50%, -60%) rotate(45deg) scale(0);
         transition: transform 0.3s ease;
-        pointer-events: inherit;
-        transform: translate(-18px, 9px) rotate(45deg);
+        transform-origin: center;
     }
 
     /* checkmark background (filled circle) */
     &:checked::before {
-        content: "";
         background-color: ${theme.vars.palette.accent.main};
-        border-color: ${theme.vars.palette.accent.main};
-        color: white;
     }
-    /* checkmark foreground (tick) */
+    
+    /* checkmark foreground (tick) - show it */
     &:checked::after {
-        content: "";
-        border-right: 2px solid #ddd;
-        border-bottom: 2px solid #ddd;
+        border-color: #ddd;
+        transform: translate(-50%, -60%) rotate(45deg) scale(1);
     }
+    
     visibility: hidden;
     ${$active && "visibility: visible; opacity: 0.5;"};
     &:checked {


### PR DESCRIPTION
## Description

Fixed Safari mobile issues: double-click requirement for full-screen image viewer and missing ::after pseudo-element rendering.

## Tests

OS | Browser | Functional
-- | -- | --
Mac M4 | Arc | ✔
Mac M4 | Brave | ✔
Mac M4 | Safari | ✔
Iphone iOS 26.0.1 | Safari | ✔
Andoid 16 | Chrome | ✔
Andoid 16 | Brave | ✔
Andoid 16 | Native Brower | ✔


