### PR TITLE
[web][photos] hide free plan option for plan expired users

### DIFF
--- a/web/packages/new/photos/components/PlanSelector.tsx
+++ b/web/packages/new/photos/components/PlanSelector.tsx
@@ -19,6 +19,7 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { SpacedRow } from "ente-base/components/containers";
 import type { ButtonishProps } from "ente-base/components/mui";
+import { DialogCloseIconButton } from "ente-base/components/mui/DialogCloseIconButton";
 import { FocusVisibleButton } from "ente-base/components/mui/FocusVisibleButton";
 import {
     errorDialogAttributes,
@@ -320,7 +321,10 @@ const FreeSubscriptionPlanSelectorCard: React.FC<
     children,
 }) => (
     <>
-        <Typography variant="h3">{t("choose_plan")}</Typography>
+        <SpacedRow sx={{ alignItems: "flex-start" }}>
+            <Typography variant="h3">{t("choose_plan")}</Typography>
+            <DialogCloseIconButton {...{ onClose }} />
+        </SpacedRow>
         <Stack sx={{ gap: 3 }}>
             <Box>
                 <PeriodToggler

--- a/web/packages/new/photos/components/PlanSelector.tsx
+++ b/web/packages/new/photos/components/PlanSelector.tsx
@@ -521,7 +521,7 @@ const Plans: React.FC<PlansProps> = ({
                     onPlanSelect={onPlanSelect}
                 />
             ))}
-        {!(subscription && isSubscriptionActivePaid(subscription)) &&
+        {(!subscription || isSubscriptionFree(subscription)) &&
             !hasAddOnBonus &&
             plansData?.freePlan && (
                 <FreePlanRow

--- a/web/packages/new/photos/components/PlanSelector.tsx
+++ b/web/packages/new/photos/components/PlanSelector.tsx
@@ -323,7 +323,9 @@ const FreeSubscriptionPlanSelectorCard: React.FC<
     <>
         <SpacedRow sx={{ alignItems: "flex-start" }}>
             <Typography variant="h3">{t("choose_plan")}</Typography>
-            <DialogCloseIconButton {...{ onClose }} />
+            {subscription && !isSubscriptionFree(subscription) && (
+                <DialogCloseIconButton {...{ onClose }} />
+            )}
         </SpacedRow>
         <Stack sx={{ gap: 3 }}>
             <Box>


### PR DESCRIPTION
## Description

The "Continue with Free Plan" option shown to users with expired plans was misleading, as it had no real function and simply closed the modal. It will no longer appear for users whose paid plans have expired.

<img width="440" height="634" alt="image" src="https://github.com/user-attachments/assets/8bfbd3fd-1c6a-44ce-8969-fe49232f8c42" />