### PR TITLE
[web][photos] Improve UX for moving to shared album

### DIFF
--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -115,8 +115,10 @@ import {
     updateCollectionCover,
 } from "ente-new/photos/services/collection";
 import {
+    canAddToCollection,
     haveOnlySystemCollections,
     PseudoCollectionID,
+    type CollectionSummary,
 } from "ente-new/photos/services/collection-summary";
 import exportService from "ente-new/photos/services/export";
 import {
@@ -979,27 +981,26 @@ const Page: React.FC = () => {
     };
 
     const createOnSelectForCollectionOp =
-        (op: CollectionOp) => (selectedCollection: Collection) => {
-            void (async () => {
+        (op: CollectionOp) =>
+        (
+            selectedCollection: Collection,
+            selectedCollectionSummary?: CollectionSummary,
+        ) => {
+            const selectedFiles = getSelectedFiles(selected, filteredFiles);
+            const userFiles = selectedFiles.filter(
+                // If a selection is happening, there must be a user.
+                (f) => f.ownerID == user!.id,
+            );
+            const sourceCollectionID = selected.collectionID;
+
+            const performSelectedCollectionOp = async (
+                op: CollectionOp,
+                filesToProcess: EnteFile[],
+                notifySkippedFiles = false,
+            ) => {
                 showLoadingBar();
                 try {
                     setOpenCollectionSelector(false);
-                    const selectedFiles = getSelectedFiles(
-                        selected,
-                        filteredFiles,
-                    );
-                    const userFiles = selectedFiles.filter(
-                        // If a selection is happening, there must be a user.
-                        (f) => f.ownerID == user!.id,
-                    );
-                    /**
-                     * The add/copy path can process non-owned files when a
-                     * shared album requires copying them through the current
-                     * user's library.
-                     */
-                    const filesToProcess =
-                        op == "add" ? selectedFiles : userFiles;
-                    const sourceCollectionID = selected.collectionID;
                     if (filesToProcess.length > 0) {
                         await performCollectionOp(
                             op,
@@ -1008,18 +1009,53 @@ const Page: React.FC = () => {
                             sourceCollectionID,
                         );
                     }
-                    if (
-                        op != "add" &&
-                        userFiles.length != selectedFiles.length
-                    ) {
+                    if (notifySkippedFiles) {
                         showMiniDialog(notifyOthersFilesDialogAttributes());
                     }
                     clearSelection();
                     await remotePull({ silent: true });
-                } catch (e) {
-                    onGenericError(e);
                 } finally {
                     hideLoadingBar();
+                }
+            };
+
+            const shouldAddInsteadOfMove =
+                op == "move" &&
+                !!selectedCollectionSummary &&
+                selectedCollectionSummary.attributes.has("sharedIncoming") &&
+                canAddToCollection(selectedCollectionSummary);
+
+            if (shouldAddInsteadOfMove) {
+                setOpenCollectionSelector(false);
+                showMiniDialog({
+                    title: t("cannot_move_to_shared_albums"),
+                    message: t("cannot_move_to_shared_albums_message"),
+                    continue: {
+                        text: t("add"),
+                        action: () =>
+                            performSelectedCollectionOp("add", selectedFiles),
+                    },
+                    cancel: t("cancel"),
+                });
+                return;
+            }
+
+            void (async () => {
+                try {
+                    /**
+                     * The add/copy path can process non-owned files when a
+                     * shared album requires copying them through the current
+                     * user's library.
+                     */
+                    const filesToProcess =
+                        op == "add" ? selectedFiles : userFiles;
+                    await performSelectedCollectionOp(
+                        op,
+                        filesToProcess,
+                        op != "add" && userFiles.length != selectedFiles.length,
+                    );
+                } catch (e) {
+                    onGenericError(e);
                 }
             })();
         };

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -107,6 +107,7 @@ import { shouldShowWhatsNew } from "ente-new/photos/services/changelog";
 import {
     addToCollection,
     addToFavoritesCollection,
+    canAddFilesToCollection,
     createAlbum,
     createPublicURL,
     createQuickLinkCollection,
@@ -115,10 +116,8 @@ import {
     updateCollectionCover,
 } from "ente-new/photos/services/collection";
 import {
-    canAddToCollection,
     haveOnlySystemCollections,
     PseudoCollectionID,
-    type CollectionSummary,
 } from "ente-new/photos/services/collection-summary";
 import exportService from "ente-new/photos/services/export";
 import {
@@ -981,11 +980,7 @@ const Page: React.FC = () => {
     };
 
     const createOnSelectForCollectionOp =
-        (op: CollectionOp) =>
-        (
-            selectedCollection: Collection,
-            selectedCollectionSummary?: CollectionSummary,
-        ) => {
+        (op: CollectionOp) => (selectedCollection: Collection) => {
             const selectedFiles = getSelectedFiles(selected, filteredFiles);
             const userFiles = selectedFiles.filter(
                 // If a selection is happening, there must be a user.
@@ -1021,12 +1016,10 @@ const Page: React.FC = () => {
 
             const shouldAddInsteadOfMove =
                 op == "move" &&
-                !!selectedCollectionSummary &&
-                selectedCollectionSummary.attributes.has("sharedIncoming") &&
-                canAddToCollection(selectedCollectionSummary);
+                selectedCollection.owner.id != user!.id &&
+                canAddFilesToCollection(selectedCollection);
 
             if (shouldAddInsteadOfMove) {
-                setOpenCollectionSelector(false);
                 showMiniDialog({
                     title: t("cannot_move_to_shared_albums"),
                     message: t("cannot_move_to_shared_albums_message"),

--- a/web/packages/base/locales/en-US/translation.json
+++ b/web/packages/base/locales/en-US/translation.json
@@ -422,6 +422,8 @@
     "added_to_album": "Added to album",
     "added_to_person": "Added to person",
     "move_to_album": "Move to album",
+    "cannot_move_to_shared_albums": "Can't move to shared albums",
+    "cannot_move_to_shared_albums_message": "Items can only be added to shared albums, not moved. Would you like to add instead?",
     "unhide_to_album": "Unhide to album",
     "restore_to_album": "Restore to album",
     "section_all": "All",

--- a/web/packages/new/photos/components/CollectionSelector.tsx
+++ b/web/packages/new/photos/components/CollectionSelector.tsx
@@ -83,10 +83,7 @@ export interface CollectionSelectorAttributes {
      * Callback invoked when the user selects one the existing collections
      * listed in the dialog.
      */
-    onSelectCollection: (
-        collection: Collection,
-        collectionSummary: CollectionSummary,
-    ) => void;
+    onSelectCollection: (collection: Collection) => void;
     /**
      * Callback invoked when the user cancels the collection selection dialog.
      */
@@ -166,7 +163,10 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
             (cs) => {
                 if (cs.id === attributes.sourceCollectionSummaryID) {
                     return false;
-                } else if (attributes.action == "add") {
+                } else if (
+                    attributes.action == "add" ||
+                    attributes.action == "move"
+                ) {
                     return canAddToCollection(cs) && cs.type != "userFavorites";
                 } else if (attributes.action == "upload") {
                     return (
@@ -178,14 +178,6 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
                     return (
                         (canMoveToCollection(cs) ||
                             cs.type == "uncategorized") &&
-                        cs.type != "userFavorites"
-                    );
-                } else if (attributes.action == "move") {
-                    const canAddInsteadOfMove =
-                        cs.attributes.has("sharedIncoming") &&
-                        canAddToCollection(cs);
-                    return (
-                        (canMoveToCollection(cs) || canAddInsteadOfMove) &&
                         cs.type != "userFavorites"
                     );
                 } else {
@@ -245,13 +237,7 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
         attributes;
 
     const handleCollectionSummaryClick = async (id: number) => {
-        const collectionSummary = filteredCollections.find((cs) => cs.id == id);
-        if (!collectionSummary) return;
-
-        onSelectCollection(
-            await collectionForCollectionSummaryID(id),
-            collectionSummary,
-        );
+        onSelectCollection(await collectionForCollectionSummaryID(id));
         onClose();
     };
 

--- a/web/packages/new/photos/components/CollectionSelector.tsx
+++ b/web/packages/new/photos/components/CollectionSelector.tsx
@@ -83,7 +83,10 @@ export interface CollectionSelectorAttributes {
      * Callback invoked when the user selects one the existing collections
      * listed in the dialog.
      */
-    onSelectCollection: (collection: Collection) => void;
+    onSelectCollection: (
+        collection: Collection,
+        collectionSummary: CollectionSummary,
+    ) => void;
     /**
      * Callback invoked when the user cancels the collection selection dialog.
      */
@@ -177,8 +180,16 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
                             cs.type == "uncategorized") &&
                         cs.type != "userFavorites"
                     );
+                } else if (attributes.action == "move") {
+                    const canAddInsteadOfMove =
+                        cs.attributes.has("sharedIncoming") &&
+                        canAddToCollection(cs);
+                    return (
+                        (canMoveToCollection(cs) || canAddInsteadOfMove) &&
+                        cs.type != "userFavorites"
+                    );
                 } else {
-                    // "move" and "unhide"
+                    // "unhide"
                     return (
                         canMoveToCollection(cs) && cs.type != "userFavorites"
                     );
@@ -234,7 +245,13 @@ export const CollectionSelector: React.FC<CollectionSelectorProps> = ({
         attributes;
 
     const handleCollectionSummaryClick = async (id: number) => {
-        onSelectCollection(await collectionForCollectionSummaryID(id));
+        const collectionSummary = filteredCollections.find((cs) => cs.id == id);
+        if (!collectionSummary) return;
+
+        onSelectCollection(
+            await collectionForCollectionSummaryID(id),
+            collectionSummary,
+        );
         onClose();
     };
 

--- a/web/packages/new/photos/components/SelectedFileOptions.tsx
+++ b/web/packages/new/photos/components/SelectedFileOptions.tsx
@@ -136,7 +136,10 @@ interface SelectedFileOptionsProps {
      */
     createOnSelectForCollectionOp: (
         op: CollectionOp,
-    ) => (selectedCollection: Collection) => void;
+    ) => (
+        selectedCollection: Collection,
+        selectedCollectionSummary?: CollectionSummary,
+    ) => void;
     /**
      * A function called to obtain a handler for the provided {@link op}.
      *

--- a/web/packages/new/photos/components/SelectedFileOptions.tsx
+++ b/web/packages/new/photos/components/SelectedFileOptions.tsx
@@ -136,10 +136,7 @@ interface SelectedFileOptionsProps {
      */
     createOnSelectForCollectionOp: (
         op: CollectionOp,
-    ) => (
-        selectedCollection: Collection,
-        selectedCollectionSummary?: CollectionSummary,
-    ) => void;
+    ) => (selectedCollection: Collection) => void;
     /**
      * A function called to obtain a handler for the provided {@link op}.
      *


### PR DESCRIPTION
## Description

On mobile, when a user selects one or more photos and taps **Move**, shared albums appear in the destination list. However, selecting a shared album does not actually move the photos. Instead, it performs an **Add to Shared Album** action, since photos cannot be moved directly into a shared album. The user must retain an owned copy of the image.

On web and desktop, shared albums are currently hidden from the **Move** destination selector. Updating this behavior to match the mobile experience by showing shared albums in the selector and treating the action as **Add to Shared Album** rather than a direct move.

