### PR TITLE
[auth] [UX] Add type to serach behaviour on desktop

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1154,6 +1154,8 @@ class _HomePageState extends State<HomePage> {
           !pressed.contains(LogicalKeyboardKey.altLeft) &&
           !pressed.contains(LogicalKeyboardKey.alt) &&
           !pressed.contains(LogicalKeyboardKey.altRight) &&
+          event.logicalKey != LogicalKeyboardKey.keyC &&
+          event.logicalKey != LogicalKeyboardKey.keyN &&
           event.character != null &&
           event.character!.trim().isNotEmpty) {
         final String searchStarter = event.character!;

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1147,6 +1147,34 @@ class _HomePageState extends State<HomePage> {
         return true;
       }
 
+      // On desktop, typing a printable character opens search with that input.
+      if (PlatformDetector.isDesktop() &&
+          !isHomeSearchFocused &&
+          !isMetaKeyPressed &&
+          !pressed.contains(LogicalKeyboardKey.altLeft) &&
+          !pressed.contains(LogicalKeyboardKey.alt) &&
+          !pressed.contains(LogicalKeyboardKey.altRight) &&
+          event.character != null &&
+          event.character!.trim().isNotEmpty) {
+        final String searchStarter = event.character!;
+        setState(() {
+          _showSearchBox = true;
+        });
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          searchBoxFocusNode.requestFocus();
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            _searchText = searchStarter;
+            _textController.value = TextEditingValue(
+              text: searchStarter,
+              selection: TextSelection.collapsed(offset: searchStarter.length),
+            );
+          });
+        });
+        return true;
+      }
+
       // Only use Escape for the HomePage search UI.
       if (event.logicalKey == LogicalKeyboardKey.escape && _showSearchBox) {
         setState(() {

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -60,6 +60,7 @@ import 'package:ente_ui/pages/base_home_page.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' as widgets;
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:hugeicons/hugeicons.dart';
@@ -1128,6 +1129,16 @@ class _HomePageState extends State<HomePage> {
           pressed.contains(LogicalKeyboardKey.shiftRight) ||
           pressed.contains(LogicalKeyboardKey.shift);
 
+      final focusContext = primaryFocus?.context;
+      final bool isFocusedCopyShortcut =
+          focusContext != null &&
+          ((event.logicalKey == LogicalKeyboardKey.keyC &&
+                  widgets.Actions.maybeFind<CopyIntent>(focusContext) !=
+                      null) ||
+              (event.logicalKey == LogicalKeyboardKey.keyN &&
+                  widgets.Actions.maybeFind<CopyNextIntent>(focusContext) !=
+                      null));
+
       if (isMetaKeyPressed && event.logicalKey == LogicalKeyboardKey.keyW) {
         if (PlatformDetector.isDesktop()) {
           windowManager.close();
@@ -1154,8 +1165,7 @@ class _HomePageState extends State<HomePage> {
           !pressed.contains(LogicalKeyboardKey.altLeft) &&
           !pressed.contains(LogicalKeyboardKey.alt) &&
           !pressed.contains(LogicalKeyboardKey.altRight) &&
-          event.logicalKey != LogicalKeyboardKey.keyC &&
-          event.logicalKey != LogicalKeyboardKey.keyN &&
+          !isFocusedCopyShortcut &&
           event.character != null &&
           event.character!.trim().isNotEmpty) {
         final String searchText = _showSearchBox

--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -1158,21 +1158,20 @@ class _HomePageState extends State<HomePage> {
           event.logicalKey != LogicalKeyboardKey.keyN &&
           event.character != null &&
           event.character!.trim().isNotEmpty) {
-        final String searchStarter = event.character!;
+        final String searchText = _showSearchBox
+            ? _textController.text + event.character!
+            : event.character!;
         setState(() {
           _showSearchBox = true;
+          _searchText = searchText;
+          _textController.value = TextEditingValue(
+            text: searchText,
+            selection: TextSelection.collapsed(offset: searchText.length),
+          );
         });
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!mounted) return;
           searchBoxFocusNode.requestFocus();
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (!mounted) return;
-            _searchText = searchStarter;
-            _textController.value = TextEditingValue(
-              text: searchStarter,
-              selection: TextSelection.collapsed(offset: searchStarter.length),
-            );
-          });
         });
         return true;
       }
@@ -1606,6 +1605,7 @@ class _HomePageState extends State<HomePage> {
                 autocorrect: false,
                 enableSuggestions: false,
                 autofocus: _autoFocusSearch && !Platform.isAndroid,
+                selectAllOnFocus: false,
                 controller: _textController,
                 onChanged: (val) {
                   _searchText = val;


### PR DESCRIPTION
## Description

Adds type-to-search behavior on the Ente Auth desktop home page. When the home page is focused and the user types a printable character, the search bar opens and starts the query with that character.

Existing shortcuts like Ctrl/Cmd+F, `/`, Escape, Cmd+W and the focused-code `c`/`n` copy shortcuts are preserved. and the behavior does not trigger while another text field or the settings drawer is active.

## Tests

- Ran Ente Auth on Windows desktop
- Verified typing a character on the home page opens search
- Verified Escape still closes search
- Verified Ctrl+F still opens search