### PR TITLE
Delete album modal displays actions based on photo count

### DIFF
--- a/web/apps/photos/src/components/Collections/CollectionHeader.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionHeader.tsx
@@ -170,12 +170,44 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
         [activeCollection, onRemotePull],
     );
 
+    const hasAlbumFiles = fileCount > 0;
+
     const confirmDeleteCollection = () => {
+        if (hasAlbumFiles) {
+            showMiniDialog({
+                title: t("delete_album_title"),
+                message: (
+                    <Trans
+                        i18nKey={"delete_album_message"}
+                        components={{
+                            a: (
+                                <Box
+                                    component={"span"}
+                                    sx={{ color: "text.base" }}
+                                />
+                            ),
+                        }}
+                    />
+                ),
+                continue: {
+                    text: t("keep_photos"),
+                    color: "primary",
+                    action: deleteCollectionButKeepFiles,
+                },
+                secondary: {
+                    text: t("delete_photos"),
+                    color: "critical",
+                    action: deleteCollectionAlongWithFiles,
+                },
+            });
+            return;
+        }
+
         showMiniDialog({
             title: t("delete_album_title"),
             message: (
                 <Trans
-                    i18nKey={"delete_album_message"}
+                    i18nKey={"delete_album_message_no_photos"}
                     components={{
                         a: (
                             <Box
@@ -187,12 +219,7 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
                 />
             ),
             continue: {
-                text: t("keep_photos"),
-                color: "primary",
-                action: deleteCollectionButKeepFiles,
-            },
-            secondary: {
-                text: t("delete_photos"),
+                text: t("delete_album"),
                 color: "critical",
                 action: deleteCollectionAlongWithFiles,
             },

--- a/web/packages/base/locales/en-US/translation.json
+++ b/web/packages/base/locales/en-US/translation.json
@@ -225,6 +225,7 @@
     "delete_album": "Delete album",
     "delete_album_title": "Delete album?",
     "delete_album_message": "Also delete the photos (and videos) present in this album from <a>all</a> other albums they are part of?",
+    "delete_album_message_no_photos": "Are you sure you want to delete this album?",
     "delete_photos": "Delete photos",
     "keep_photos": "Keep photos",
     "share_album": "Share album",


### PR DESCRIPTION
## Description

Earlier while trying to delete a album with no photos, it asked the user whether to keep or delete the photo which wasn't relevant. so the modal is updated as below

<img width="1207" height="426" alt="image" src="https://github.com/user-attachments/assets/772c5e03-270f-4c84-b579-8995fdec9c6f" />

