### PR TITLE
[photos][desktop] passing currentUserId for non-window contexts

### DIFF
--- a/web/packages/new/photos/services/file.ts
+++ b/web/packages/new/photos/services/file.ts
@@ -65,8 +65,10 @@ export const computeAllCollectionFilesFromSaved = async () =>
  * The long name and the "compute" in it is to signal that this is not just a DB
  * read, and that it also does some potentially non-trivial computation.
  */
-export const computeNormalCollectionFilesFromSaved = async () => {
-    const hiddenCollections = await savedHiddenCollections();
+export const computeNormalCollectionFilesFromSaved = async (
+    currentUserID?: number,
+) => {
+    const hiddenCollections = await savedHiddenCollections(currentUserID);
     const hiddenCollectionIDs = new Set(hiddenCollections.map((c) => c.id));
 
     const collectionFiles = await savedCollectionFiles();

--- a/web/packages/new/photos/services/ml/index.ts
+++ b/web/packages/new/photos/services/ml/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { proxy, transfer } from "comlink";
+import { ensureLocalUser } from "ente-accounts/services/user";
 import { isDesktop } from "ente-base/app";
 import { blobCache } from "ente-base/blob-cache";
 import { ensureElectron } from "ente-base/electron";
@@ -953,9 +954,15 @@ export const addManualFileAssignmentsToPerson = async (
  * Return suggestions for the given {@link person}.
  *
  * The suggestion computation happens in a web worker.
- */
+ *
+ * Since the computation is happening in a web worker, and it doesn't
+ * have access to any localStorage, we need to pass the currentUserID explicitly.
+ * for the isHiddenCollection checks in the process.
+ *  */
 export const suggestionsAndChoicesForPerson = async (person: CGroupPerson) =>
-    worker().then((w) => w.suggestionsAndChoicesForPerson(person));
+    worker().then((w) =>
+        w.suggestionsAndChoicesForPerson(person, ensureLocalUser().id),
+    );
 
 /**
  * Implementation for the "save" action on the SuggestionsDialog.

--- a/web/packages/new/photos/services/ml/people.ts
+++ b/web/packages/new/photos/services/ml/people.ts
@@ -487,6 +487,7 @@ export interface PersonSuggestionsAndChoices {
  */
 export const _suggestionsAndChoicesForPerson = async (
     person: CGroupPerson,
+    currentUserID: number,
 ): Promise<PersonSuggestionsAndChoices> => {
     const startTime = Date.now();
 
@@ -565,7 +566,8 @@ export const _suggestionsAndChoicesForPerson = async (
 
     // Annotate the clusters with the information that the UI needs to show its
     // preview faces.
-    const normalCollectionFiles = await computeNormalCollectionFilesFromSaved();
+    const normalCollectionFiles =
+        await computeNormalCollectionFilesFromSaved(currentUserID);
     const fileByID = new Map(normalCollectionFiles.map((f) => [f.id, f]));
 
     const toPreviewable = (cluster: FaceCluster) => {

--- a/web/packages/new/photos/services/ml/worker.ts
+++ b/web/packages/new/photos/services/ml/worker.ts
@@ -339,8 +339,11 @@ export class MLWorker {
     /**
      * Return suggestions and choices for the given cgroup {@link person}.
      */
-    async suggestionsAndChoicesForPerson(person: CGroupPerson) {
-        return _suggestionsAndChoicesForPerson(person);
+    async suggestionsAndChoicesForPerson(
+        person: CGroupPerson,
+        currentUserID: number,
+    ) {
+        return _suggestionsAndChoicesForPerson(person, currentUserID);
     }
 }
 


### PR DESCRIPTION
In the people tab's Review Suggestions the ensureLocalUser was trying to access the localStroage which was inaccessible since the whole process was happening in a web worker. And as a fix we are passing in the currentUserId fro the main thread itself.

fixes #9026 