### PR TITLE
[web][photos] fix-download-not-preserved-across-navigation

### DIFF
--- a/web/apps/photos/src/services/logout.ts
+++ b/web/apps/photos/src/services/logout.ts
@@ -3,7 +3,10 @@ import {
     logoutClearStateAgain,
 } from "ente-accounts/services/logout";
 import log from "ente-base/log";
-import { logoutFileViewerDataSource } from "ente-gallery/components/viewer/data-source";
+import { resetSaveGroups } from "ente-gallery/components/utils/save-groups";
+import {
+    logoutFileViewerDataSource,
+} from "ente-gallery/components/viewer/data-source";
 import { downloadManager } from "ente-gallery/services/download";
 import { clearFilesDB } from "ente-gallery/services/files-db";
 import { resetUploadState } from "ente-gallery/services/upload";
@@ -80,6 +83,12 @@ export const photosLogout = async () => {
         downloadManager.logout();
     } catch (e) {
         ignoreError("Download", e);
+    }
+
+    try {
+        resetSaveGroups();
+    } catch (e) {
+        ignoreError("Download UI", e);
     }
 
     try {

--- a/web/apps/photos/src/services/logout.ts
+++ b/web/apps/photos/src/services/logout.ts
@@ -4,9 +4,7 @@ import {
 } from "ente-accounts/services/logout";
 import log from "ente-base/log";
 import { resetSaveGroups } from "ente-gallery/components/utils/save-groups";
-import {
-    logoutFileViewerDataSource,
-} from "ente-gallery/components/viewer/data-source";
+import { logoutFileViewerDataSource } from "ente-gallery/components/viewer/data-source";
 import { downloadManager } from "ente-gallery/services/download";
 import { clearFilesDB } from "ente-gallery/services/files-db";
 import { resetUploadState } from "ente-gallery/services/upload";

--- a/web/packages/gallery/components/utils/save-groups.ts
+++ b/web/packages/gallery/components/utils/save-groups.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 /**
  * An object that keeps track of progress of a user-initiated download of a set
@@ -162,33 +162,75 @@ export type UpdateSaveGroup = (
 export type RemoveSaveGroup = (saveGroup: SaveGroup) => void;
 
 /**
+ * Keep save groups outside the component tree so remounts can rehydrate
+ * in-progress downloads after route changes.
+ */
+type SaveGroupsListener = () => void;
+
+let saveGroupsSnapshot: SaveGroup[] = [];
+const listeners = new Set<SaveGroupsListener>();
+
+const emitChange = () => {
+    for (const listener of listeners) listener();
+};
+
+const getSnapshot = () => saveGroupsSnapshot;
+
+const subscribe = (listener: SaveGroupsListener) => {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+};
+
+const setSaveGroupsSnapshot = (
+    next:
+        | SaveGroup[]
+        | ((currentSaveGroups: SaveGroup[]) => SaveGroup[]),
+) => {
+    saveGroupsSnapshot =
+        typeof next == "function" ? next(saveGroupsSnapshot) : next;
+    emitChange();
+};
+
+const addSaveGroup: AddSaveGroup = (saveGroup) => {
+    const id = Math.random();
+    setSaveGroupsSnapshot((groups) => [
+        ...groups,
+        { ...saveGroup, id, success: 0, failed: 0 },
+    ]);
+
+    return (tx: (group: SaveGroup) => SaveGroup) => {
+        setSaveGroupsSnapshot((groups) =>
+            groups.map((g) => (g.id == id ? tx(g) : g)),
+        );
+    };
+};
+
+const removeSaveGroup: RemoveSaveGroup = ({ id }) =>
+    setSaveGroupsSnapshot((groups) => groups.filter((g) => g.id != id));
+
+export const resetSaveGroups = () => {
+    if (!saveGroupsSnapshot.length) return;
+
+    saveGroupsSnapshot = [];
+    emitChange();
+};
+
+/**
  * A custom React hook that manages a list of active {@link SaveGroup}s, and
  * provides functions to add and remove entries to the list.
  */
 export const useSaveGroups = () => {
-    const [saveGroups, setSaveGroups] = useState<SaveGroup[]>([]);
-
-    const handleAddSaveGroup: AddSaveGroup = useCallback((saveGroup) => {
-        const id = Math.random();
-        setSaveGroups((groups) => [
-            ...groups,
-            { ...saveGroup, id, success: 0, failed: 0 },
-        ]);
-        return (tx: (group: SaveGroup) => SaveGroup) => {
-            setSaveGroups((groups) =>
-                groups.map((g) => (g.id == id ? tx(g) : g)),
-            );
-        };
-    }, []);
-
-    const handleRemoveSaveGroup: RemoveSaveGroup = useCallback(
-        ({ id }) => setSaveGroups((groups) => groups.filter((g) => g.id != id)),
-        [],
+    const saveGroups = useSyncExternalStore(
+        subscribe,
+        getSnapshot,
+        getSnapshot,
     );
 
     return {
         saveGroups,
-        onAddSaveGroup: handleAddSaveGroup,
-        onRemoveSaveGroup: handleRemoveSaveGroup,
+        onAddSaveGroup: addSaveGroup,
+        onRemoveSaveGroup: removeSaveGroup,
     };
 };

--- a/web/packages/gallery/components/utils/save-groups.ts
+++ b/web/packages/gallery/components/utils/save-groups.ts
@@ -170,12 +170,15 @@ type SaveGroupsListener = () => void;
 let saveGroupsSnapshot: SaveGroup[] = [];
 const listeners = new Set<SaveGroupsListener>();
 
+// Notify subscribers after the snapshot changes.
 const emitChange = () => {
     for (const listener of listeners) listener();
 };
 
+// Return the current snapshot for external-store consumers.
 const getSnapshot = () => saveGroupsSnapshot;
 
+// Register a listener and return its unsubscribe cleanup.
 const subscribe = (listener: SaveGroupsListener) => {
     listeners.add(listener);
     return () => {
@@ -184,9 +187,7 @@ const subscribe = (listener: SaveGroupsListener) => {
 };
 
 const setSaveGroupsSnapshot = (
-    next:
-        | SaveGroup[]
-        | ((currentSaveGroups: SaveGroup[]) => SaveGroup[]),
+    next: SaveGroup[] | ((currentSaveGroups: SaveGroup[]) => SaveGroup[]),
 ) => {
     saveGroupsSnapshot =
         typeof next == "function" ? next(saveGroupsSnapshot) : next;


### PR DESCRIPTION
## Description

This pull request refactors the save groups management logic in the gallery app to improve state persistence across route changes and adds a new reset function to clear save groups on logout. The main changes include moving save groups state outside the React component tree, switching to `useSyncExternalStore` for state management, and integrating the new `resetSaveGroups` function into the logout workflow.
