### PR TITLE
[web][photos] Added logging for finding files with invalid date

### DIFF
--- a/web/apps/photos/src/components/FileListWithViewer.tsx
+++ b/web/apps/photos/src/components/FileListWithViewer.tsx
@@ -6,6 +6,7 @@ import { useModalVisibility } from "ente-base/components/utils/modal";
 import { useBaseContext } from "ente-base/context";
 import { isSameDay } from "ente-base/date";
 import { formattedDate } from "ente-base/i18n-date";
+import log from "ente-base/log";
 import type { AddSaveGroup } from "ente-gallery/components/utils/save-groups";
 import {
     FileViewer,
@@ -474,6 +475,10 @@ const MapIcon = styled("img")<{ $isDarkMode: boolean }>(
  */
 const fileTimelineDateString = (file: EnteFile) => {
     const date = fileCreationPhotoDate(file);
+    if (!Number.isFinite(date.getTime()))
+        log.error(
+            `Invalid file creation date for ${fileFileName(file)} (${file.id})`,
+        );
     return isSameDay(date, new Date())
         ? t("today")
         : isSameDay(date, new Date(Date.now() - 24 * 60 * 60 * 1000))

--- a/web/apps/photos/src/components/FileListWithViewer.tsx
+++ b/web/apps/photos/src/components/FileListWithViewer.tsx
@@ -476,9 +476,7 @@ const MapIcon = styled("img")<{ $isDarkMode: boolean }>(
 const fileTimelineDateString = (file: EnteFile) => {
     const date = fileCreationPhotoDate(file);
     if (!Number.isFinite(date.getTime()))
-        log.error(
-            `Invalid file creation date for ${fileFileName(file)} (${file.id})`,
-        );
+        log.error(`Invalid file creation date for ${file.id}`);
     return isSameDay(date, new Date())
         ? t("today")
         : isSameDay(date, new Date(Date.now() - 24 * 60 * 60 * 1000))


### PR DESCRIPTION
## Description

A user reported a client-side issue when starting the app and shared logs from the browser. It appears the app crashes while trying to parse a date. It works on some browsers but fails on others.

This is a temporary log added to catch the file causing the issue, so we can either remove or fix it from a working browser. Once addressed, this log will be removed.
