### PR TITLE
[web][photos] Update archive section to show archived albums only

### DIFF
--- a/desktop/changes/parse-takeout-folder-title-metadata.md
+++ b/desktop/changes/parse-takeout-folder-title-metadata.md
@@ -1,0 +1,1 @@
+- Use Google Takeout metadata titles when naming imported folders.

--- a/desktop/changes/show-archived-albums-section.md
+++ b/desktop/changes/show-archived-albums-section.md
@@ -1,0 +1,1 @@
+- Update the Archive section to show only archived albums on the top bar.

--- a/web/apps/photos/src/components/Collections/AllAlbums.tsx
+++ b/web/apps/photos/src/components/Collections/AllAlbums.tsx
@@ -58,6 +58,7 @@ interface AllAlbums {
     collectionsSortBy: CollectionsSortBy;
     onChangeCollectionsSortBy: (by: CollectionsSortBy) => void;
     isInHiddenSection: boolean;
+    canCreateAlbum: boolean;
     onRemotePull: () => Promise<void>;
 }
 
@@ -72,6 +73,7 @@ export const AllAlbums: React.FC<AllAlbums> = ({
     collectionsSortBy,
     onChangeCollectionsSortBy,
     isInHiddenSection,
+    canCreateAlbum,
     onRemotePull,
 }) => {
     const fullScreen = useMediaQuery("(max-width: 428px)");
@@ -130,13 +132,14 @@ export const AllAlbums: React.FC<AllAlbums> = ({
     }, [collectionSummaries, searchTerm]);
 
     const showCreateButton = useMemo(() => {
+        if (!canCreateAlbum) return false;
         if (!searchTerm.trim()) {
             return true;
         }
         const searchLower = searchTerm.toLowerCase();
         const createText = t("new_album").toLowerCase();
         return createText.includes(searchLower);
-    }, [searchTerm]);
+    }, [canCreateAlbum, searchTerm]);
 
     return (
         <>

--- a/web/apps/photos/src/components/Collections/GalleryBarAndListHeader.tsx
+++ b/web/apps/photos/src/components/Collections/GalleryBarAndListHeader.tsx
@@ -65,6 +65,7 @@ type GalleryBarAndListHeaderProps = Omit<
     setActiveCollectionID: (collectionID: number) => void;
     setFileListHeader: (header: FileListHeaderOrFooter) => void;
     saveGroups: SaveGroup[];
+    canCreateAlbum: boolean;
 } & Pick<
         CollectionHeaderProps,
         | "files"
@@ -120,6 +121,7 @@ export const GalleryBarAndListHeader: React.FC<
     people,
     allPeople,
     saveGroups,
+    canCreateAlbum,
     files,
     mapFileSource,
     activePerson,
@@ -326,6 +328,7 @@ export const GalleryBarAndListHeader: React.FC<
                 onChangeCollectionsSortBy={setCollectionsSortBy}
                 collectionsSortBy={collectionsSortBy}
                 isInHiddenSection={mode == "hidden-albums"}
+                canCreateAlbum={canCreateAlbum}
                 onRemotePull={onRemotePull}
             />
             <AllPeople

--- a/web/apps/photos/src/components/FileList.tsx
+++ b/web/apps/photos/src/components/FileList.tsx
@@ -738,7 +738,8 @@ export const FileList: React.FC<FileListProps> = ({
                         : {
                               mode: (mode ?? "albums") as
                                   | "albums"
-                                  | "hidden-albums",
+                                  | "hidden-albums"
+                                  | "archive-albums",
                               collectionID: activeCollectionID,
                           };
                 setSelected({

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -501,40 +501,12 @@ const Page: React.FC = () => {
         (activeCollectionID == PseudoCollectionID.archiveItems ||
             activeCollectionSummary?.attributes.has("archived"));
 
-    // TODO: Move into reducer
-    const barCollectionSummaries = useMemo(() => {
-        if (barMode == "hidden-albums") return state.hiddenCollectionSummaries;
-        if (!isInArchiveSection) return state.normalCollectionSummaries;
-
-        const archiveCollectionSummaries = new Map(
-            [...state.normalCollectionSummaries].filter(
-                ([id, collectionSummary]) =>
-                    id == PseudoCollectionID.archiveItems ||
-                    collectionSummary.attributes.has("archived"),
-            ),
-        );
-        const archiveSummary = archiveCollectionSummaries.get(
-            PseudoCollectionID.archiveItems,
-        );
-        if (archiveSummary) {
-            archiveCollectionSummaries.set(PseudoCollectionID.archiveItems, {
-                ...archiveSummary,
-                coverFile:
-                    archiveSummary.coverFile ?? archiveSummary.latestFile,
-                attributes: new Set(
-                    [...archiveSummary.attributes].filter(
-                        (attribute) => attribute != "hideFromCollectionBar",
-                    ),
-                ),
-            });
-        }
-        return archiveCollectionSummaries;
-    }, [
-        barMode,
-        isInArchiveSection,
-        state.hiddenCollectionSummaries,
-        state.normalCollectionSummaries,
-    ]);
+    const barCollectionSummaries =
+        barMode == "hidden-albums"
+            ? state.hiddenCollectionSummaries
+            : isInArchiveSection
+              ? state.archivedCollectionSummaries
+              : state.normalCollectionSummaries;
 
     const router = useRouter();
 

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -496,18 +496,45 @@ const Page: React.FC = () => {
         filteredFiles.length > 0 &&
         selectedFilesInView.length === filteredFiles.length;
 
+    const isInArchiveSection =
+        barMode == "albums" &&
+        (activeCollectionID == PseudoCollectionID.archiveItems ||
+            activeCollectionSummary?.attributes.has("archived"));
+
     // TODO: Move into reducer
-    const barCollectionSummaries = useMemo(
-        () =>
-            barMode == "hidden-albums"
-                ? state.hiddenCollectionSummaries
-                : state.normalCollectionSummaries,
-        [
-            barMode,
-            state.hiddenCollectionSummaries,
-            state.normalCollectionSummaries,
-        ],
-    );
+    const barCollectionSummaries = useMemo(() => {
+        if (barMode == "hidden-albums") return state.hiddenCollectionSummaries;
+        if (!isInArchiveSection) return state.normalCollectionSummaries;
+
+        const archiveCollectionSummaries = new Map(
+            [...state.normalCollectionSummaries].filter(
+                ([id, collectionSummary]) =>
+                    id == PseudoCollectionID.archiveItems ||
+                    collectionSummary.attributes.has("archived"),
+            ),
+        );
+        const archiveSummary = archiveCollectionSummaries.get(
+            PseudoCollectionID.archiveItems,
+        );
+        if (archiveSummary) {
+            archiveCollectionSummaries.set(PseudoCollectionID.archiveItems, {
+                ...archiveSummary,
+                coverFile:
+                    archiveSummary.coverFile ?? archiveSummary.latestFile,
+                attributes: new Set(
+                    [...archiveSummary.attributes].filter(
+                        (attribute) => attribute != "hideFromCollectionBar",
+                    ),
+                ),
+            });
+        }
+        return archiveCollectionSummaries;
+    }, [
+        barMode,
+        isInArchiveSection,
+        state.hiddenCollectionSummaries,
+        state.normalCollectionSummaries,
+    ]);
 
     const router = useRouter();
 
@@ -2046,8 +2073,15 @@ const Page: React.FC = () => {
                         onEditLocation={showEditLocation}
                     />
                 ) : barMode == "hidden-albums" ? (
-                    <HiddenSectionNavbarContents
+                    <SectionNavbarContents
+                        title={t("section_hidden")}
                         onBack={() => dispatch({ type: "showAlbums" })}
+                        onUpload={openUploader}
+                    />
+                ) : !isInSearchMode && isInArchiveSection ? (
+                    <SectionNavbarContents
+                        title={t("section_archive")}
+                        onBack={() => dispatch({ type: "showAll" })}
                         onUpload={openUploader}
                     />
                 ) : (
@@ -2081,6 +2115,7 @@ const Page: React.FC = () => {
                     activePerson,
                     setFileListHeader,
                     saveGroups,
+                    canCreateAlbum: !isInArchiveSection,
                     onAddSaveGroup,
                     onMarkTempDeleted: handleMarkTempDeleted,
                     onAddFileToCollection: handleAddSingleFileToCollection,
@@ -2376,14 +2411,17 @@ const UploadButton: React.FC<ButtonishProps> = ({ onClick }) => {
     );
 };
 
-interface HiddenSectionNavbarContentsProps {
+interface SectionNavbarContentsProps {
+    title: string;
     onBack: () => void;
     onUpload: () => void;
 }
 
-const HiddenSectionNavbarContents: React.FC<
-    HiddenSectionNavbarContentsProps
-> = ({ onBack, onUpload }) => (
+const SectionNavbarContents: React.FC<SectionNavbarContentsProps> = ({
+    title,
+    onBack,
+    onUpload,
+}) => (
     <Stack
         direction="row"
         sx={(theme) => ({
@@ -2396,7 +2434,7 @@ const HiddenSectionNavbarContents: React.FC<
         <IconButton onClick={onBack}>
             <ArrowBackIcon />
         </IconButton>
-        <Typography sx={{ flex: 1 }}>{t("section_hidden")}</Typography>
+        <Typography sx={{ flex: 1 }}>{title}</Typography>
         <UploadButton onClick={onUpload} />
     </Stack>
 );

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -447,7 +447,9 @@ const Page: React.FC = () => {
 
     const activeCollectionFiles = useMemo(() => {
         if (!activeCollection) return [];
-        if (barMode == "hidden-albums") return filteredFiles;
+        if (barMode == "hidden-albums" || barMode == "archive-albums") {
+            return filteredFiles;
+        }
 
         return filteredFiles.filter(({ id, magicMetadata }) => {
             const visibility = magicMetadata?.data.visibility;
@@ -496,15 +498,12 @@ const Page: React.FC = () => {
         filteredFiles.length > 0 &&
         selectedFilesInView.length === filteredFiles.length;
 
-    const isInArchiveSection =
-        barMode == "albums" &&
-        (activeCollectionID == PseudoCollectionID.archiveItems ||
-            activeCollectionSummary?.attributes.has("archived"));
+    const isInArchiveSection = barMode == "archive-albums";
 
     const barCollectionSummaries =
         barMode == "hidden-albums"
             ? state.hiddenCollectionSummaries
-            : isInArchiveSection
+            : barMode == "archive-albums"
               ? state.archivedCollectionSummaries
               : state.normalCollectionSummaries;
 
@@ -759,7 +758,10 @@ const Page: React.FC = () => {
                 barMode == "people" && activePersonID
                     ? { mode: "people" as const, personID: activePersonID }
                     : {
-                          mode: barMode as "albums" | "hidden-albums",
+                          mode: barMode as
+                              | "albums"
+                              | "hidden-albums"
+                              | "archive-albums",
                           collectionID: activeCollectionID!,
                       },
         };
@@ -786,7 +788,10 @@ const Page: React.FC = () => {
                 barMode == "people" && activePersonID
                     ? { mode: "people" as const, personID: activePersonID }
                     : {
-                          mode: barMode as "albums" | "hidden-albums",
+                          mode: barMode as
+                              | "albums"
+                              | "hidden-albums"
+                              | "archive-albums",
                           collectionID: activeCollectionID!,
                       },
         };
@@ -2054,7 +2059,7 @@ const Page: React.FC = () => {
                 ) : !isInSearchMode && isInArchiveSection ? (
                     <SectionNavbarContents
                         title={t("section_archive")}
-                        onBack={() => dispatch({ type: "showAll" })}
+                        onBack={() => dispatch({ type: "showAlbums" })}
                         onUpload={openUploader}
                     />
                 ) : (

--- a/web/packages/new/photos/components/gallery/BarImpl.tsx
+++ b/web/packages/new/photos/components/gallery/BarImpl.tsx
@@ -63,7 +63,7 @@ export interface GalleryBarImplProps {
     /**
      * The ID of the currently active collection (if any).
      *
-     * Required if mode is not "albums" or "hidden-albums".
+     * Required if mode is not "people".
      */
     activeCollectionID: number | undefined;
     /**
@@ -198,6 +198,7 @@ export const GalleryBarImpl: React.FC<GalleryBarImplProps> = ({
         switch (mode) {
             case "albums":
             case "hidden-albums":
+            case "archive-albums":
                 i = collectionSummaries.findIndex(
                     ({ id }) => id == activeCollectionID,
                 );
@@ -211,7 +212,9 @@ export const GalleryBarImpl: React.FC<GalleryBarImplProps> = ({
 
     const itemData = useMemo<ItemData>(
         () =>
-            mode == "albums" || mode == "hidden-albums"
+            mode == "albums" ||
+            mode == "hidden-albums" ||
+            mode == "archive-albums"
                 ? {
                       type: "collections",
                       collectionSummaries,
@@ -357,9 +360,12 @@ export const Row2 = styled("div")`
 const ModeIndicator: React.FC<
     Pick<GalleryBarImplProps, "mode" | "onChangeMode">
 > = ({ mode, onChangeMode }) => {
-    // Mode switcher is not shown in the hidden albums section.
+    // Mode switcher is not shown in section-specific album views.
     if (mode == "hidden-albums") {
         return <Typography>{t("hidden_albums")}</Typography>;
+    }
+    if (mode == "archive-albums") {
+        return <Typography>{t("section_archive")}</Typography>;
     }
 
     // Show the static mode indicator with only the "Albums" title if ML is not

--- a/web/packages/new/photos/components/gallery/index.tsx
+++ b/web/packages/new/photos/components/gallery/index.tsx
@@ -59,7 +59,10 @@ export interface RemotePullOpts {
  * and starts a new selection.
  * */
 export type SelectionContext =
-    | { mode: "albums" | "hidden-albums"; collectionID: number }
+    | {
+          mode: "albums" | "hidden-albums" | "archive-albums";
+          collectionID: number;
+      }
     | { mode: "people"; personID: string };
 
 interface SearchResultsHeaderProps {

--- a/web/packages/new/photos/components/gallery/reducer.ts
+++ b/web/packages/new/photos/components/gallery/reducer.ts
@@ -1123,7 +1123,10 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                 selectedCollectionSummaryID !== undefined &&
                 state.archivedCollectionSummaries.has(
                     selectedCollectionSummaryID,
-                )
+                ) &&
+                (state.view?.type == "archive-albums" ||
+                    selectedCollectionSummaryID ==
+                        PseudoCollectionID.archiveItems)
             ) {
                 const activeCollectionSummaryID = selectedCollectionSummaryID;
                 view = {

--- a/web/packages/new/photos/components/gallery/reducer.ts
+++ b/web/packages/new/photos/components/gallery/reducer.ts
@@ -47,7 +47,11 @@ import type { FamilyData, UserDetails } from "../../services/user-details";
  * TODO: Deprecated(?). Use GalleryView instead. Deprecated if it can be used in
  * all cases where the bar mode was in use.
  */
-export type GalleryBarMode = "albums" | "hidden-albums" | "people";
+export type GalleryBarMode =
+    | "albums"
+    | "hidden-albums"
+    | "archive-albums"
+    | "people";
 
 /**
  * Specifies what the gallery is currently displaying.
@@ -57,17 +61,16 @@ export type GalleryBarMode = "albums" | "hidden-albums" | "people";
 export type GalleryView =
     | {
           /**
-           * We're either in the "Albums" or "Hidden albums" section.
+           * We're in the Albums, Hidden albums, or Archive section.
            */
-          type: "albums" | "hidden-albums";
+          type: "albums" | "hidden-albums" | "archive-albums";
           activeCollectionSummaryID: number;
           /**
            * If the active collection ID is for a collection and not a
            * pseudo-collection, this property will be set to the corresponding
            * {@link Collection}.
            *
-           * It is guaranteed that this will be one of the {@link collections}
-           * or {@link hiddenCollections}.
+           * It is guaranteed that this will be one of the {@link collections}.
            */
           activeCollection: Collection | undefined;
           /**
@@ -741,6 +744,13 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                         hiddenCollectionSummaries,
                         selectedCollectionSummaryID,
                     ));
+            } else if (state.view?.type == "archive-albums") {
+                ({ view, selectedCollectionSummaryID } =
+                    deriveArchiveAlbumsViewAndSelectedID(
+                        collections,
+                        archivedCollectionSummaries,
+                        selectedCollectionSummaryID,
+                    ));
             }
 
             return stateByUpdatingFilteredFiles({
@@ -1106,6 +1116,22 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                     activeCollection,
                     activeCollectionSummary:
                         state.hiddenCollectionSummaries.get(
+                            activeCollectionSummaryID,
+                        )!,
+                };
+            } else if (
+                selectedCollectionSummaryID !== undefined &&
+                state.archivedCollectionSummaries.has(
+                    selectedCollectionSummaryID,
+                )
+            ) {
+                const activeCollectionSummaryID = selectedCollectionSummaryID;
+                view = {
+                    type: "archive-albums",
+                    activeCollectionSummaryID,
+                    activeCollection,
+                    activeCollectionSummary:
+                        state.archivedCollectionSummaries.get(
                             activeCollectionSummaryID,
                         )!,
                 };
@@ -1868,9 +1894,15 @@ const deriveAlbumsViewAndSelectedID = (
     selectedCollectionSummaryID: GalleryState["selectedCollectionSummaryID"],
 ) => {
     // Make sure that the last selected ID is still valid by searching for it.
-    const selectedCollectionSummary = selectedCollectionSummaryID
+    const candidateCollectionSummary = selectedCollectionSummaryID
         ? collectionSummaries.get(selectedCollectionSummaryID)
         : undefined;
+    const selectedCollectionSummary =
+        candidateCollectionSummary &&
+        !candidateCollectionSummary.attributes.has("archiveItems") &&
+        !candidateCollectionSummary.attributes.has("archived")
+            ? candidateCollectionSummary
+            : undefined;
 
     const activeCollectionSummaryID =
         selectedCollectionSummary?.id ?? PseudoCollectionID.all;
@@ -1922,6 +1954,41 @@ const deriveHiddenAlbumsViewAndSelectedID = (
         selectedCollectionSummaryID: activeCollectionSummaryID,
         view: {
             type: "hidden-albums" as const,
+            activeCollectionSummaryID,
+            activeCollection,
+            activeCollectionSummary,
+        },
+    };
+};
+
+/**
+ * Sibling of {@link deriveAlbumsViewAndSelectedID} for when we're in the
+ * archive albums section.
+ */
+const deriveArchiveAlbumsViewAndSelectedID = (
+    collections: GalleryState["collections"],
+    archivedCollectionSummaries: GalleryState["archivedCollectionSummaries"],
+    selectedCollectionSummaryID: GalleryState["selectedCollectionSummaryID"],
+) => {
+    // Make sure that the last selected ID is still valid by searching for it.
+    const selectedCollectionSummary = selectedCollectionSummaryID
+        ? archivedCollectionSummaries.get(selectedCollectionSummaryID)
+        : undefined;
+
+    const activeCollectionSummaryID =
+        selectedCollectionSummary?.id ?? PseudoCollectionID.archiveItems;
+    const activeCollectionSummary = archivedCollectionSummaries.get(
+        activeCollectionSummaryID,
+    )!;
+    const activeCollection =
+        selectedCollectionSummary &&
+        activeCollectionSummaryID != PseudoCollectionID.archiveItems
+            ? collections.find(({ id }) => id == activeCollectionSummaryID)
+            : undefined;
+    return {
+        selectedCollectionSummaryID: activeCollectionSummaryID,
+        view: {
+            type: "archive-albums" as const,
             activeCollectionSummaryID,
             activeCollection,
             activeCollectionSummary,
@@ -2098,7 +2165,9 @@ const stateByUpdatingFilteredFiles = (state: GalleryState) => {
         const visibleSearchFiles = suppressSharedFilesSavedByUser(
             searchFiles,
             state.user?.id,
-            state.view?.type == "albums" || state.view?.type == "hidden-albums"
+            state.view?.type == "albums" ||
+                state.view?.type == "hidden-albums" ||
+                state.view?.type == "archive-albums"
                 ? state.view.activeCollection
                 : undefined,
         );
@@ -2111,7 +2180,8 @@ const stateByUpdatingFilteredFiles = (state: GalleryState) => {
         return { ...state, filteredFiles };
     } else if (
         state.view?.type == "albums" ||
-        state.view?.type == "hidden-albums"
+        state.view?.type == "hidden-albums" ||
+        state.view?.type == "archive-albums"
     ) {
         const filteredFiles = deriveAlbumsOrHiddenAlbumsFilteredFiles(
             state.trashItems,
@@ -2141,7 +2211,7 @@ const stateByUpdatingFilteredFiles = (state: GalleryState) => {
 
 /**
  * Compute the sorted list of files to show when we're in the "albums" or
- * "hidden-albums" view and the dependencies change.
+ * "hidden-albums", or "archive-albums" view and the dependencies change.
  */
 const deriveAlbumsOrHiddenAlbumsFilteredFiles = (
     trashItems: GalleryState["trashItems"],
@@ -2152,7 +2222,10 @@ const deriveAlbumsOrHiddenAlbumsFilteredFiles = (
     archivedFileIDs: GalleryState["archivedFileIDs"],
     tempDeletedFileIDs: GalleryState["tempDeletedFileIDs"],
     tempHiddenFileIDs: GalleryState["tempHiddenFileIDs"],
-    view: Extract<GalleryView, { type: "albums" | "hidden-albums" }>,
+    view: Extract<
+        GalleryView,
+        { type: "albums" | "hidden-albums" | "archive-albums" }
+    >,
     currentUserID: number | undefined,
 ) => {
     const activeCollectionSummaryID = view.activeCollectionSummaryID;

--- a/web/packages/new/photos/components/gallery/reducer.ts
+++ b/web/packages/new/photos/components/gallery/reducer.ts
@@ -286,6 +286,11 @@ export interface GalleryState {
      */
     hiddenCollectionSummaries: Map<number, CollectionSummary>;
     /**
+     * A variant of {@link normalCollectionSummaries}, but for archived
+     * collections and the archive section entry.
+     */
+    archivedCollectionSummaries: Map<number, CollectionSummary>;
+    /**
      * The ID of the collection summary that should be shown when the user
      * navigates to the uncategorized section.
      *
@@ -526,6 +531,7 @@ const initialGalleryState: GalleryState = {
     shareSuggestionEmails: [],
     normalCollectionSummaries: new Map(),
     hiddenCollectionSummaries: new Map(),
+    archivedCollectionSummaries: new Map(),
     uncategorizedCollectionSummaryID:
         PseudoCollectionID.uncategorizedPlaceholder,
     tempDeletedFileIDs: new Set(),
@@ -592,6 +598,13 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                 action.user,
                 collectionFiles,
             );
+            const archivedCollectionSummaries =
+                deriveArchivedCollectionSummaries(
+                    normalCollections,
+                    action.user,
+                    collectionFiles,
+                    hiddenFileIDs,
+                );
 
             const view = {
                 type: "albums" as const,
@@ -637,6 +650,7 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                 ),
                 normalCollectionSummaries,
                 hiddenCollectionSummaries,
+                archivedCollectionSummaries,
                 uncategorizedCollectionSummaryID:
                     deriveUncategorizedCollectionSummaryID(normalCollections),
                 view,
@@ -700,6 +714,13 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                 state.user!,
                 state.collectionFiles,
             );
+            const archivedCollectionSummaries =
+                deriveArchivedCollectionSummaries(
+                    normalCollections,
+                    state.user!,
+                    state.collectionFiles,
+                    hiddenFileIDs,
+                );
 
             // Revalidate the active view if needed.
             let view = state.view;
@@ -753,6 +774,7 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                 ),
                 normalCollectionSummaries,
                 hiddenCollectionSummaries,
+                archivedCollectionSummaries,
                 uncategorizedCollectionSummaryID:
                     deriveUncategorizedCollectionSummaryID(normalCollections),
                 selectedCollectionSummaryID,
@@ -1515,10 +1537,9 @@ const deriveNormalCollectionSummaries = (
         ),
     );
 
-    const archiveItemsFiles = uniqueFilesByID(
-        collectionFiles.filter(
-            (f) => !hiddenFileIDs.has(f.id) && isArchivedFile(f),
-        ),
+    const archiveItemsFiles = deriveArchiveItemsFiles(
+        collectionFiles,
+        hiddenFileIDs,
     );
 
     normalCollectionSummaries.set(PseudoCollectionID.all, {
@@ -1573,6 +1594,16 @@ const pseudoCollectionOptionsForLatestFileAndCount = (
     updationTime: file?.updationTime,
 });
 
+const deriveArchiveItemsFiles = (
+    collectionFiles: GalleryState["collectionFiles"],
+    hiddenFileIDs: GalleryState["hiddenFileIDs"],
+) =>
+    uniqueFilesByID(
+        collectionFiles.filter(
+            (file) => !hiddenFileIDs.has(file.id) && isArchivedFile(file),
+        ),
+    );
+
 /**
  * Compute hidden collection summaries from their dependencies.
  */
@@ -1601,6 +1632,35 @@ const deriveHiddenCollectionSummaries = (
     });
 
     return hiddenCollectionSummaries;
+};
+
+/**
+ * Compute archived collection summaries from their dependencies.
+ */
+const deriveArchivedCollectionSummaries = (
+    normalCollections: Collection[],
+    user: LocalUser,
+    collectionFiles: GalleryState["collectionFiles"],
+    hiddenFileIDs: GalleryState["hiddenFileIDs"],
+) => {
+    const archivedCollectionSummaries = createCollectionSummaries(
+        user,
+        normalCollections.filter(isArchivedCollection),
+        collectionFiles,
+    );
+
+    archivedCollectionSummaries.set(PseudoCollectionID.archiveItems, {
+        ...pseudoCollectionOptionsForFiles(
+            deriveArchiveItemsFiles(collectionFiles, hiddenFileIDs),
+        ),
+        id: PseudoCollectionID.archiveItems,
+        name: t("section_archive"),
+        type: "archiveItems",
+        attributes: new Set(["archiveItems", "system"]),
+        sortPriority: CollectionSummarySortPriority.system,
+    });
+
+    return archivedCollectionSummaries;
 };
 
 /**
@@ -1957,18 +2017,26 @@ const stateForUpdatedCollectionFiles = (
     state: GalleryState,
     collectionFiles: GalleryState["collectionFiles"],
 ): GalleryState => {
+    const normalCollections = state.collections.filter(
+        (c) => !state.hiddenCollectionIDs.has(c.id),
+    );
+    const hiddenCollections = state.collections.filter((c) =>
+        state.hiddenCollectionIDs.has(c.id),
+    );
     const hiddenFileIDs = deriveHiddenFileIDs(
         collectionFiles,
         state.hiddenCollectionIDs,
     );
+    const archivedFileIDs = deriveArchivedFileIDs(
+        state.archivedCollectionIDs,
+        collectionFiles,
+    );
+
     return {
         ...state,
         collectionFiles,
         hiddenFileIDs,
-        archivedFileIDs: deriveArchivedFileIDs(
-            state.archivedCollectionIDs,
-            collectionFiles,
-        ),
+        archivedFileIDs,
         favoriteFileIDs: deriveFavoriteFileIDs(
             state.user!,
             state.collections,
@@ -1980,21 +2048,23 @@ const stateForUpdatedCollectionFiles = (
             state.hiddenCollectionIDs,
         ),
         normalCollectionSummaries: deriveNormalCollectionSummaries(
-            state.collections.filter(
-                (c) => !state.hiddenCollectionIDs.has(c.id),
-            ),
+            normalCollections,
             state.user!,
             state.trashItems,
             collectionFiles,
             hiddenFileIDs,
-            state.archivedFileIDs,
+            archivedFileIDs,
         ),
         hiddenCollectionSummaries: deriveHiddenCollectionSummaries(
-            state.collections.filter((c) =>
-                state.hiddenCollectionIDs.has(c.id),
-            ),
+            hiddenCollections,
             state.user!,
             collectionFiles,
+        ),
+        archivedCollectionSummaries: deriveArchivedCollectionSummaries(
+            normalCollections,
+            state.user!,
+            collectionFiles,
+            hiddenFileIDs,
         ),
         pendingSearchSuggestions: enqueuePendingSearchSuggestionsIfNeeded(
             state.searchSuggestion,

--- a/web/packages/new/photos/utils/file-actions.ts
+++ b/web/packages/new/photos/utils/file-actions.ts
@@ -32,7 +32,7 @@ export type FileContextAction =
  * Context needed to determine which file actions should be available.
  */
 export interface FileActionContext {
-    /** The current bar mode (albums, hidden-albums, people). */
+    /** The current bar mode (albums, hidden-albums, archive-albums, people). */
     barMode?: GalleryBarMode;
     /** Whether we're in search mode. */
     isInSearchMode: boolean;


### PR DESCRIPTION
## Description

Web and desktop currently do not provide a single place to view all archived albums, unlike mobile.

This update makes the Archived section header show archived albums, matching the Hidden section behavior. Users can now browse all archived albums from one view.

> Current View

<img width="220" height="240" alt="image" src="https://github.com/user-attachments/assets/556caa43-cac4-4bd7-9ec4-706337cc3eca" />


> Post Implementation View

<img width="313" height="246" alt="image" src="https://github.com/user-attachments/assets/081d8a88-aed5-4cd4-a42e-f192e4e4d4c0" />
