### PR TITLE
[web][photos] Disable album download icon on file selection

### DIFF
--- a/web/apps/photos/src/components/Collections/CollectionHeader.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionHeader.tsx
@@ -859,14 +859,14 @@ const QuickOptions: React.FC<QuickOptionsProps> = ({
         {showEmptyTrashQuickOption(collectionSummary) && (
             <EmptyTrashQuickOption onClick={onEmptyTrashClick} />
         )}
-        {!hasActiveFileSelection &&
-            showDownloadQuickOption(collectionSummary) &&
+        {showDownloadQuickOption(collectionSummary) &&
             collectionSummary.fileCount > 0 &&
             (isDownloadInProgress() ? (
                 <ActivityIndicator size="20px" sx={{ m: "12px" }} />
             ) : (
                 <DownloadQuickOption
                     collectionSummary={collectionSummary}
+                    disabled={hasActiveFileSelection}
                     onClick={onDownloadClick}
                 />
             ))}
@@ -954,6 +954,7 @@ const shouldShowMapOption = ({ type, fileCount }: CollectionSummary) =>
 
 type DownloadQuickOptionProps = OptionProps & {
     collectionSummary: CollectionSummary;
+    disabled?: boolean;
 };
 
 const DownloadIcon: React.FC = () => (
@@ -975,6 +976,7 @@ const DownloadIcon: React.FC = () => (
 
 const DownloadQuickOption: React.FC<DownloadQuickOptionProps> = ({
     collectionSummary: { type },
+    disabled,
     onClick,
 }) => (
     <Tooltip
@@ -988,19 +990,21 @@ const DownloadQuickOption: React.FC<DownloadQuickOptionProps> = ({
                     : t("download_album")
         }
     >
-        <IconButton onClick={onClick}>
-            <Box
-                sx={{
-                    width: 24,
-                    height: 24,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                }}
-            >
-                <DownloadIcon />
-            </Box>
-        </IconButton>
+        <span>
+            <IconButton disabled={disabled} onClick={onClick}>
+                <Box
+                    sx={{
+                        width: 24,
+                        height: 24,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                    }}
+                >
+                    <DownloadIcon />
+                </Box>
+            </IconButton>
+        </span>
     </Tooltip>
 );
 

--- a/web/apps/photos/src/components/Collections/CollectionHeader.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionHeader.tsx
@@ -109,6 +109,7 @@ export interface CollectionHeaderProps extends Pick<
     onCollectionCast: () => void;
     canSetAlbumCover: boolean;
     onSetAlbumCover: () => void;
+    hasActiveFileSelection: boolean;
     /**
      * A function that can be used to create a UI notification to track the
      * progress of user-initiated download, and to cancel it if needed.
@@ -170,6 +171,7 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
     onCollectionCast,
     canSetAlbumCover,
     onSetAlbumCover,
+    hasActiveFileSelection,
     onAddSaveGroup,
     isActiveCollectionDownloadInProgress,
     onMarkTempDeleted,
@@ -762,6 +764,7 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
             <QuickOptions
                 collectionSummary={collectionSummary}
                 isQuickLinkAlbum={isQuickLinkAlbum}
+                hasActiveFileSelection={hasActiveFileSelection}
                 isDownloadInProgress={isActiveCollectionDownloadInProgress}
                 onMapClick={handleShowMap}
                 onEmptyTrashClick={confirmEmptyTrash}
@@ -830,6 +833,7 @@ interface OptionProps {
 interface QuickOptionsProps {
     collectionSummary: CollectionSummary;
     isQuickLinkAlbum: boolean;
+    hasActiveFileSelection: boolean;
     isDownloadInProgress: () => boolean;
     onMapClick: () => void;
     onEmptyTrashClick: () => void;
@@ -848,13 +852,15 @@ const QuickOptions: React.FC<QuickOptionsProps> = ({
     onCleanUncategorizedClick,
     collectionSummary,
     isQuickLinkAlbum,
+    hasActiveFileSelection,
     isDownloadInProgress,
 }) => (
     <Stack direction="row" sx={{ alignItems: "center", gap: "16px" }}>
         {showEmptyTrashQuickOption(collectionSummary) && (
             <EmptyTrashQuickOption onClick={onEmptyTrashClick} />
         )}
-        {showDownloadQuickOption(collectionSummary) &&
+        {!hasActiveFileSelection &&
+            showDownloadQuickOption(collectionSummary) &&
             collectionSummary.fileCount > 0 &&
             (isDownloadInProgress() ? (
                 <ActivityIndicator size="20px" sx={{ m: "12px" }} />

--- a/web/apps/photos/src/components/Collections/GalleryBarAndListHeader.tsx
+++ b/web/apps/photos/src/components/Collections/GalleryBarAndListHeader.tsx
@@ -64,6 +64,7 @@ type GalleryBarAndListHeaderProps = Omit<
     activeCollection: Collection | undefined;
     setActiveCollectionID: (collectionID: number) => void;
     setFileListHeader: (header: FileListHeaderOrFooter) => void;
+    hasActiveFileSelection: boolean;
     saveGroups: SaveGroup[];
 } & Pick<
         CollectionHeaderProps,
@@ -120,6 +121,7 @@ export const GalleryBarAndListHeader: React.FC<
     people,
     allPeople,
     saveGroups,
+    hasActiveFileSelection,
     files,
     mapFileSource,
     activePerson,
@@ -239,6 +241,7 @@ export const GalleryBarAndListHeader: React.FC<
                     onCollectionCast={showCollectionCast}
                     canSetAlbumCover={canSetAlbumCover}
                     onSetAlbumCover={onSetAlbumCover}
+                    hasActiveFileSelection={hasActiveFileSelection}
                 />
             ) : mode != "people" && collectionSummary ? (
                 <GalleryItemsHeaderAdapter>
@@ -272,6 +275,7 @@ export const GalleryBarAndListHeader: React.FC<
         openCollectionShare,
         openCollectionManageLink,
         showCollectionCast,
+        hasActiveFileSelection,
         onRemotePull,
         onAddSaveGroup,
         onMarkTempDeleted,

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -1952,9 +1952,10 @@ const Page: React.FC = () => {
         [showAppDownloadFooter],
     );
 
+    const hasActiveFileSelection =
+        selected.count > 0 && selected.collectionID === activeCollectionID;
     const showSelectionBar =
-        selected.count > 0 &&
-        selected.collectionID === activeCollectionID &&
+        hasActiveFileSelection &&
         !suppressContextSelectionBar &&
         !(isContextMenuOpen && selected.count === 1);
 
@@ -2110,6 +2111,7 @@ const Page: React.FC = () => {
                 onChangeMode={handleChangeBarMode}
                 setBlockingLoad={setBlockingLoad}
                 setActiveCollectionID={handleShowCollectionSummaryWithID}
+                hasActiveFileSelection={hasActiveFileSelection}
                 onRemotePull={remotePull}
                 onSelectPerson={handleSelectPerson}
             />


### PR DESCRIPTION
## Description

When files are selected, two download icons appear. The one closest to the selection downloads the album instead of the selected files, which is confusing.

This change disables the album download icon while a file selection is active. So the user just have a single download icon in view.

<img width="315" height="459" alt="image" src="https://github.com/user-attachments/assets/dc1246fb-d306-4a89-8bad-12960bd4168f" />
