### PR TITLE
[web][photos] Updated logic for file-actions

### DIFF
--- a/desktop/changes/shared-file-action-menus.md
+++ b/desktop/changes/shared-file-action-menus.md
@@ -1,0 +1,1 @@
+- Fix shared file action menus to show only available actions.

--- a/web/apps/photos/src/components/FileList.tsx
+++ b/web/apps/photos/src/components/FileList.tsx
@@ -677,25 +677,38 @@ export const FileList: React.FC<FileListProps> = ({
     // Compute available context menu actions based on stable context and
     // the favorite status of the current selection (for toggling).
     const contextMenuActions = useMemo(() => {
-        if (!onContextMenuAction) return [];
+        if (!onContextMenuAction || !contextMenu) return [];
+        const isTemporarySingleSelection =
+            previousSelectionRef.current !== null;
+        let selectionCount: number;
+        let favoriteCount: number;
+        let hasOnlyOwnFiles: boolean;
+
+        if (isTemporarySingleSelection) {
+            selectionCount = 1;
+            favoriteCount = favoriteFileIDs?.has(contextMenu.file.id) ? 1 : 0;
+            hasOnlyOwnFiles = contextMenu.file.ownerID === user?.id;
+        } else {
+            selectionCount = selected.count;
+            favoriteCount = selectedFavoriteCount;
+            hasOnlyOwnFiles =
+                selectionCount > 0 && selected.ownCount === selectionCount;
+        }
         const actions = getAvailableFileActions({
             barMode: mode,
             isInSearchMode: modePlus === "search",
             collectionSummary,
+            hasOnlyOwnFiles,
             showAddPerson: !!showAddPersonAction,
-            showEditLocation: !!showEditLocationAction && selected.ownCount > 0,
-            showSendLink: selected.ownCount > 0,
+            showEditLocation: !!showEditLocationAction && hasOnlyOwnFiles,
         });
         if (!actions.includes("favorite")) return actions;
-        if (
-            selectedFavoriteCount > 0 &&
-            selectedFavoriteCount < selected.count
-        ) {
+        if (favoriteCount > 0 && favoriteCount < selectionCount) {
             return actions.filter(
                 (action) => action !== "favorite" && action !== "unfavorite",
             );
         }
-        if (selectedFavoriteCount === selected.count && selected.count > 0) {
+        if (favoriteCount === selectionCount && selectionCount > 0) {
             return actions.map((action) =>
                 action === "favorite" ? "unfavorite" : action,
             );
@@ -703,11 +716,14 @@ export const FileList: React.FC<FileListProps> = ({
         return actions;
     }, [
         onContextMenuAction,
+        contextMenu,
         mode,
         modePlus,
         collectionSummary,
         showAddPersonAction,
         showEditLocationAction,
+        favoriteFileIDs,
+        user?.id,
         selected.ownCount,
         selectedFavoriteCount,
         selected.count,
@@ -724,7 +740,6 @@ export const FileList: React.FC<FileListProps> = ({
             // Reset tracking for this menu open.
             previousSelectionRef.current = null;
             contextMenuActionTakenRef.current = false;
-
             // Handle selection behavior on right-click
             if (!selected[file.id]) {
                 // Store current selection before replacing it
@@ -792,14 +807,13 @@ export const FileList: React.FC<FileListProps> = ({
     const handleContextMenuActionWithTracking = useCallback(
         (action: FileContextAction) => {
             const isEphemeralSingleSelection =
-                selected.count === 1 &&
                 previousSelectionRef.current?.count === 0;
             contextMenuActionTakenRef.current = true;
             onContextMenuAction?.(action, contextMenu?.file, {
                 isEphemeralSingleSelection,
             });
         },
-        [onContextMenuAction, contextMenu, selected.count],
+        [onContextMenuAction, contextMenu],
     );
 
     const renderListItem = useCallback(

--- a/web/packages/gallery/components/viewer/FileViewer.tsx
+++ b/web/packages/gallery/components/viewer/FileViewer.tsx
@@ -2252,7 +2252,7 @@ export const FileViewer: React.FC<FileViewerProps> = ({
                     </MoreMenuItem>
                 )}
                 {handleAddFileToCollection &&
-                    activeAnnotatedFile.annotation.isOwnFile && (
+                    !(isInTrashSection || isInHiddenSection) && (
                         <MoreMenuItem onClick={handleAddFileToCollection}>
                             <MoreMenuItemTitle>
                                 {t("add_to_album")}

--- a/web/packages/new/photos/components/SelectedFileOptions.tsx
+++ b/web/packages/new/photos/components/SelectedFileOptions.tsx
@@ -27,10 +27,11 @@ import type { CollectionSelectorAttributes } from "ente-new/photos/components/Co
 import type { GalleryBarMode } from "ente-new/photos/components/gallery/reducer";
 import { StarBorderIcon } from "ente-new/photos/components/icons/StarIcon";
 import { StarOffIcon } from "ente-new/photos/components/icons/StarOffIcon";
+import type { CollectionSummary } from "ente-new/photos/services/collection-summary";
 import {
-    PseudoCollectionID,
-    type CollectionSummary,
-} from "ente-new/photos/services/collection-summary";
+    getAvailableFileActions,
+    type FileContextAction,
+} from "ente-new/photos/utils/file-actions";
 import { t } from "i18next";
 
 /**
@@ -200,9 +201,6 @@ export const SelectedFileOptions: React.FC<SelectedFileOptionsProps> = ({
 }) => {
     const { showMiniDialog } = useBaseContext();
 
-    const isUserFavorites =
-        !!collectionSummary?.attributes.has("userFavorites");
-
     const handleFavorite = createFileOpHandler("favorite");
     const handleUnfavorite = createFileOpHandler("unfavorite");
 
@@ -257,18 +255,13 @@ export const SelectedFileOptions: React.FC<SelectedFileOptionsProps> = ({
     const isSharedOutgoing =
         collectionSummary?.attributes.has("sharedOutgoing");
     const isRemovingOthers = selectedFileCount != selectedOwnFileCount;
+    const hasOnlyOwnFiles = selectedOwnFileCount > 0 && !isRemovingOthers;
     const favoriteAction =
         selectedFavoriteCount === 0
             ? "favorite"
             : selectedFavoriteCount === selectedFileCount
               ? "unfavorite"
               : "none";
-    const favoriteActionButton =
-        favoriteAction === "favorite" ? (
-            <FavoriteButton onClick={handleFavorite} />
-        ) : favoriteAction === "unfavorite" ? (
-            <UnfavoriteButton onClick={handleUnfavorite} />
-        ) : null;
 
     const handleRemoveFromCollection = () => {
         if (!collection) return;
@@ -338,6 +331,88 @@ export const SelectedFileOptions: React.FC<SelectedFileOptionsProps> = ({
         });
     };
 
+    const toolbarActions = getAvailableFileActions({
+        barMode,
+        isInSearchMode,
+        collectionSummary,
+        hasOnlyOwnFiles,
+        showAddPerson: !!onShowAssignPersonDialog,
+        showEditLocation: !!onEditLocation && hasOnlyOwnFiles,
+    }).flatMap((action): FileContextAction[] => {
+        if (action !== "favorite" && action !== "unfavorite") return [action];
+        return favoriteAction === "none" ? [] : [favoriteAction];
+    });
+
+    const renderActionButton = (action: FileContextAction) => {
+        switch (action) {
+            case "sendLink":
+                return <SendLinkButton key={action} onClick={handleSendLink} />;
+            case "download":
+                return <DownloadButton key={action} onClick={handleDownload} />;
+            case "fixTime":
+                return <FixTimeButton key={action} onClick={handleFixTime} />;
+            case "editLocation":
+                return onEditLocation ? (
+                    <EditLocationButton key={action} onClick={onEditLocation} />
+                ) : null;
+            case "favorite":
+                return <FavoriteButton key={action} onClick={handleFavorite} />;
+            case "unfavorite":
+                return (
+                    <UnfavoriteButton key={action} onClick={handleUnfavorite} />
+                );
+            case "archive":
+                return <ArchiveButton key={action} onClick={handleArchive} />;
+            case "unarchive":
+                return (
+                    <UnarchiveButton key={action} onClick={handleUnarchive} />
+                );
+            case "hide":
+                return <HideButton key={action} onClick={handleHide} />;
+            case "unhide":
+                return <UnhideButton key={action} onClick={handleUnhide} />;
+            case "trash":
+                return <DeleteButton key={action} onClick={handleDelete} />;
+            case "deletePermanently":
+                return (
+                    <DeletePermanentlyButton
+                        key={action}
+                        onClick={handleDeletePermanently}
+                    />
+                );
+            case "restore":
+                return <RestoreButton key={action} onClick={handleRestore} />;
+            case "addToAlbum":
+                return (
+                    <AddToCollectionButton
+                        key={action}
+                        onClick={handleAddToCollection}
+                    />
+                );
+            case "moveToAlbum":
+                return (
+                    <MoveToCollectionButton
+                        key={action}
+                        onClick={handleMoveToCollection}
+                    />
+                );
+            case "removeFromAlbum":
+                return (
+                    <RemoveFromCollectionButton
+                        key={action}
+                        onClick={handleRemoveFromCollection}
+                    />
+                );
+            case "addPerson":
+                return onShowAssignPersonDialog ? (
+                    <AddPersonButton
+                        key={action}
+                        onClick={onShowAssignPersonDialog}
+                    />
+                ) : null;
+        }
+    };
+
     return (
         <>
             <SpacedRow sx={{ flex: 1, gap: 1, flexWrap: "wrap" }}>
@@ -359,143 +434,7 @@ export const SelectedFileOptions: React.FC<SelectedFileOptionsProps> = ({
 
                 <Box sx={{ mr: "auto" }} />
 
-                {isInSearchMode ? (
-                    <>
-                        {selectedOwnFileCount > 0 && (
-                            <SendLinkButton onClick={handleSendLink} />
-                        )}
-                        {favoriteActionButton}
-                        <FixTimeButton onClick={handleFixTime} />
-                        {onEditLocation && selectedOwnFileCount > 0 && (
-                            <EditLocationButton onClick={onEditLocation} />
-                        )}
-                        <DownloadButton onClick={handleDownload} />
-                        <AddToCollectionButton
-                            onClick={handleAddToCollection}
-                        />
-                        {!!onShowAssignPersonDialog && (
-                            <AddPersonButton
-                                onClick={onShowAssignPersonDialog}
-                            />
-                        )}
-                        <ArchiveButton onClick={handleArchive} />
-                        <HideButton onClick={handleHide} />
-                        <DeleteButton onClick={handleDelete} />
-                    </>
-                ) : barMode == "people" ? (
-                    <>
-                        {selectedOwnFileCount > 0 && (
-                            <SendLinkButton onClick={handleSendLink} />
-                        )}
-                        {favoriteActionButton}
-                        <DownloadButton onClick={handleDownload} />
-                        <AddToCollectionButton
-                            onClick={handleAddToCollection}
-                        />
-                        {!!onShowAssignPersonDialog && (
-                            <AddPersonButton
-                                onClick={onShowAssignPersonDialog}
-                            />
-                        )}
-                        <ArchiveButton onClick={handleArchive} />
-                        <HideButton onClick={handleHide} />
-                        <DeleteButton onClick={handleDelete} />
-                    </>
-                ) : collectionSummary?.id == PseudoCollectionID.trash ? (
-                    <>
-                        <RestoreButton onClick={handleRestore} />
-                        <DeletePermanentlyButton
-                            onClick={handleDeletePermanently}
-                        />
-                    </>
-                ) : collectionSummary?.attributes.has("uncategorized") ? (
-                    <>
-                        {selectedOwnFileCount > 0 && (
-                            <SendLinkButton onClick={handleSendLink} />
-                        )}
-                        <DownloadButton onClick={handleDownload} />
-                        {!!onShowAssignPersonDialog && (
-                            <AddPersonButton
-                                onClick={onShowAssignPersonDialog}
-                            />
-                        )}
-                        <MoveToCollectionButton
-                            onClick={handleMoveToCollection}
-                        />
-                        <DeleteButton onClick={handleDelete} />
-                    </>
-                ) : collectionSummary?.attributes.has("sharedIncoming") ? (
-                    <>
-                        {selectedOwnFileCount > 0 && (
-                            <SendLinkButton onClick={handleSendLink} />
-                        )}
-                        {favoriteActionButton}
-                        <DownloadButton onClick={handleDownload} />
-                        {!!onShowAssignPersonDialog && (
-                            <AddPersonButton
-                                onClick={onShowAssignPersonDialog}
-                            />
-                        )}
-                        <RemoveFromCollectionButton
-                            onClick={handleRemoveFromCollection}
-                        />
-                    </>
-                ) : barMode == "hidden-albums" ? (
-                    <>
-                        {selectedOwnFileCount > 0 && (
-                            <SendLinkButton onClick={handleSendLink} />
-                        )}
-                        <DownloadButton onClick={handleDownload} />
-                        {!!onShowAssignPersonDialog && (
-                            <AddPersonButton
-                                onClick={onShowAssignPersonDialog}
-                            />
-                        )}
-                        <UnhideButton onClick={handleUnhide} />
-                        <DeleteButton onClick={handleDelete} />
-                    </>
-                ) : (
-                    <>
-                        {selectedOwnFileCount > 0 && (
-                            <SendLinkButton onClick={handleSendLink} />
-                        )}
-                        {collectionSummary?.id !=
-                            PseudoCollectionID.archiveItems &&
-                            favoriteActionButton}
-                        <FixTimeButton onClick={handleFixTime} />
-                        {onEditLocation && selectedOwnFileCount > 0 && (
-                            <EditLocationButton onClick={onEditLocation} />
-                        )}
-                        <DownloadButton onClick={handleDownload} />
-                        <AddToCollectionButton
-                            onClick={handleAddToCollection}
-                        />
-                        {!!onShowAssignPersonDialog && (
-                            <AddPersonButton
-                                onClick={onShowAssignPersonDialog}
-                            />
-                        )}
-                        {collectionSummary?.id === PseudoCollectionID.all ? (
-                            <ArchiveButton onClick={handleArchive} />
-                        ) : collectionSummary?.id ==
-                          PseudoCollectionID.archiveItems ? (
-                            <UnarchiveButton onClick={handleUnarchive} />
-                        ) : (
-                            !isUserFavorites && (
-                                <>
-                                    <MoveToCollectionButton
-                                        onClick={handleMoveToCollection}
-                                    />
-                                    <RemoveFromCollectionButton
-                                        onClick={handleRemoveFromCollection}
-                                    />
-                                </>
-                            )
-                        )}
-                        <HideButton onClick={handleHide} />
-                        <DeleteButton onClick={handleDelete} />
-                    </>
-                )}
+                {toolbarActions.map(renderActionButton)}
             </SpacedRow>
         </>
     );

--- a/web/packages/new/photos/utils/file-actions.ts
+++ b/web/packages/new/photos/utils/file-actions.ts
@@ -31,7 +31,7 @@ export type FileContextAction =
 /**
  * Context needed to determine which file actions should be available.
  */
-export interface FileActionContext {
+interface FileActionContext {
     /** The current bar mode (albums, hidden-albums, archive-albums, people). */
     barMode?: GalleryBarMode;
     /** Whether we're in search mode. */
@@ -43,6 +43,10 @@ export interface FileActionContext {
      */
     collectionSummary: CollectionSummary | undefined;
     /**
+     * Whether every selected file is owned by the current user.
+     */
+    hasOnlyOwnFiles: boolean;
+    /**
      * Whether to show the "Add Person" action.
      *
      * This depends on ML being enabled and having named people.
@@ -51,15 +55,9 @@ export interface FileActionContext {
     /**
      * Whether to show the "Edit Location" action.
      *
-     * This depends on the selection containing owned files.
+     * This depends on every selected file being owned.
      */
     showEditLocation: boolean;
-    /**
-     * Whether to show the "Send link" action.
-     *
-     * This depends on the selection containing owned files.
-     */
-    showSendLink: boolean;
 }
 
 /**
@@ -75,19 +73,20 @@ export function getAvailableFileActions(
         barMode,
         isInSearchMode,
         collectionSummary,
+        hasOnlyOwnFiles,
         showAddPerson,
         showEditLocation,
-        showSendLink,
     } = context;
 
     const actions = getBaseActions(
         barMode,
         isInSearchMode,
         collectionSummary,
+        hasOnlyOwnFiles,
         showEditLocation,
     );
 
-    if (showSendLink && collectionSummary?.id !== PseudoCollectionID.trash) {
+    if (hasOnlyOwnFiles && collectionSummary?.id !== PseudoCollectionID.trash) {
         insertSendLinkBeforeDownload(actions);
     }
 
@@ -107,28 +106,36 @@ function getBaseActions(
     barMode: GalleryBarMode | undefined,
     isInSearchMode: boolean,
     collectionSummary: CollectionSummary | undefined,
+    hasOnlyOwnFiles: boolean,
     showEditLocation: boolean,
 ): FileContextAction[] {
     // Search mode actions
     if (isInSearchMode) {
-        const actions: FileContextAction[] = ["favorite", "fixTime"];
+        const actions: FileContextAction[] = ["favorite"];
+        if (hasOnlyOwnFiles) {
+            actions.push("fixTime");
+        }
         if (showEditLocation) {
             actions.push("editLocation");
         }
-        actions.push("download", "addToAlbum", "archive", "hide", "trash");
+        actions.push("download", "addToAlbum");
+        if (hasOnlyOwnFiles) {
+            actions.push("archive", "hide", "trash");
+        }
         return actions;
     }
 
     // People mode actions
     if (barMode === "people") {
-        return [
+        const actions: FileContextAction[] = [
             "favorite",
             "download",
             "addToAlbum",
-            "archive",
-            "hide",
-            "trash",
         ];
+        if (hasOnlyOwnFiles) {
+            actions.push("archive", "hide", "trash");
+        }
+        return actions;
     }
 
     // Trash actions
@@ -138,12 +145,27 @@ function getBaseActions(
 
     // Uncategorized actions
     if (collectionSummary?.attributes.has("uncategorized")) {
-        return ["download", "moveToAlbum", "trash"];
+        const actions: FileContextAction[] = ["download"];
+        if (hasOnlyOwnFiles) {
+            actions.push("moveToAlbum", "trash");
+        }
+        return actions;
     }
 
     // Shared incoming actions
     if (collectionSummary?.attributes.has("sharedIncoming")) {
-        return ["favorite", "download", "removeFromAlbum"];
+        const actions: FileContextAction[] = [
+            "favorite",
+            "download",
+            "addToAlbum",
+        ];
+        if (
+            hasOnlyOwnFiles ||
+            collectionSummary.attributes.has("sharedIncomingAdmin")
+        ) {
+            actions.push("removeFromAlbum");
+        }
+        return actions;
     }
 
     // Hidden albums mode actions
@@ -166,21 +188,32 @@ function getBaseActions(
         actions.push("favorite");
     }
 
-    actions.push("fixTime");
+    if (hasOnlyOwnFiles) {
+        actions.push("fixTime");
+    }
     if (showEditLocation) {
         actions.push("editLocation");
     }
     actions.push("download", "addToAlbum");
 
     if (collectionSummary?.id === PseudoCollectionID.all) {
-        actions.push("archive");
+        if (hasOnlyOwnFiles) {
+            actions.push("archive");
+        }
     } else if (isArchiveItems) {
-        actions.push("unarchive");
+        if (hasOnlyOwnFiles) {
+            actions.push("unarchive");
+        }
     } else if (!isUserFavorites) {
-        actions.push("moveToAlbum", "removeFromAlbum");
+        if (hasOnlyOwnFiles) {
+            actions.push("moveToAlbum");
+        }
+        actions.push("removeFromAlbum");
     }
 
-    actions.push("hide", "trash");
+    if (hasOnlyOwnFiles) {
+        actions.push("hide", "trash");
+    }
 
     return actions;
 }


### PR DESCRIPTION
## Description

Earlier, file-actions were rendered such that if the selection had at least one owned file, it would show all available options for all files. for example, if you selected a shared file and an owned file together, the context menu would still show options like Fix Time, Delete, etc. this behavior was observed in the "All" gallery.

Also, in the sharedIncoming view, we hadn't added the newly added function like "Add to Album."

Additionally, if a non-owned file was selected on its own, the options rendered were based on the view rather than considering file ownership - for example, showing Archive even when it shouldn't apply.

This PR addresses all of the above. Also file actions are now generated in `file-actions` and supplied to both the context menu and the top bar to maintain consistency.