### PR TITLE
fix(desktop): avoid renderer OOM during folder-watch upload of large libraries

### DIFF
--- a/desktop/changes/fix-watch-upload-large-library-oom.md
+++ b/desktop/changes/fix-watch-upload-large-library-oom.md
@@ -1,0 +1,1 @@
+- Fix the desktop app crashing during large folder-watch uploads by bounding renderer memory and refreshing gallery state after watcher completion.

--- a/desktop/src/main/services/ffmpeg.ts
+++ b/desktop/src/main/services/ffmpeg.ts
@@ -1,4 +1,9 @@
-import { wrap } from "comlink";
+/**
+ * @file A bridge to the ffmpeg utility process. This code runs in the main
+ * process.
+ */
+
+import { wrap, type Remote } from "comlink";
 import fs from "node:fs/promises";
 import type { FFmpegCommand, ZipItem } from "../../types/ipc";
 import {
@@ -9,11 +14,29 @@ import {
 import type { FFmpegUtilityProcess } from "./ffmpeg-worker";
 import { ffmpegUtilityProcessEndpoint } from "./workers";
 
-export const ffmpegUtilityProcess = () =>
-    ffmpegUtilityProcessEndpoint().then((port) =>
-        wrap<FFmpegUtilityProcess>(port),
-    );
+/** Cache one Comlink wrapper per utility-process endpoint. */
+let ffmpegWorkerEndpoint: ReturnType<typeof ffmpegUtilityProcessEndpoint>;
+let ffmpegWorker: Promise<Remote<FFmpegUtilityProcess>> | undefined;
 
+/**
+ * Return a handle to the ffmpeg utility process, starting it if needed.
+ */
+export const ffmpegUtilityProcess = () => {
+    const endpoint = ffmpegUtilityProcessEndpoint();
+    if (ffmpegWorkerEndpoint !== endpoint) {
+        ffmpegWorkerEndpoint = endpoint;
+        ffmpegWorker = endpoint.then((port) =>
+            wrap<FFmpegUtilityProcess>(port),
+        );
+    }
+    return ffmpegWorker!;
+};
+
+/**
+ * Implement the IPC "ffmpegExec" contract, writing the input and output to
+ * temporary files as needed, and then forward to the {@link ffmpegExec} running
+ * in the utility process.
+ */
 export const ffmpegExec = async (
     command: FFmpegCommand,
     pathOrZipItem: string | ZipItem,
@@ -51,6 +74,11 @@ export const withInputFile = async <T>(
     }
 };
 
+/**
+ * Implement the IPC "ffmpegDetermineVideoDuration" contract, writing the input
+ * to temporary files as needed, and then forward to the
+ * {@link ffmpegDetermineVideoDuration} running in the utility process.
+ */
 export const ffmpegDetermineVideoDuration = async (
     pathOrZipItem: string | ZipItem,
 ): Promise<number> =>

--- a/desktop/src/main/utils/comlink.ts
+++ b/desktop/src/main/utils/comlink.ts
@@ -16,9 +16,7 @@ export const messagePortMainEndpoint = (mp: MessagePortMain): Endpoint => {
                 "handleEvent" in eh
                     ? eh.handleEvent({ data } as MessageEvent)
                     : eh(data as unknown as MessageEvent);
-            mp.on("message", (data) => {
-                l(data);
-            });
+            mp.on("message", l);
             listeners.set(eh, l);
         },
         removeEventListener: (_, eh) => {

--- a/web/apps/photos/src/components/FileList.tsx
+++ b/web/apps/photos/src/components/FileList.tsx
@@ -752,7 +752,6 @@ export const FileList: React.FC<FileListProps> = ({
     const handleScroll = useCallback(
         ({ scrollOffset }: { scrollOffset: number }) => {
             onScroll?.(scrollOffset);
-
             setShowBackToTop(scrollOffset > 500);
 
             if (onVisibleDateChange && items.length > 0) {

--- a/web/apps/photos/src/components/Upload.tsx
+++ b/web/apps/photos/src/components/Upload.tsx
@@ -336,7 +336,9 @@ export const Upload: React.FC<UploadProps> = ({
                 setHasLivePhotos,
                 setUploadProgressView,
             },
-            onUploadFile,
+            (file) => {
+                if (!watcher.isUploadRunning()) onUploadFile(file);
+            },
         );
 
         if (uploadManager.isUploadRunning()) {
@@ -1013,6 +1015,18 @@ export const Upload: React.FC<UploadProps> = ({
         collections: Collection[],
         opts?: UploadFilesOptions,
     ) => {
+        const isFolderWatchUpload = isDesktop && watcher.isUploadRunning();
+        const handleResult = async (result: UploadBatchResult) => {
+            await handlePostUploadBatchResult(
+                result,
+                opts?.postUploadTargetCollection,
+            );
+            await handleTakeoutFavoritesPostUpload(
+                result,
+                opts?.postUploadTargetCollection,
+                opts?.importTakeoutFavorites ?? true,
+            );
+        };
         try {
             retrySharedAlbumUploadTarget.current =
                 opts?.postUploadTargetCollection;
@@ -1045,20 +1059,16 @@ export const Upload: React.FC<UploadProps> = ({
                     skipDuplicateAddToUploadCollection:
                         !!opts?.postUploadTargetCollection,
                     includePartnerSharedFiles: opts?.includePartnerSharedFiles,
+                    onChunkResult: isFolderWatchUpload
+                        ? handleResult
+                        : undefined,
                 },
             );
             if (!batchResult.processedAny) closeUploadProgress();
-            await handlePostUploadBatchResult(
-                batchResult,
-                opts?.postUploadTargetCollection,
-            );
-            await handleTakeoutFavoritesPostUpload(
-                batchResult,
-                opts?.postUploadTargetCollection,
-                opts?.importTakeoutFavorites ?? true,
-            );
+            if (!isFolderWatchUpload || batchResult.itemResults.length)
+                await handleResult(batchResult);
             if (isDesktop) {
-                if (watcher.isUploadRunning()) {
+                if (isFolderWatchUpload) {
                     await watcher.allFileUploadsDone(uploadItemsWithCollection);
                 } else if (watcher.isSyncPaused()) {
                     // Resume the watch upload displaced by this user upload.

--- a/web/apps/photos/src/components/Upload.tsx
+++ b/web/apps/photos/src/components/Upload.tsx
@@ -462,7 +462,9 @@ export const Upload: React.FC<UploadProps> = ({
                 setHasLivePhotos,
                 setUploadProgressView,
             },
-            onUploadFile,
+            (file) => {
+                if (!watcher.isUploadRunning()) onUploadFile(file);
+            },
         );
 
         if (uploadManager.isUploadRunning()) {
@@ -1220,6 +1222,18 @@ export const Upload: React.FC<UploadProps> = ({
         collections: Collection[],
         opts?: UploadFilesOptions,
     ) => {
+        const isFolderWatchUpload = isDesktop && watcher.isUploadRunning();
+        const handleResult = async (result: UploadBatchResult) => {
+            await handlePostUploadBatchResult(
+                result,
+                opts?.postUploadTargetCollection,
+            );
+            await handleTakeoutFavoritesPostUpload(
+                result,
+                opts?.postUploadTargetCollection,
+                opts?.importTakeoutFavorites ?? true,
+            );
+        };
         try {
             retrySharedAlbumUploadTarget.current =
                 opts?.postUploadTargetCollection;
@@ -1252,20 +1266,16 @@ export const Upload: React.FC<UploadProps> = ({
                     skipDuplicateAddToUploadCollection:
                         !!opts?.postUploadTargetCollection,
                     includePartnerSharedFiles: opts?.includePartnerSharedFiles,
+                    onChunkResult: isFolderWatchUpload
+                        ? handleResult
+                        : undefined,
                 },
             );
             if (!batchResult.processedAny) closeUploadProgress();
-            await handlePostUploadBatchResult(
-                batchResult,
-                opts?.postUploadTargetCollection,
-            );
-            await handleTakeoutFavoritesPostUpload(
-                batchResult,
-                opts?.postUploadTargetCollection,
-                opts?.importTakeoutFavorites ?? true,
-            );
+            if (!isFolderWatchUpload || batchResult.itemResults.length)
+                await handleResult(batchResult);
             if (isDesktop) {
-                if (watcher.isUploadRunning()) {
+                if (isFolderWatchUpload) {
                     await watcher.allFileUploadsDone(uploadItemsWithCollection);
                 } else if (watcher.isSyncPaused()) {
                     // Resume folder watch after the user upload that

--- a/web/apps/photos/src/components/Upload.tsx
+++ b/web/apps/photos/src/components/Upload.tsx
@@ -353,9 +353,8 @@ export const Upload: React.FC<UploadProps> = ({
                 setDesktopFilePaths(filePaths);
             };
 
-            watcher.init(
-                upload,
-                () => void onRemotePull({ source: "watcher-upload" }),
+            watcher.init(upload, () =>
+                onRemotePull({ source: "watcher-upload", strict: true }),
             );
 
             void electron.pendingUploads().then((pending) => {
@@ -999,15 +998,17 @@ export const Upload: React.FC<UploadProps> = ({
 
     const preUploadAction = async (
         parsedMetadataJSONMap?: Map<string, ParsedMetadataJSON>,
+        refreshGallery = true,
     ) => {
         uploadManager.prepareForNewUpload(parsedMetadataJSONMap);
         uploadManager.showUploadProgressDialog();
-        await onRemotePull({ silent: true, source: "pre-upload" });
+        if (refreshGallery)
+            await onRemotePull({ silent: true, source: "pre-upload" });
     };
 
-    function postUploadAction() {
+    function postUploadAction(refreshGallery = true) {
         resetUploadUIState();
-        void onRemotePull({ source: "post-upload" });
+        if (refreshGallery) void onRemotePull({ source: "post-upload" });
     }
 
     const uploadFiles = async (
@@ -1016,6 +1017,7 @@ export const Upload: React.FC<UploadProps> = ({
         opts?: UploadFilesOptions,
     ) => {
         const isFolderWatchUpload = isDesktop && watcher.isUploadRunning();
+        let refreshGallery = true;
         const handleResult = async (result: UploadBatchResult) => {
             await handlePostUploadBatchResult(
                 result,
@@ -1034,7 +1036,7 @@ export const Upload: React.FC<UploadProps> = ({
                 opts?.importTakeoutFavorites ?? true;
             retryIncludePartnerSharedFiles.current =
                 opts?.includePartnerSharedFiles ?? true;
-            await preUploadAction();
+            await preUploadAction(undefined, !isFolderWatchUpload);
             if (
                 opts?.persistPendingUploads &&
                 electron &&
@@ -1070,6 +1072,7 @@ export const Upload: React.FC<UploadProps> = ({
             if (isDesktop) {
                 if (isFolderWatchUpload) {
                     await watcher.allFileUploadsDone(uploadItemsWithCollection);
+                    refreshGallery = false;
                 } else if (watcher.isSyncPaused()) {
                     // Resume the watch upload displaced by this user upload.
                     watcher.resumePausedSync();
@@ -1077,10 +1080,21 @@ export const Upload: React.FC<UploadProps> = ({
             }
         } catch (e) {
             log.error("Failed to upload files", e);
+            if (isFolderWatchUpload) {
+                refreshGallery = false;
+                try {
+                    if (watcher.isUploadRunning())
+                        await watcher.allFileUploadsDone(
+                            uploadItemsWithCollection,
+                        );
+                } finally {
+                    watcher.rescanAfterFailedUpload();
+                }
+            }
             closeUploadProgress();
             notifyUser(e);
         } finally {
-            postUploadAction();
+            postUploadAction(refreshGallery);
         }
     };
 

--- a/web/apps/photos/src/components/gallery/reducer.ts
+++ b/web/apps/photos/src/components/gallery/reducer.ts
@@ -135,6 +135,15 @@ type GalleryAction =
     | { type: "setUserDetails"; userDetails: UserDetails }
     | { type: "setCollections"; collections: Collection[] }
     | { type: "setCollectionFiles"; collectionFiles: EnteFile[] }
+    | {
+          type: "mergeCollectionFileChange";
+          collectionID: number;
+          updatedFiles: EnteFile[];
+          deletedFileIDs: number[];
+          collectionDeleted?: boolean;
+      }
+    | { type: "appendCollectionFiles"; collectionFiles: EnteFile[] }
+    | { type: "finishCollectionFileHydration" }
     | { type: "uploadFile"; file: EnteFile }
     | { type: "setTrashItems"; trashItems: TrashItem[] }
     | { type: "setPeopleState"; peopleState: PeopleState | undefined }
@@ -206,6 +215,9 @@ const initialGalleryState: GalleryState = {
     isInSearchMode: false,
     searchSortAsc: undefined,
 };
+
+const fileKey = (file: Pick<EnteFile, "collectionID" | "id">) =>
+    `${file.collectionID}:${file.id}`;
 
 const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
     state,
@@ -453,6 +465,72 @@ const galleryReducer: React.Reducer<GalleryState, GalleryAction> = (
                 ...stateForUpdatedCollectionFiles(state, collectionFiles),
                 lastSyncedCollectionFiles,
                 unsyncedPrivateMagicMetadataUpdates: new Map(),
+            });
+        }
+
+        case "mergeCollectionFileChange": {
+            const deletedFileIDs = new Set(action.deletedFileIDs);
+            const filesByID = new Map(
+                state.collectionFiles
+                    .filter(
+                        (file) =>
+                            !(
+                                file.collectionID == action.collectionID &&
+                                deletedFileIDs.has(file.id)
+                            ) &&
+                            (!action.collectionDeleted ||
+                                file.collectionID != action.collectionID),
+                    )
+                    .map((file) => [fileKey(file), file]),
+            );
+            for (const file of action.updatedFiles)
+                filesByID.set(fileKey(file), file);
+
+            const lastSyncedCollectionFiles = sortFiles([
+                ...filesByID.values(),
+            ]);
+            const collectionFiles = deriveCollectionFiles(
+                lastSyncedCollectionFiles,
+                state.unsyncedPrivateMagicMetadataUpdates,
+            );
+            return stateByUpdatingFilteredFiles({
+                ...stateForUpdatedCollectionFiles(state, collectionFiles),
+                lastSyncedCollectionFiles,
+                unsyncedPrivateMagicMetadataUpdates: new Map(),
+            });
+        }
+
+        case "appendCollectionFiles": {
+            const filesByID = new Map(
+                state.collectionFiles.map((file) => [fileKey(file), file]),
+            );
+            for (const file of action.collectionFiles) {
+                if (!filesByID.has(fileKey(file)))
+                    filesByID.set(fileKey(file), file);
+            }
+            const collectionFiles = [...filesByID.values()];
+
+            // Defer derived indexes until all persisted chunks are loaded. Rebuilding
+            // them per chunk briefly retains several full-library copies.
+            return {
+                ...state,
+                collectionFiles,
+                lastSyncedCollectionFiles: collectionFiles,
+            };
+        }
+
+        case "finishCollectionFileHydration": {
+            const lastSyncedCollectionFiles = sortFiles(
+                state.lastSyncedCollectionFiles,
+            );
+            const collectionFiles = deriveCollectionFiles(
+                lastSyncedCollectionFiles,
+                state.unsyncedPrivateMagicMetadataUpdates,
+            );
+
+            return stateByUpdatingFilteredFiles({
+                ...stateForUpdatedCollectionFiles(state, collectionFiles),
+                lastSyncedCollectionFiles,
             });
         }
 

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -149,7 +149,8 @@ import {
     resolveQuickLinkURL,
 } from "ente-gallery/utils/quick-link";
 import {
-    savedCollectionFiles,
+    hasCompletedV2RemoteFileSync,
+    savedCollectionFileChunks,
     savedCollections,
     savedTrashItems,
 } from "ente-new/photos/services/photos-fdb";
@@ -189,6 +190,76 @@ const Page: React.FC = () => {
 
     const isOffline = useIsOffline();
     const [state, dispatch] = useGalleryReducer();
+    const localFileChunksRef = useRef<AsyncGenerator<EnteFile[]> | undefined>(
+        undefined,
+    );
+    const localFileLoadInProgressRef = useRef(false);
+    const localFileHydrationCancelledRef = useRef(false);
+    const localFileHydrationRunRef = useRef(0);
+    const localFileHydrationPromiseRef = useRef<Promise<boolean> | undefined>(
+        undefined,
+    );
+    const isInitialGalleryLoadRef = useRef(false);
+
+    const loadMoreLocalFiles = useCallback(
+        async (
+            showProgress: boolean,
+            finish: boolean,
+            isCurrent: () => boolean,
+        ) => {
+            const chunks = localFileChunksRef.current;
+            if (!chunks || localFileLoadInProgressRef.current) return;
+
+            localFileLoadInProgressRef.current = true;
+            const ownsLoadingBar =
+                showProgress && !isInitialGalleryLoadRef.current;
+            if (ownsLoadingBar) showLoadingBar();
+            try {
+                const files: EnteFile[] = [];
+                let reachedEnd = false;
+                while (files.length < 16_384) {
+                    const result = await chunks.next();
+                    if (!isCurrent()) return;
+                    if (result.done) {
+                        localFileChunksRef.current = undefined;
+                        reachedEnd = true;
+                        break;
+                    }
+                    files.push(...result.value);
+                }
+                if (!isCurrent()) return;
+                if (files.length > 0) {
+                    dispatch({
+                        type: "appendCollectionFiles",
+                        collectionFiles: files,
+                    });
+                }
+                if (finish || reachedEnd)
+                    dispatch({ type: "finishCollectionFileHydration" });
+            } finally {
+                localFileLoadInProgressRef.current = false;
+                if (ownsLoadingBar) hideLoadingBar();
+            }
+        },
+        [hideLoadingBar, showLoadingBar],
+    );
+
+    const hydrateRemainingLocalFiles = useCallback(
+        async (run: number) => {
+            const isCancelled = () =>
+                localFileHydrationCancelledRef.current ||
+                localFileHydrationRunRef.current != run;
+            const hasChunks = () => localFileChunksRef.current !== undefined;
+            const isCurrent = () => !isCancelled();
+
+            while (isCurrent() && hasChunks()) {
+                await new Promise<void>((resolve) => setTimeout(resolve, 50));
+                if (!isCurrent() || !hasChunks()) return;
+                await loadMoreLocalFiles(false, false, isCurrent);
+            }
+        },
+        [loadMoreLocalFiles],
+    );
 
     const [isFirstLoad, setIsFirstLoad] = useState(false);
     const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
@@ -446,6 +517,7 @@ const Page: React.FC = () => {
         tempDeletedFileIDs,
         tempHiddenFileIDs,
     ]);
+
     const mapFileSource = useMemo(
         () => ({
             collectionFiles: state.collectionFiles,
@@ -485,11 +557,17 @@ const Page: React.FC = () => {
 
     useEffect(() => {
         const electron = globalThis.electron;
+        const hydrationRun = ++localFileHydrationRunRef.current;
+        const isCurrent = () =>
+            localFileHydrationRunRef.current == hydrationRun &&
+            !localFileHydrationCancelledRef.current;
         let syncIntervalID: ReturnType<typeof setInterval> | undefined;
         let unsubscribeMainWindowFocus: (() => void) | undefined;
 
         void (async () => {
+            localFileHydrationCancelledRef.current = false;
             const authToken = await savedAuthToken();
+            if (!isCurrent()) return;
             if (!haveMasterKeyInSession() || !authToken) {
                 stashRedirect("/gallery");
                 void router.push("/");
@@ -512,6 +590,7 @@ const Page: React.FC = () => {
                 }
                 return;
             }
+            if (!isCurrent()) return;
 
             preloadImage("/images/subscription-card-background");
             initSettings();
@@ -534,34 +613,71 @@ const Page: React.FC = () => {
                 );
             });
             const userDetails = await savedUserDetailsOrTriggerPull();
+            const [collections, trashItems] = await Promise.all([
+                savedCollections(),
+                savedTrashItems(),
+            ]);
+            if (!isCurrent()) return;
             dispatch({
                 type: "mount",
                 user,
                 familyData: userDetails?.familyData,
-                collections: await savedCollections(),
-                collectionFiles: await savedCollectionFiles(),
-                trashItems: await savedTrashItems(),
+                collections,
+                collectionFiles: [],
+                trashItems,
             });
 
-            // Join first so the initial pull includes the new album.
+            isInitialGalleryLoadRef.current = true;
+            showLoadingBar();
             let joinedAlbumId: number | null = null;
-
-            if (hasPendingAlbumToJoin()) {
-                try {
-                    const joinedCollectionId = await processPendingAlbumJoin();
-                    if (joinedCollectionId) {
-                        joinedAlbumId = joinedCollectionId;
+            try {
+                // Join first so the initial pull includes the new album.
+                if (hasPendingAlbumToJoin()) {
+                    try {
+                        const joinedCollectionId =
+                            await processPendingAlbumJoin();
+                        if (joinedCollectionId) {
+                            joinedAlbumId = joinedCollectionId;
+                        }
+                    } catch (error) {
+                        log.error("Failed to join album", error);
+                        showMiniDialog({
+                            title: t("error"),
+                            message:
+                                t("album_join_failed") +
+                                ": " +
+                                (error as Error).message,
+                        });
                     }
-                } catch (error) {
-                    log.error("Failed to join album", error);
-                    showMiniDialog({
-                        title: t("error"),
-                        message: t("album_join_failed"),
-                    });
                 }
-            }
 
-            await remotePull({ source: "gallery-mount" });
+                // Reconcile storage before taking the lazy gallery snapshot.
+                try {
+                    const completeLocalStorage =
+                        await hasCompletedV2RemoteFileSync();
+                    if (!isCurrent()) return;
+                    await remotePull({
+                        source: "gallery-mount",
+                        strict: !completeLocalStorage,
+                    });
+                } catch (error) {
+                    if (isCurrent()) {
+                        setIsFirstLoad(false);
+                        onGenericError(error);
+                    }
+                    return;
+                }
+                if (!isCurrent()) return;
+
+                // Load only the first bounded batch. Remaining files hydrate in
+                // the background through the same generator.
+                localFileChunksRef.current = savedCollectionFileChunks();
+                await loadMoreLocalFiles(true, true, isCurrent);
+            } finally {
+                isInitialGalleryLoadRef.current = false;
+                hideLoadingBar();
+            }
+            if (!isCurrent()) return;
 
             if (joinedAlbumId) {
                 dispatch({
@@ -571,6 +687,22 @@ const Page: React.FC = () => {
             }
 
             setIsFirstLoad(false);
+            const hydration = hydrateRemainingLocalFiles(hydrationRun)
+                .then(() => true)
+                .catch((error: unknown) => {
+                    if (!isCurrent()) return false;
+                    log.error(
+                        "Failed to hydrate remaining gallery files",
+                        error,
+                    );
+                    localFileChunksRef.current = undefined;
+                    return false;
+                });
+            localFileHydrationPromiseRef.current = hydration;
+            void hydration.then(() => {
+                if (localFileHydrationPromiseRef.current == hydration)
+                    localFileHydrationPromiseRef.current = undefined;
+            });
 
             syncIntervalID = setInterval(
                 () => remotePull({ silent: true, source: "gallery-periodic" }),
@@ -589,8 +721,14 @@ const Page: React.FC = () => {
         return () => {
             clearInterval(syncIntervalID);
             unsubscribeMainWindowFocus?.();
+            localFileHydrationCancelledRef.current = true;
+            localFileHydrationRunRef.current++;
+            localFileHydrationPromiseRef.current = undefined;
+            const chunks = localFileChunksRef.current;
+            if (chunks) void chunks.return(undefined);
+            localFileChunksRef.current = undefined;
         };
-    }, []);
+    }, [hydrateRemainingLocalFiles, loadMoreLocalFiles]);
 
     useEffect(() => {
         if (state.user && userDetails) {
@@ -797,11 +935,20 @@ const Page: React.FC = () => {
         setPendingFileNavigation(undefined);
     }, []);
 
-    // Use this for collection/file/trash-only effects; a full pull costs more.
+    // Use incremental sync for automatic collection/file/trash-only effects.
     const remoteFilesPull = useCallback(
-        () =>
-            remoteFilesPullQueue.current.add(() =>
-                pullFiles({
+        (
+            collectionFileSyncMode:
+                | "full"
+                | "incremental"
+                | "bootstrap" = "full",
+        ) =>
+            remoteFilesPullQueue.current.add(async () => {
+                const hydration = localFileHydrationPromiseRef.current;
+                if (hydration) await hydration;
+
+                return pullFiles({
+                    collectionFileSyncMode,
                     onSetCollections: (collections) =>
                         dispatch({ type: "setCollections", collections }),
                     onSetCollectionFiles: (collectionFiles) =>
@@ -809,12 +956,17 @@ const Page: React.FC = () => {
                             type: "setCollectionFiles",
                             collectionFiles,
                         }),
+                    onCollectionFileChange: (change) =>
+                        dispatch({
+                            type: "mergeCollectionFileChange",
+                            ...change,
+                        }),
                     onSetTrashedItems: (trashItems) =>
                         dispatch({ type: "setTrashItems", trashItems }),
                     onDidUpdateCollectionFiles: () =>
                         exportService.onLocalFilesUpdated(),
-                }),
-            ),
+                });
+            }),
         [],
     );
 
@@ -844,9 +996,21 @@ const Page: React.FC = () => {
                 }
 
                 try {
-                    if (!silent) showLoadingBar();
+                    const ownsLoadingBar =
+                        !silent && !isInitialGalleryLoadRef.current;
+                    if (ownsLoadingBar) showLoadingBar();
                     await prePullFiles();
-                    await remoteFilesPull();
+                    const collectionFileSyncMode =
+                        source == "gallery-mount"
+                            ? "bootstrap"
+                            : [
+                                    "gallery-periodic",
+                                    "desktop-focus",
+                                    "watcher-upload",
+                                ].includes(source ?? "")
+                              ? "incremental"
+                              : "full";
+                    await remoteFilesPull(collectionFileSyncMode);
                     await postPullFiles(source);
                 } catch (e) {
                     // A later pull retries transient failures after remote mutations.
@@ -854,7 +1018,8 @@ const Page: React.FC = () => {
                     if (strict) throw e;
                 } finally {
                     dispatch({ type: "clearUnsyncedState" });
-                    if (!silent) hideLoadingBar();
+                    if (!silent && !isInitialGalleryLoadRef.current)
+                        hideLoadingBar();
                 }
             }),
         [

--- a/web/apps/photos/src/services/pull.ts
+++ b/web/apps/photos/src/services/pull.ts
@@ -8,8 +8,10 @@ import type { Collection } from "ente-media/collection";
 import type { EnteFile } from "ente-media/file";
 import {
     movePendingRemovalActionsToUncategorized,
+    pullCollectionFileDiffs,
     pullCollectionFiles,
     pullCollections,
+    type CollectionFileChange,
 } from "ente-new/photos/services/collection";
 import {
     isMLSupported,
@@ -25,9 +27,13 @@ export const prePullFiles = async () => {
     await Promise.all([pullSettings(), isMLSupported && pullMLStatus()]);
 };
 
+type CollectionFileSyncMode = "full" | "incremental" | "bootstrap";
+
 interface PullFilesOpts {
+    collectionFileSyncMode?: CollectionFileSyncMode;
     onSetCollections: (collections: Collection[]) => void;
     onSetCollectionFiles: (collectionFiles: EnteFile[]) => void;
+    onCollectionFileChange?: (change: CollectionFileChange) => void;
     onSetTrashedItems: (trashItems: TrashItem[]) => void;
     onDidUpdateCollectionFiles: () => void;
 }
@@ -37,10 +43,15 @@ export const pullFiles = async (opts?: PullFilesOpts) => {
     await ensureAuthenticatedSession();
     const collections = await pullCollections();
     opts?.onSetCollections(collections);
-    const didUpdateFiles = await pullCollectionFiles(
-        collections,
-        opts?.onSetCollectionFiles,
-    );
+    const syncMode = opts?.collectionFileSyncMode ?? "full";
+    const didUpdateFiles =
+        syncMode == "full"
+            ? await pullCollectionFiles(collections, opts?.onSetCollectionFiles)
+            : await pullCollectionFileDiffs(
+                  collections,
+                  opts?.onCollectionFileChange,
+                  syncMode,
+              );
     await pullTrash(
         collections,
         opts?.onSetTrashedItems,
@@ -66,7 +77,22 @@ export const pullFiles = async (opts?: PullFilesOpts) => {
 };
 
 export const postPullFiles = async (source?: string) => {
-    await Promise.all([searchDataSync(), videoProcessingSyncIfNeeded()]);
-    // Initial indexing can be long; do not block the remote pull.
-    void mlSync(source ? `remote-pull:${source}` : "remote-pull");
+    await Promise.all([
+        searchDataSync(),
+        source == "watcher-upload" ||
+        source == "gallery-mount" ||
+        source == "gallery-periodic" ||
+        source == "desktop-focus"
+            ? undefined
+            : videoProcessingSyncIfNeeded(),
+    ]);
+    // ML sync might take a very long time for initial indexing, so don't wait
+    // for it to finish. Automatic pulls should not start full-library ML work;
+    // explicit, upload, and watcher-completion pulls will catch up when needed.
+    if (
+        source != "gallery-mount" &&
+        source != "gallery-periodic" &&
+        source != "desktop-focus"
+    )
+        void mlSync(source ? `remote-pull:${source}` : "remote-pull");
 };

--- a/web/apps/photos/src/services/upload-manager.ts
+++ b/web/apps/photos/src/services/upload-manager.ts
@@ -91,6 +91,7 @@ export interface UploadBatchResult {
 interface UploadItemsOptions {
     skipDuplicateAddToUploadCollection?: boolean;
     includePartnerSharedFiles?: boolean;
+    onChunkResult?: (batchResult: UploadBatchResult) => Promise<void>;
 }
 
 export const successfulFilesFromUploadBatchResult = (
@@ -154,6 +155,9 @@ interface ProgressUpdater {
 }
 
 const maxConcurrentUploads = 4;
+
+/** Maximum files retained in one folder-watch upload chunk. */
+const folderWatchUploadChunkSize = 200;
 
 export type UploadItemWithCollection = UploadAsset & {
     localID: number;
@@ -406,7 +410,46 @@ class UploadManager {
                     mediaItems.length != clusteredMediaItems.length,
                 );
 
-                await this.uploadMediaItems(clusteredMediaItems, options);
+                this.uiService.reset(clusteredMediaItems.length);
+                await UploadService.setFileCount(clusteredMediaItems.length);
+                this.uiService.setUploadPhase("uploading");
+
+                // Bound per-item results retained during large folder-watch uploads.
+                const chunkSize =
+                    isDesktop && watcher.isUploadRunning()
+                        ? folderWatchUploadChunkSize
+                        : clusteredMediaItems.length;
+                for (
+                    let i = 0;
+                    i < clusteredMediaItems.length;
+                    i += chunkSize
+                ) {
+                    await this.uploadMediaItems(
+                        clusteredMediaItems.slice(i, i + chunkSize),
+                        options,
+                    );
+
+                    if (options?.onChunkResult) {
+                        const chunkResult = {
+                            processedAny: this.uiService.hasFilesInResultList(),
+                            itemResults: [...this.itemResults],
+                        };
+                        const partnerSharedCount =
+                            chunkResult.itemResults.filter(
+                                ({ result }) => result.type == "partnerShared",
+                            ).length;
+                        if (partnerSharedCount) {
+                            log.info(
+                                `Skipped ${partnerSharedCount} partner shared files`,
+                            );
+                        }
+                        try {
+                            await options.onChunkResult(chunkResult);
+                        } finally {
+                            this.itemResults = [];
+                        }
+                    }
+                }
             }
         } catch (e) {
             if (!isUploadCancelledError(e)) {
@@ -511,9 +554,6 @@ class UploadManager {
         options?: UploadItemsOptions,
     ) {
         this.itemsToBeUploaded = [...this.itemsToBeUploaded, ...mediaItems];
-        this.uiService.reset(mediaItems.length);
-        await UploadService.setFileCount(mediaItems.length);
-        this.uiService.setUploadPhase("uploading");
 
         const uploadProcesses = new Array<Promise<void>>();
         for (
@@ -521,6 +561,7 @@ class UploadManager {
             i < maxConcurrentUploads && this.itemsToBeUploaded.length > 0;
             i++
         ) {
+            this.comlinkCryptoWorkers[i]?.terminate();
             this.comlinkCryptoWorkers[i] = createComlinkCryptoWorker();
             const worker = await this.comlinkCryptoWorkers[i]!.remote;
             uploadProcesses.push(this.uploadNextItemInQueue(worker, options));

--- a/web/apps/photos/src/services/upload-manager.ts
+++ b/web/apps/photos/src/services/upload-manager.ts
@@ -92,6 +92,7 @@ export interface UploadBatchResult {
 interface UploadItemsOptions {
     skipDuplicateAddToUploadCollection?: boolean;
     includePartnerSharedFiles?: boolean;
+    onChunkResult?: (batchResult: UploadBatchResult) => Promise<void>;
 }
 
 export const successfulFilesFromUploadBatchResult = (
@@ -162,6 +163,9 @@ export interface ProgressUpdater {
 
 /** The number of uploads to process in parallel. */
 const maxConcurrentUploads = 4;
+
+/** Maximum files retained in one folder-watch upload chunk. */
+const folderWatchUploadChunkSize = 200;
 
 export type UploadItemWithCollection = UploadAsset & {
     localID: number;
@@ -451,7 +455,46 @@ class UploadManager {
                     mediaItems.length != clusteredMediaItems.length,
                 );
 
-                await this.uploadMediaItems(clusteredMediaItems, options);
+                this.uiService.reset(clusteredMediaItems.length);
+                await UploadService.setFileCount(clusteredMediaItems.length);
+                this.uiService.setUploadPhase("uploading");
+
+                // Bound per-item results retained during large folder-watch uploads.
+                const chunkSize =
+                    isDesktop && watcher.isUploadRunning()
+                        ? folderWatchUploadChunkSize
+                        : clusteredMediaItems.length;
+                for (
+                    let i = 0;
+                    i < clusteredMediaItems.length;
+                    i += chunkSize
+                ) {
+                    await this.uploadMediaItems(
+                        clusteredMediaItems.slice(i, i + chunkSize),
+                        options,
+                    );
+
+                    if (options?.onChunkResult) {
+                        const chunkResult = {
+                            processedAny: this.uiService.hasFilesInResultList(),
+                            itemResults: [...this.itemResults],
+                        };
+                        const partnerSharedCount =
+                            chunkResult.itemResults.filter(
+                                ({ result }) => result.type == "partnerShared",
+                            ).length;
+                        if (partnerSharedCount) {
+                            log.info(
+                                `Skipped ${partnerSharedCount} partner shared files`,
+                            );
+                        }
+                        try {
+                            await options.onChunkResult(chunkResult);
+                        } finally {
+                            this.itemResults = [];
+                        }
+                    }
+                }
             }
         } catch (e) {
             if (!isUploadCancelledError(e)) {
@@ -576,9 +619,6 @@ class UploadManager {
         options?: UploadItemsOptions,
     ) {
         this.itemsToBeUploaded = [...this.itemsToBeUploaded, ...mediaItems];
-        this.uiService.reset(mediaItems.length);
-        await UploadService.setFileCount(mediaItems.length);
-        this.uiService.setUploadPhase("uploading");
 
         const uploadProcesses = new Array<Promise<void>>();
         for (
@@ -586,6 +626,7 @@ class UploadManager {
             i < maxConcurrentUploads && this.itemsToBeUploaded.length > 0;
             i++
         ) {
+            this.comlinkCryptoWorkers[i]?.terminate();
             this.comlinkCryptoWorkers[i] = createComlinkCryptoWorker();
             const worker = await this.comlinkCryptoWorkers[i]!.remote;
             uploadProcesses.push(this.uploadNextItemInQueue(worker, options));

--- a/web/apps/photos/src/services/upload-manager.ts
+++ b/web/apps/photos/src/services/upload-manager.ts
@@ -29,10 +29,13 @@ import {
 import UploadService, {
     areLivePhotoAssets,
     isUploadCancelledError,
+    settleUploadWorkers,
+    shouldReloadExistingFilesForUpload,
     storageLimitExceededErrorMessage,
     upload,
     uploadCancelledErrorMessage,
     uploadItemFileName,
+    type ExistingFileFinder,
     type PotentialLivePhotoAsset,
     type UploadAsset,
 } from "ente-gallery/services/upload/upload-service";
@@ -41,13 +44,23 @@ import type { Collection } from "ente-media/collection";
 import type { EnteFile } from "ente-media/file";
 import {
     fileCreationTime,
+    fileFileName,
     fileLocation,
+    metadataHash,
+    type FileMetadata,
     type ParsedMetadata,
 } from "ente-media/file-metadata";
 import { FileType } from "ente-media/file-type";
 import { potentialFileTypeFromExtension } from "ente-media/live-photo";
-import { computeNormalCollectionFilesFromSaved } from "ente-new/photos/services/file";
+import {
+    savedHiddenCollections,
+    savedNormalCollections,
+} from "ente-new/photos/services/collection";
 import { indexNewUpload } from "ente-new/photos/services/ml";
+import {
+    savedCollectionFileByID,
+    savedCollectionFileChunksForCollections,
+} from "ente-new/photos/services/photos-fdb";
 import { settingsSnapshot } from "ente-new/photos/services/settings";
 import { wait } from "ente-utils/promise";
 import watcher from "./watch";
@@ -308,6 +321,20 @@ const groupByResult = (finishedUploads: FinishedUploads) => {
     return groups;
 };
 
+const existingMetadataKey = (metadata: FileMetadata) => {
+    const hash = metadataHash(metadata);
+    return hash
+        ? `${metadata.title}\u0000${metadata.fileType}\u0000${hash}`
+        : undefined;
+};
+
+const existingFileKey = (file: EnteFile) => {
+    const hash = metadataHash(file.metadata);
+    return hash
+        ? `${fileFileName(file)}\u0000${file.metadata.fileType}\u0000${hash}`
+        : undefined;
+};
+
 class UploadManager {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     private comlinkCryptoWorkers: ComlinkWorker<typeof CryptoWorker>[] =
@@ -316,6 +343,14 @@ class UploadManager {
     private itemsToBeUploaded: ClusteredUploadItem[] = [];
     private failedItems: ClusteredUploadItem[] = [];
     private existingFiles: EnteFile[] = [];
+    private existingFileFinder: ExistingFileFinder = (metadata) =>
+        Promise.resolve(
+            this.existingFiles.filter(
+                (file) =>
+                    existingFileKey(file) == existingMetadataKey(metadata),
+            ),
+        );
+    private existingFilesLoadedForWatcherSession: number | undefined;
     private itemResults: UploadBatchItemResult[] = [];
     private onUploadFile: ((file: EnteFile) => void) | undefined;
     private collections = new Map<number, Collection>();
@@ -522,9 +557,96 @@ class UploadManager {
     };
 
     private async updateExistingFilesAndCollections(collections: Collection[]) {
-        const files = await computeNormalCollectionFilesFromSaved();
-        const userID = ensureLocalUser().id;
-        this.existingFiles = files.filter((file) => file.ownerID == userID);
+        const watcherSessionID =
+            isDesktop && watcher.isUploadRunning()
+                ? watcher.uploadSessionID()
+                : undefined;
+        if (
+            shouldReloadExistingFilesForUpload(
+                watcherSessionID,
+                this.existingFilesLoadedForWatcherSession,
+            )
+        ) {
+            const userID = ensureLocalUser().id;
+            const hiddenCollections = await savedHiddenCollections(userID);
+            const hiddenFileIDs = new Set<number>();
+            for await (const chunk of savedCollectionFileChunksForCollections(
+                hiddenCollections.map((collection) => collection.id),
+            )) {
+                for (const file of chunk) hiddenFileIDs.add(file.id);
+            }
+
+            const referencesByKey = new Map<
+                string,
+                { id: number; collectionID: number }[]
+            >();
+            const normalCollections = await savedNormalCollections();
+            for await (const chunk of savedCollectionFileChunksForCollections(
+                normalCollections.map((collection) => collection.id),
+            )) {
+                for (const file of chunk) {
+                    if (file.ownerID != userID || hiddenFileIDs.has(file.id))
+                        continue;
+                    const key = existingFileKey(file);
+                    if (!key) continue;
+                    const references = referencesByKey.get(key) ?? [];
+                    references.push({
+                        id: file.id,
+                        collectionID: file.collectionID,
+                    });
+                    referencesByKey.set(key, references);
+                }
+            }
+            const resolvedFiles = new Map<
+                string,
+                Promise<EnteFile | undefined>
+            >();
+            // ponytail: retain at most 512 matched files; reload older matches
+            // from IndexedDB when needed instead of growing renderer heap.
+            const maxResolvedFiles = 512;
+            this.existingFiles = [];
+            this.existingFileFinder = async (metadata, collectionID) => {
+                const key = existingMetadataKey(metadata);
+                if (!key) return [];
+                const matches = this.existingFiles.filter(
+                    (file) => existingFileKey(file) == key,
+                );
+                const references = referencesByKey.get(key) ?? [];
+                const referencesToResolve = [
+                    ...references.filter(
+                        (reference) => reference.collectionID == collectionID,
+                    ),
+                    ...references.filter(
+                        (reference) => reference.collectionID != collectionID,
+                    ),
+                ].slice(0, 2);
+                const persistedMatches = await Promise.all(
+                    referencesToResolve.map((reference) => {
+                        const referenceKey = `${reference.collectionID}:${reference.id}`;
+                        let resolved = resolvedFiles.get(referenceKey);
+                        if (!resolved) {
+                            resolved = savedCollectionFileByID(
+                                reference.collectionID,
+                                reference.id,
+                            );
+                            resolvedFiles.set(referenceKey, resolved);
+                            if (resolvedFiles.size > maxResolvedFiles)
+                                resolvedFiles.delete(
+                                    resolvedFiles.keys().next().value!,
+                                );
+                        }
+                        return resolved;
+                    }),
+                );
+                return [
+                    ...matches,
+                    ...persistedMatches.filter(
+                        (file): file is EnteFile => !!file,
+                    ),
+                ];
+            };
+        }
+        this.existingFilesLoadedForWatcherSession = watcherSessionID;
         this.collections = new Map(
             collections.map((collection) => [collection.id, collection]),
         );
@@ -564,9 +686,22 @@ class UploadManager {
             this.comlinkCryptoWorkers[i]?.terminate();
             this.comlinkCryptoWorkers[i] = createComlinkCryptoWorker();
             const worker = await this.comlinkCryptoWorkers[i]!.remote;
-            uploadProcesses.push(this.uploadNextItemInQueue(worker, options));
+            uploadProcesses.push(
+                this.uploadNextItemInQueue(worker, options).catch(
+                    (error: unknown) => {
+                        if (!this.fatalUploadError) {
+                            this.fatalUploadError =
+                                error instanceof Error
+                                    ? error
+                                    : new Error(String(error));
+                        }
+                        this.itemsToBeUploaded = [];
+                        throw error;
+                    },
+                ),
+            );
         }
-        await Promise.all(uploadProcesses);
+        await settleUploadWorkers(uploadProcesses);
     }
 
     private async uploadNextItemInQueue(
@@ -584,6 +719,8 @@ class UploadManager {
             skipDuplicateAddToUploadCollection:
                 options?.skipDuplicateAddToUploadCollection,
             includePartnerSharedFiles: options?.includePartnerSharedFiles,
+            skipMultipartChecksums: isDesktop && watcher.isUploadRunning(),
+            stopOnUploadError: isDesktop && watcher.isUploadRunning(),
             abortIfCancelled: this.abortIfCancelled.bind(this),
             updateUploadProgress:
                 uiService.updateUploadProgress.bind(uiService),
@@ -606,7 +743,7 @@ class UploadManager {
                 uploadResult = await upload(
                     uploadableItem,
                     undefined,
-                    this.existingFiles,
+                    this.existingFileFinder,
                     this.parsedMetadataJSONMap,
                     worker,
                     uploadContext,
@@ -671,8 +808,12 @@ class UploadManager {
                     {
                         const { file } = uploadResult;
 
-                        indexNewUpload(file, processableUploadItem);
-                        processVideoNewUpload(file, processableUploadItem);
+                        // Defer live ML indexing during folder-watch uploads;
+                        // each completion can trigger a full cluster refresh.
+                        if (!watcher.isUploadRunning()) {
+                            indexNewUpload(file, processableUploadItem);
+                            processVideoNewUpload(file, processableUploadItem);
+                        }
 
                         this.updateExistingFiles(file);
                     }

--- a/web/apps/photos/src/services/watch.ts
+++ b/web/apps/photos/src/services/watch.ts
@@ -1,3 +1,8 @@
+/**
+ * @file Interface with the Node.js layer of our desktop app to provide the
+ * watch folders functionality.
+ */
+
 import debounce from "debounce";
 import { ensureElectron } from "ente-base/electron";
 import { basename, dirname, lowercaseExtension } from "ente-base/file-name";
@@ -13,35 +18,93 @@ import { groupFilesByCollectionID } from "ente-gallery/utils/file";
 import type { EnteFile } from "ente-media/file";
 import { removeFromOwnCollection } from "ente-new/photos/services/collection";
 import { computeAllCollectionFilesFromSaved } from "ente-new/photos/services/file";
+import { setMLClusterUpdatesDeferred } from "ente-new/photos/services/ml";
 import { ensureString } from "ente-utils/ensure";
 import { type UploadItemWithCollection, uploadManager } from "./upload-manager";
 
+/**
+ * Watch for file system folders and automatically update the corresponding Ente
+ * collections.
+ *
+ * This class relies on APIs exposed over the Electron IPC layer, and thus only
+ * works when we're running inside our desktop app.
+ */
 class FolderWatcher {
+    /** Pending file system events that we need to process. */
     private eventQueue: WatchEvent[] = [];
+    /** The folder watch whose event we're currently processing */
     private activeWatch: FolderWatch | undefined;
-    // A root deletion can be followed by stale child events.
+    /**
+     * If the file system directory corresponding to the (root) folder path of a
+     * folder watch is deleted on disk, we note down that in this queue so that
+     * we can ignore any file system events that come for it next.
+     */
     private deletedFolderPaths: string[] = [];
+    /**
+     * A set of folder paths that were inaccessible in the last accessibility
+     * check. Used to detect when a folder transitions from inaccessible to
+     * accessible (e.g., when an external drive is reconnected).
+     */
     private previouslyInaccessiblePaths = new Set<string>();
+    /** `true` if we are using the uploader. */
     private uploadRunning = false;
+    /** Identifies one queued watcher drain across its individual batches. */
+    private uploadSession = 0;
+    /** `true` if we are temporarily paused to let a user upload go through. */
     private isPaused = false;
+    /** `true` if completed watcher work needs one gallery refresh. */
+    private remotePullPending = false;
+    /** `true` while the completion pull keeps ML work deferred. */
+    private remotePullInProgress = false;
+    /**
+     * A map from file paths to the (fileID, collectionID) of the file that was
+     * uploaded (or symlinked) as part of the most recent upload attempt.
+     */
     private uploadedFileForPath = new Map<string, EnteFile>();
+    /**
+     * A set of file paths that could not be uploaded in the most recent upload
+     * attempt. These are the uploads that failed due to a permanent error that
+     * a retry will not fix.
+     */
     private unUploadableFilePaths = new Set<string>();
+    private retryableFilePaths = new Set<string>();
 
+    /**
+     * A function to call when we want to enqueue a new upload of the given list
+     * of file paths to the given Ente collection.
+     *
+     * This is passed as a param to {@link init}.
+     */
     private upload:
         | ((collectionName: string, filePaths: string[]) => void)
         | undefined;
-    private onTriggerRemotePull: (() => void) | undefined;
+    /**
+     * A function to call when we want to trigger a full remote pull.
+     *
+     * This is passed as a param to {@link init}.
+     */
+    private onTriggerRemotePull: (() => void | Promise<void>) | undefined;
 
+    /** A helper function that debounces invocations of {@link runNextEvent}. */
     private debouncedRunNextEvent: () => void;
 
     constructor() {
+        // TODO:
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         this.debouncedRunNextEvent = debounce(() => this.runNextEvent(), 1000);
     }
 
+    /**
+     * Initialize the watcher and start processing file system events.
+     *
+     * This is only called when we're running in the context of our desktop app.
+     *
+     * The caller provides us with the hooks we can use to actually upload the
+     * files, and to pull the latest changes from remote (say after deletion).
+     */
     init(
         upload: (collectionName: string, filePaths: string[]) => void,
-        onTriggerRemotePull: () => void,
+        onTriggerRemotePull: () => void | Promise<void>,
     ) {
         this.upload = upload;
         this.onTriggerRemotePull = onTriggerRemotePull;
@@ -50,6 +113,11 @@ class FolderWatcher {
         this.triggerSyncWithDisk();
     }
 
+    /**
+     * Initialize the accessibility tracking state by capturing which watches
+     * are currently inaccessible. This allows subsequent checkAccessibility
+     * calls to detect when a folder transitions from inaccessible to accessible.
+     */
     private initializeAccessibilityState() {
         void this.getWatches().then((watches) => {
             for (const watch of watches) {
@@ -65,33 +133,63 @@ class FolderWatcher {
         });
     }
 
+    /** Return `true` if we are currently using the uploader. */
     isUploadRunning() {
         return this.uploadRunning;
     }
 
+    /** Return the current queued watcher-drain identity. */
+    uploadSessionID() {
+        return this.uploadSession;
+    }
+
+    /** Return `true` if syncing has been temporarily paused. */
     isSyncPaused() {
         return this.isPaused;
     }
 
+    /**
+     * Temporarily pause syncing and cancel any running uploads.
+     *
+     * This frees up the uploader for handling user initiated uploads.
+     */
     pauseRunningSync() {
-        // User uploads share this uploader with folder watch.
         this.isPaused = true;
         uploadManager.cancelRunningUpload();
     }
 
+    /**
+     * Resume from a temporary pause, resyncing from disk.
+     *
+     * Sibling of {@link pauseRunningSync}.
+     */
     resumePausedSync() {
         this.isPaused = false;
         this.triggerSyncWithDisk();
     }
 
+    /** Requeue disk changes left behind by a failed upload batch. */
+    rescanAfterFailedUpload() {
+        this.triggerSyncWithDisk();
+    }
+
+    /** Return the list of folders we are watching for changes. */
     async getWatches(): Promise<FolderWatch[]> {
         return await ensureElectron().watch.get();
     }
 
+    /**
+     * Check accessibility of all watch folders and trigger sync if any
+     * previously inaccessible folder has become accessible.
+     *
+     * This is meant to be called when the app gains focus, allowing us to
+     * detect when an external drive has been reconnected.
+     */
     async checkAccessibility(): Promise<void> {
         try {
             const watches = await this.getWatches();
 
+            // Determine which folders are currently inaccessible.
             const currentlyInaccessiblePaths = new Set<string>();
             for (const watch of watches) {
                 if (watch.isAccessible === false) {
@@ -99,9 +197,12 @@ class FolderWatcher {
                 }
             }
 
+            // Check if any previously inaccessible folder is now accessible.
             const newlyAccessiblePaths: string[] = [];
             for (const path of this.previouslyInaccessiblePaths) {
                 if (!currentlyInaccessiblePaths.has(path)) {
+                    // This folder was inaccessible before but is no longer in
+                    // the inaccessible set. Check if the watch still exists.
                     const watchStillExists = watches.some(
                         (w) => w.folderPath === path,
                     );
@@ -111,29 +212,49 @@ class FolderWatcher {
                 }
             }
 
+            // Update our tracking of inaccessible paths for the next check.
             this.previouslyInaccessiblePaths = currentlyInaccessiblePaths;
 
+            // Only trigger sync if at least one folder became accessible.
             if (newlyAccessiblePaths.length > 0 && !this.isPaused) {
                 log.info(
                     `Folder watch: ${newlyAccessiblePaths.length} folder(s) became accessible (${newlyAccessiblePaths.join(", ")}), triggering sync`,
                 );
                 this.triggerSyncWithDisk();
             }
+            this.maybeTriggerRemotePull();
         } catch (e) {
             log.error("Error checking watch folder accessibility", e);
         }
     }
 
+    /**
+     * Return true if we are currently syncing files that belong to the given
+     * {@link folderPath}.
+     */
     isSyncingFolder(folderPath: string) {
         return this.activeWatch?.folderPath == folderPath;
     }
 
+    /**
+     * Add a new folder watch for the given root {@link folderPath}
+     *
+     * @param mapping The {@link CollectionMapping} to use to decide which
+     * collection do files belonging to nested directories go to.
+     *
+     * @returns The updated list of watches.
+     */
     async addWatch(folderPath: string, mapping: CollectionMapping) {
         const watches = await ensureElectron().watch.add(folderPath, mapping);
         this.triggerSyncWithDisk();
         return watches;
     }
 
+    /**
+     * Remove the folder watch for the given root {@link folderPath}.
+     *
+     * @returns The updated list of watches.
+     */
     async removeWatch(folderPath: string) {
         return await ensureElectron().watch.remove(folderPath);
     }
@@ -150,6 +271,10 @@ class FolderWatcher {
             const events = await deduceEvents(watches);
             log.info(`Folder watch deduced ${events.length} events`);
             this.eventQueue = this.eventQueue.concat(events);
+            if (events.length > 0) {
+                this.uploadSession++;
+                setMLClusterUpdatesDeferred(true);
+            }
 
             this.debouncedRunNextEvent();
         } catch (e) {
@@ -158,6 +283,9 @@ class FolderWatcher {
     }
 
     pushEvent(event: WatchEvent) {
+        if (this.eventQueue.length == 0 && !this.activeWatch)
+            this.uploadSession++;
+        setMLClusterUpdatesDeferred(true);
         this.eventQueue.push(event);
         log.info("Folder watch event", event);
         this.debouncedRunNextEvent();
@@ -166,7 +294,11 @@ class FolderWatcher {
     private registerListeners() {
         const watch = ensureElectron().watch;
 
-        // Renames arrive as add and remove events in either order.
+        // [Note: File renames during folder watch]
+        //
+        // Renames come as two file system events - an `onAddFile` + an
+        // `onRemoveFile` - in an arbitrary order.
+
         watch.onAddFile((path: string, watch: FolderWatch) => {
             this.pushEvent({
                 action: "upload",
@@ -190,14 +322,25 @@ class FolderWatcher {
                 log.info(
                     `Received file system delete event for a watched folder at ${path}`,
                 );
+                setMLClusterUpdatesDeferred(true);
+                this.remotePullPending = true;
                 this.deletedFolderPaths.push(path);
+                this.debouncedRunNextEvent();
             }
         });
     }
 
     private async runNextEvent() {
-        if (this.eventQueue.length == 0 || this.activeWatch || this.isPaused)
+        if (this.eventQueue.length == 0 || this.activeWatch || this.isPaused) {
+            if (
+                this.eventQueue.length == 0 &&
+                !this.activeWatch &&
+                !this.isPaused
+            )
+                this.deletedFolderPaths = [];
+            this.maybeTriggerRemotePull();
             return;
+        }
 
         const event = this.dequeueClubbedEvent();
         if (!event) return;
@@ -207,6 +350,7 @@ class FolderWatcher {
 
         const skip = (reason: string) => {
             log.info(`Ignoring event since ${reason}`);
+            this.maybeTriggerRemotePull();
             this.debouncedRunNextEvent();
         };
 
@@ -214,6 +358,7 @@ class FolderWatcher {
             (watch) => watch.folderPath == event.folderPath,
         );
         if (!watch) {
+            // Possibly stale
             skip(`no folder watch for found for ${event.folderPath}`);
             return;
         }
@@ -229,6 +374,9 @@ class FolderWatcher {
                 skip("none of the files need uploading");
                 return;
             }
+
+            // Here we pass control to the uploader. When the upload is done,
+            // the uploader will notify us by calling allFileUploadsDone.
 
             this.activeWatch = watch;
             this.uploadRunning = true;
@@ -257,7 +405,9 @@ class FolderWatcher {
             );
 
             this.activeWatch = watch;
-
+            // A partial batch may already have reached the server when a later
+            // collection deletion fails; reconcile regardless of the outcome.
+            this.remotePullPending = true;
             try {
                 await this.moveToTrash(removed);
             } catch (e) {
@@ -267,19 +417,31 @@ class FolderWatcher {
                 );
             }
 
-            // Always update syncedFiles to remove stale entries, even if
-            // trashing failed. Otherwise we'll keep retrying forever.
-            await ensureElectron().watch.updateSyncedFiles(
-                rest,
-                watch.folderPath,
-            );
-
-            this.activeWatch = undefined;
-
-            this.debouncedRunNextEvent();
+            try {
+                // Always update syncedFiles to remove stale entries, even if
+                // trashing failed. Otherwise we'll keep retrying forever.
+                await ensureElectron().watch.updateSyncedFiles(
+                    rest,
+                    watch.folderPath,
+                );
+            } catch (e) {
+                log.error(
+                    "Failed to persist folder watch sync state after trash",
+                    e,
+                );
+            } finally {
+                this.activeWatch = undefined;
+                this.maybeTriggerRemotePull();
+                this.debouncedRunNextEvent();
+            }
         }
     }
 
+    /**
+     * Batch the next run of events with the same action, collection and folder
+     * path into a single clubbed event that contains the list of all effected
+     * file paths from the individual events.
+     */
     private dequeueClubbedEvent(): ClubbedWatchEvent | undefined {
         const event = this.eventQueue.shift();
         if (!event) return undefined;
@@ -297,80 +459,96 @@ class FolderWatcher {
         return { ...event, filePaths };
     }
 
+    /**
+     * Callback invoked by the uploader whenever a item we requested to
+     * {@link upload} gets uploaded.
+     */
     onFileUpload(item: UploadItemWithCollection, uploadResult: UploadResult) {
-        // Watch uploads use absolute path strings despite UploadItem's wider type.
+        // Re the usage of ensureString: For desktop watch, the only possibility
+        // for a UploadItem is for it to be a string (the absolute path to a
+        // file on disk).
+        const paths = item.isLivePhoto
+            ? [
+                  ensureString(item.livePhotoAssets?.image),
+                  ensureString(item.livePhotoAssets?.video),
+              ]
+            : [ensureString(item.uploadItem)];
+
         switch (uploadResult.type) {
             case "alreadyUploaded":
             case "addedSymlink":
             case "uploaded":
             case "uploadedWithStaticThumbnail":
-                {
-                    if (item.isLivePhoto) {
-                        this.uploadedFileForPath.set(
-                            ensureString(item.livePhotoAssets?.image),
-                            uploadResult.file,
-                        );
-                        this.uploadedFileForPath.set(
-                            ensureString(item.livePhotoAssets?.video),
-                            uploadResult.file,
-                        );
-                    } else {
-                        this.uploadedFileForPath.set(
-                            ensureString(item.uploadItem),
-                            uploadResult.file,
-                        );
-                    }
-                }
+                for (const path of paths)
+                    this.uploadedFileForPath.set(path, uploadResult.file);
                 break;
             case "partnerShared":
             case "unsupported":
             case "tooLarge":
-                {
-                    if (item.isLivePhoto) {
-                        this.unUploadableFilePaths.add(
-                            ensureString(item.livePhotoAssets?.image),
-                        );
-                        this.unUploadableFilePaths.add(
-                            ensureString(item.livePhotoAssets?.video),
-                        );
-                    } else {
-                        this.unUploadableFilePaths.add(
-                            ensureString(item.uploadItem),
-                        );
-                    }
-                }
+                for (const path of paths) this.unUploadableFilePaths.add(path);
+                break;
+            case "failed":
+            case "blocked":
+                for (const path of paths) this.retryableFilePaths.add(path);
                 break;
         }
     }
 
+    /**
+     * Callback invoked by the uploader whenever all the files we requested to
+     * {@link upload} get uploaded.
+     */
     async allFileUploadsDone(uploadedItems: UploadAsset[]) {
-        const electron = ensureElectron();
-        const watch = this.activeWatch!;
+        const watch = this.activeWatch;
+        if (!watch) return;
 
+        const electron = ensureElectron();
+        const retryableFailure = this.retryableFilePaths.size > 0;
         log.debug(() => [
             "watch/allFileUploadsDone",
-            JSON.stringify({ uploadedItems, watch }),
+            {
+                uploadedItemCount: uploadedItems.length,
+                syncedFileCount: watch.syncedFiles.length,
+                ignoredFileCount: watch.ignoredFiles.length,
+                folderPath: watch.folderPath,
+            },
         ]);
 
         const { syncedFiles, ignoredFiles } =
             this.deduceSyncedAndIgnored(uploadedItems);
 
-        if (syncedFiles.length > 0)
-            await electron.watch.updateSyncedFiles(
-                watch.syncedFiles.concat(syncedFiles),
-                watch.folderPath,
-            );
+        let persistenceSucceeded = false;
+        try {
+            if (syncedFiles.length > 0)
+                await electron.watch.updateSyncedFiles(
+                    watch.syncedFiles.concat(syncedFiles),
+                    watch.folderPath,
+                );
+            for (const file of syncedFiles)
+                this.uploadedFileForPath.delete(file.path);
 
-        if (ignoredFiles.length > 0)
-            await electron.watch.updateIgnoredFiles(
-                watch.ignoredFiles.concat(ignoredFiles),
-                watch.folderPath,
-            );
+            if (ignoredFiles.length > 0)
+                await electron.watch.updateIgnoredFiles(
+                    watch.ignoredFiles.concat(ignoredFiles),
+                    watch.folderPath,
+                );
+            for (const path of ignoredFiles)
+                this.unUploadableFilePaths.delete(path);
+            persistenceSucceeded = true;
+        } finally {
+            this.retryableFilePaths.clear();
+            this.activeWatch = undefined;
+            this.uploadRunning = false;
 
-        this.activeWatch = undefined;
-        this.uploadRunning = false;
-
-        this.debouncedRunNextEvent();
+            // Refresh gallery once after queued watcher uploads drain. Refreshing
+            // after every small batch overlaps expensive cluster pulls with uploads.
+            if (persistenceSucceeded) {
+                this.remotePullPending = true;
+                this.maybeTriggerRemotePull();
+            }
+            this.debouncedRunNextEvent();
+            if (retryableFailure) this.rescanAfterFailedUpload();
+        }
     }
 
     private deduceSyncedAndIgnored(uploadedItems: UploadAsset[]) {
@@ -383,16 +561,17 @@ class FolderWatcher {
                 uploadedFileID: file.id,
                 collectionID: file.collectionID,
             });
-            this.uploadedFileForPath.delete(path);
         };
 
         const markIgnored = (path: string) => {
             log.debug(() => `Permanently ignoring file at ${path}`);
             ignoredFiles.push(path);
-            this.unUploadableFilePaths.delete(path);
         };
 
         for (const item of uploadedItems) {
+            // Re the usage of ensureString: For desktop watch, the only
+            // possibility for a UploadItem is for it to be a string (the
+            // absolute path to a file on disk).
             if (item.isLivePhoto) {
                 const imagePath = ensureString(item.livePhotoAssets?.image);
                 const videoPath = ensureString(item.livePhotoAssets?.video);
@@ -440,7 +619,8 @@ class FolderWatcher {
         for (const file of syncedFiles)
             syncedFileForID.set(file.uploadedFileID, file);
 
-        // Include hidden copies when removing files deleted from disk.
+        // Use all collection files (including hidden) so that files removed
+        // from the watch folder are also removed from hidden albums.
         const files = await computeAllCollectionFilesFromSaved();
         const filesToTrash = files.filter((file) => {
             const correspondingSyncedFile = syncedFileForID.get(file.id);
@@ -454,30 +634,95 @@ class FolderWatcher {
         for (const [id, files] of filesByCollectionID.entries()) {
             await removeFromOwnCollection(id, files);
         }
+    }
 
-        this.onTriggerRemotePull!();
+    private maybeTriggerRemotePull() {
+        if (
+            this.isPaused ||
+            this.activeWatch ||
+            this.eventQueue.length > 0 ||
+            this.deletedFolderPaths.length > 0 ||
+            this.remotePullInProgress
+        )
+            return;
+
+        if (!this.remotePullPending) {
+            setMLClusterUpdatesDeferred(false);
+            return;
+        }
+
+        this.remotePullPending = false;
+        this.remotePullInProgress = true;
+        void (async () => {
+            let completed = false;
+            try {
+                await this.onTriggerRemotePull!();
+                completed = true;
+            } catch (e) {
+                log.error("Failed to trigger watcher remote pull", e);
+                this.remotePullPending = true;
+            } finally {
+                this.remotePullInProgress = false;
+                if (completed) this.maybeTriggerRemotePull();
+                else setMLClusterUpdatesDeferred(false);
+            }
+        })();
     }
 }
 
+/** The singleton instance of {@link FolderWatcher}. */
 const watcher = new FolderWatcher();
 
 export default watcher;
 
+/**
+ * A file system watch event encapsulates a change that has occurred on disk
+ * that needs us to take some action within Ente to synchronize with the user's
+ * Ente collections.
+ *
+ * Events get added in two ways:
+ *
+ * - When the app starts, it reads the current state of files on disk and
+ *   compares that with its last known state to determine what all events it
+ *   missed. This is easier than it sounds as we have only two events: add and
+ *   remove.
+ *
+ * - When the app is running, it gets live notifications from our file system
+ *   watcher (from the Node.js layer) about changes that have happened on disk,
+ *   which the app then enqueues onto the event queue if they pertain to the
+ *   files we're interested in.
+ */
 interface WatchEvent {
+    /** The action to take */
     action: "upload" | "trash";
+    /** The path of the root folder corresponding to the {@link FolderWatch}. */
     folderPath: string;
+    /** The name of the Ente collection the file belongs to. */
     collectionName: string;
+    /** The absolute path to the file under consideration. */
     filePath: string;
 }
 
+/**
+ * A composite of multiple {@link WatchEvent}s that only differ in their
+ * {@link filePath}.
+ *
+ * When processing events, we combine a run of events with the same
+ * {@link action}, {@link folderPath} and {@link collectionName}. This allows us
+ * to process all the affected {@link filePaths} in one shot.
+ */
 type ClubbedWatchEvent = Omit<WatchEvent, "filePath"> & { filePaths: string[] };
 
+/**
+ * Determine which events we need to process to synchronize the watched on-disk
+ * folders to their corresponding collections.
+ */
 const deduceEvents = async (watches: FolderWatch[]): Promise<WatchEvent[]> => {
     const electron = ensureElectron();
     const events: WatchEvent[] = [];
 
     for (const watch of watches) {
-        // An ejected drive must not look like an empty folder.
+        // Skip inaccessible folders (e.g., ejected external drives).
         if (watch.isAccessible === false) {
             log.info(
                 `Skipping sync for inaccessible folder ${watch.folderPath}`,
@@ -489,6 +734,7 @@ const deduceEvents = async (watches: FolderWatch[]): Promise<WatchEvent[]> => {
 
         const filePaths = await electron.fs.findFiles(folderPath);
 
+        // Files that are on disk but not yet synced.
         for (const filePath of pathsToUpload(filePaths, watch))
             events.push({
                 action: "upload",
@@ -497,6 +743,7 @@ const deduceEvents = async (watches: FolderWatch[]): Promise<WatchEvent[]> => {
                 filePath,
             });
 
+        // Previously synced files that are no longer on disk.
         for (const filePath of pathsToRemove(filePaths, watch))
             events.push({
                 action: "trash",
@@ -509,12 +756,24 @@ const deduceEvents = async (watches: FolderWatch[]): Promise<WatchEvent[]> => {
     return events;
 };
 
-const pathsToUpload = (paths: string[], watch: FolderWatch) =>
+/**
+ * Filter out hidden files, non-media files, and previously synced or ignored
+ * paths from {@link paths} to get the list of paths that need to be uploaded
+ * to the Ente collection.
+ */
+export const pathsToUpload = (paths: string[], watch: FolderWatch) =>
     paths
+        // Filter out files whose names begins with a dot.
         .filter((path) => !basename(path).startsWith("."))
+        // Filter out known non-media files.
         .filter((path) => !shouldIgnoreForUpload(path))
+        // Files that are on disk but not yet synced or ignored.
         .filter((path) => !isSyncedOrIgnoredPath(path, watch));
 
+/**
+ * Return the paths to previously synced files that are no longer on disk and so
+ * must be removed from the Ente collection.
+ */
 const pathsToRemove = (paths: string[], watch: FolderWatch) =>
     watch.syncedFiles
         .map((f) => f.path)
@@ -531,6 +790,12 @@ const collectionNameForPath = (path: string, watch: FolderWatch) =>
 
 const parentDirectoryName = (path: string) => basename(dirname(path));
 
+/**
+ * Extensions of files that should not be uploaded from watch folders.
+ *
+ * These are common non-media file types that might be present in directories
+ * containing photos and videos, but are not themselves media files.
+ */
 const ignoredExtensions = new Set([
     "zip",
     "rar",
@@ -546,6 +811,10 @@ const ignoredExtensions = new Set([
     "sha256",
     "sha512",
     "sha",
+    "sqlite",
+    "sqlite-wal",
+    "sqlite-shm",
+    "sqlite-journal",
     "html",
     "htm",
     "xmp",
@@ -556,7 +825,14 @@ const ignoredExtensions = new Set([
     "cmap",
 ]);
 
-const shouldIgnoreForUpload = (path: string): boolean => {
+/**
+ * Return `true` if the file at the given path should be ignored for uploads.
+ *
+ * This is used to filter out known non-media files from watch folders before
+ * attempting to upload them. This prevents spurious "Skipped" messages and
+ * error logs for files that we know beforehand are not photos or videos.
+ */
+export const shouldIgnoreForUpload = (path: string): boolean => {
     const extension = lowercaseExtension(path);
     return extension !== undefined && ignoredExtensions.has(extension);
 };

--- a/web/apps/photos/tests/photos-fdb.test.ts
+++ b/web/apps/photos/tests/photos-fdb.test.ts
@@ -1,0 +1,425 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const store = vi.hoisted(() => {
+    const data = new Map<string, unknown>();
+    return {
+        data,
+        config: vi.fn(),
+        getItem: vi.fn((key: string) => Promise.resolve(data.get(key))),
+        setItem: vi.fn((key: string, value: unknown) => {
+            data.set(key, value);
+            return Promise.resolve(value);
+        }),
+        removeItem: vi.fn((key: string) => {
+            data.delete(key);
+            return Promise.resolve();
+        }),
+        keys: vi.fn(() => Promise.resolve([...data.keys()])),
+    };
+});
+
+vi.mock("localforage", () => ({ default: store }));
+
+import type { Collection } from "ente-media/collection";
+import type { EnteFile } from "ente-media/file";
+import {
+    hasCompletedV2RemoteFileSync,
+    mergeCollectionFilesForCollection,
+    prepareV2RemoteFileSync,
+    saveCollectionFiles,
+    saveCollectionFilesForCollection,
+    saveCollectionLastSyncTime,
+    savedCollectionFileChunks,
+    savedCollectionFiles,
+} from "ente-new/photos/services/photos-fdb";
+
+const file = (id: number, collectionID: number): EnteFile => ({
+    id,
+    collectionID,
+    ownerID: 1,
+    key: "key",
+    file: { decryptionHeader: "header" },
+    thumbnail: { decryptionHeader: "header" },
+    updationTime: 1,
+    metadata: {
+        fileType: 1,
+        modificationTime: 1,
+        title: "file",
+        creationTime: 1,
+    },
+});
+
+const resetStoreMocks = () => {
+    store.getItem.mockImplementation((key: string) =>
+        Promise.resolve(store.data.get(key)),
+    );
+    store.setItem.mockImplementation((key: string, value: unknown) => {
+        store.data.set(key, value);
+        return Promise.resolve(value);
+    });
+    store.removeItem.mockImplementation((key: string) => {
+        store.data.delete(key);
+        return Promise.resolve();
+    });
+    store.keys.mockImplementation(() =>
+        Promise.resolve([...store.data.keys()]),
+    );
+};
+
+describe("collection file persistence", () => {
+    beforeEach(() => {
+        store.data.clear();
+        vi.clearAllMocks();
+        resetStoreMocks();
+    });
+
+    test("bounds chunks yielded to gallery hydration", async () => {
+        const generation = "legacy";
+        store.data.set("files-v2:manifest", {
+            version: 2,
+            collections: { "10": { generation, chunkCount: 1 } },
+        });
+        store.data.set(
+            `files-v2:${generation}:collection:10:chunk:0`,
+            Array.from({ length: 513 }, (_, id) => file(id, 10)),
+        );
+
+        const chunks: EnteFile[][] = [];
+        for await (const chunk of savedCollectionFileChunks())
+            chunks.push(chunk);
+
+        expect(chunks.map((chunk) => chunk.length)).toEqual([512, 1]);
+    });
+
+    test("round trips collection files without a monolithic record", async () => {
+        const files = [file(1, 10), file(2, 20)];
+
+        await saveCollectionFiles(files);
+
+        expect(store.data.has("files")).toBe(false);
+        const manifest = store.data.get("files-v2:manifest") as {
+            version: number;
+            collections: Record<string, { chunkCount: number }>;
+        };
+        expect(manifest.version).toBe(2);
+        expect(manifest.collections["10"]?.chunkCount).toBe(1);
+        expect(manifest.collections["20"]?.chunkCount).toBe(1);
+        await expect(savedCollectionFiles()).resolves.toEqual(files);
+    });
+
+    test("does not retain loaded files across reads", async () => {
+        const files = [file(1, 10)];
+        await saveCollectionFiles(files);
+
+        const first = await savedCollectionFiles();
+        const second = await savedCollectionFiles();
+
+        expect(second).toEqual(first);
+        expect(second).not.toBe(first);
+
+        await saveCollectionFilesForCollection(10, [file(2, 10)]);
+        await expect(savedCollectionFiles()).resolves.toEqual([file(2, 10)]);
+    });
+
+    test("streams v2 chunks without assembling a second full array", async () => {
+        const files = [file(1, 10), file(2, 20)];
+        await saveCollectionFiles(files);
+
+        const chunks: EnteFile[][] = [];
+        for await (const chunk of savedCollectionFileChunks())
+            chunks.push(chunk);
+
+        expect(chunks.flat()).toEqual(files);
+        expect(chunks).toHaveLength(2);
+    });
+
+    test("repeats orphan cleanup after a successful sweep", async () => {
+        store.data.set("files-v2:manifest", { version: 2, collections: {} });
+        store.data.set("files-v2:g1:collection:10:chunk:0", [file(1, 10)]);
+
+        const firstRead = savedCollectionFileChunks();
+        await expect(firstRead.next()).resolves.toEqual({ done: true });
+        expect(store.data.has("files-v2:g1:collection:10:chunk:0")).toBe(false);
+
+        store.data.set("files-v2:g2:collection:20:chunk:0", [file(2, 20)]);
+        const secondRead = savedCollectionFileChunks();
+        await expect(secondRead.next()).resolves.toEqual({ done: true });
+        expect(store.data.has("files-v2:g2:collection:20:chunk:0")).toBe(false);
+    });
+
+    test("cleans legacy records before V2 repair", async () => {
+        store.data.set("files", [file(1, 10)]);
+        store.data.set("hidden-files", [file(2, 20)]);
+        store.data.set("10-time", 123);
+        store.data.set("files-v2:sync:v2:complete", true);
+
+        await prepareV2RemoteFileSync();
+
+        expect(store.data.has("files")).toBe(false);
+        expect(store.data.has("hidden-files")).toBe(false);
+        expect(store.data.has("10-time")).toBe(false);
+        expect(store.data.has("files-v2:sync:v2:complete")).toBe(false);
+        expect(store.data.has("files-v2:legacy-ignored")).toBe(true);
+    });
+
+    test("reads v2 chunks without requesting the monolithic files record", async () => {
+        store.data.set("files-v2:manifest", {
+            version: 2,
+            collections: { "10": { generation: "g1", chunkCount: 1 } },
+        });
+        store.data.set("files-v2:g1:collection:10:chunk:0", [file(1, 10)]);
+
+        await expect(savedCollectionFiles()).resolves.toEqual([file(1, 10)]);
+        expect(store.getItem).not.toHaveBeenCalledWith("files");
+    });
+
+    test("merges remote changes without loading full collection", async () => {
+        await saveCollectionFiles([file(1, 10), file(2, 10), file(3, 20)]);
+
+        const merged = await mergeCollectionFilesForCollection(
+            10,
+            [file(4, 10)],
+            [1],
+        );
+
+        expect(merged.updatedFiles).toEqual([file(4, 10)]);
+        expect(merged.deletedFileIDs).toEqual([1]);
+        await expect(savedCollectionFiles()).resolves.toEqual([
+            file(2, 10),
+            file(4, 10),
+            file(3, 20),
+        ]);
+    });
+
+    test("serializes collection replacement without deleting siblings", async () => {
+        await saveCollectionFiles([file(1, 10), file(2, 20)]);
+
+        await Promise.all([
+            saveCollectionFilesForCollection(10, [file(3, 10)]),
+            saveCollectionFilesForCollection(20, [file(4, 20)]),
+        ]);
+        await expect(savedCollectionFiles()).resolves.toEqual([
+            file(3, 10),
+            file(4, 20),
+        ]);
+
+        await saveCollectionFilesForCollection(10, []);
+        await expect(savedCollectionFiles()).resolves.toEqual([file(4, 20)]);
+    });
+
+    test("transforms only legacy entries within a chunk", async () => {
+        const legacy = {
+            ...file(1, 10),
+            metadata: { ...file(1, 10).metadata, modificationTime: undefined },
+        } as unknown as EnteFile;
+        const clean = file(2, 10);
+
+        await saveCollectionFiles([legacy, clean]);
+        const manifest = store.data.get("files-v2:manifest") as {
+            collections: Record<string, { generation: string }>;
+        };
+        const generation = manifest.collections["10"]!.generation;
+        const chunk = store.data.get(
+            `files-v2:${generation}:collection:10:chunk:0`,
+        ) as EnteFile[];
+
+        expect(chunk[0]).not.toBe(legacy);
+        expect(chunk[1]).toBe(clean);
+    });
+
+    test("ignores legacy files without loading the monolithic value", async () => {
+        store.data.set("files", [file(1, 10)]);
+        store.data.set("10-time", 123);
+
+        await expect(savedCollectionFiles()).resolves.toEqual([]);
+        expect(store.getItem).not.toHaveBeenCalledWith("files");
+        expect(store.data.has("files-v2:legacy-ignored")).toBe(true);
+        expect(store.data.has("10-time")).toBe(false);
+    });
+
+    test("retries legacy cleanup after a removal failure", async () => {
+        store.data.set("files", [file(1, 10)]);
+        store.data.set("10-time", 123);
+        let shouldFail = true;
+        store.removeItem.mockImplementation((key) => {
+            if (shouldFail && key == "10-time")
+                throw new Error("cleanup failed");
+            store.data.delete(key);
+            return Promise.resolve();
+        });
+
+        await expect(savedCollectionFiles()).rejects.toThrow("cleanup failed");
+        expect(store.data.has("files-v2:legacy-ignored")).toBe(false);
+
+        shouldFail = false;
+        await expect(savedCollectionFiles()).resolves.toEqual([]);
+        expect(store.data.has("files-v2:legacy-ignored")).toBe(true);
+        expect(store.data.has("10-time")).toBe(false);
+    });
+
+    test("resets sync times when a migrated manifest disappears", async () => {
+        store.data.set("files-v2:legacy-ignored", true);
+        store.data.set("files-v2:sync:v2:collection:10", 123);
+        store.data.set("files-v2:sync:v2:complete", true);
+        store.data.set("files-v2:remote-reconciled", true);
+
+        await expect(savedCollectionFiles()).resolves.toEqual([]);
+        expect(store.data.has("files-v2:legacy-ignored")).toBe(true);
+        expect(store.data.has("files-v2:sync:v2:collection:10")).toBe(false);
+        expect(store.data.has("files-v2:sync:v2:complete")).toBe(false);
+        expect(store.data.has("files-v2:remote-reconciled")).toBe(false);
+    });
+
+    test("ignores the hidden-files legacy key without loading it", async () => {
+        store.data.set("hidden-files", [file(1, 10)]);
+        store.data.set("hidden-collection-ids", [10]);
+        store.data.set("10-time", 123);
+
+        await expect(savedCollectionFiles()).resolves.toEqual([]);
+        expect(store.getItem).not.toHaveBeenCalledWith("hidden-files");
+        expect(store.data.has("files-v2:legacy-ignored")).toBe(true);
+        expect(store.data.has("hidden-collection-ids")).toBe(false);
+        expect(store.data.has("10-time")).toBe(false);
+    });
+
+    test("keeps the previous manifest when publishing a new one fails", async () => {
+        await saveCollectionFiles([file(1, 10)]);
+        const previousManifest = store.data.get("files-v2:manifest");
+        store.setItem.mockImplementation((key, value) => {
+            if (key == "files-v2:manifest") throw new Error("write failed");
+            store.data.set(key, value);
+            return Promise.resolve(value);
+        });
+
+        await expect(saveCollectionFiles([file(2, 10)])).rejects.toThrow(
+            "write failed",
+        );
+        expect(store.data.get("files-v2:manifest")).toEqual(previousManifest);
+        await expect(savedCollectionFiles()).resolves.toEqual([file(1, 10)]);
+    });
+
+    test("keeps the previous manifest when a chunk write fails", async () => {
+        await saveCollectionFiles([file(1, 10)]);
+        const previousManifest = store.data.get("files-v2:manifest");
+        store.setItem.mockImplementation((key, value) => {
+            if (key.startsWith("files-v2:") && key != "files-v2:manifest")
+                throw new Error("chunk write failed");
+            store.data.set(key, value);
+            return Promise.resolve(value);
+        });
+
+        await expect(saveCollectionFiles([file(2, 10)])).rejects.toThrow(
+            "chunk write failed",
+        );
+        expect(store.data.get("files-v2:manifest")).toEqual(previousManifest);
+        await expect(savedCollectionFiles()).resolves.toEqual([file(1, 10)]);
+    });
+
+    test("does not trust the previous V2 sync generation", async () => {
+        store.data.set("files-v2:sync:v1:complete", true);
+
+        await expect(hasCompletedV2RemoteFileSync()).resolves.toBe(false);
+    });
+
+    test("invalidates completion when the manifest is missing", async () => {
+        store.data.set("files-v2:sync:v2:complete", true);
+
+        await expect(hasCompletedV2RemoteFileSync()).resolves.toBe(false);
+        expect(store.data.has("files-v2:sync:v2:complete")).toBe(false);
+    });
+
+    test("invalidates completion when a declared chunk is missing", async () => {
+        store.data.set("files-v2:sync:v2:complete", true);
+        store.data.set("files-v2:manifest", {
+            version: 2,
+            collections: { "10": { generation: "g1", chunkCount: 1 } },
+        });
+
+        await expect(hasCompletedV2RemoteFileSync()).resolves.toBe(false);
+        expect(store.data.has("files-v2:sync:v2:complete")).toBe(false);
+    });
+
+    test("invalidates completion when a declared chunk is malformed", async () => {
+        store.data.set("files-v2:sync:v2:complete", true);
+        store.data.set("files-v2:manifest", {
+            version: 2,
+            collections: { "10": { generation: "g1", chunkCount: 1 } },
+        });
+        store.data.set("files-v2:g1:collection:10:chunk:0", { invalid: true });
+
+        await expect(hasCompletedV2RemoteFileSync()).resolves.toBe(false);
+        expect(store.data.has("files-v2:sync:v2:complete")).toBe(false);
+    });
+
+    test("accepts a complete empty V2 manifest", async () => {
+        store.data.set("files-v2:sync:v2:complete", true);
+        store.data.set("files-v2:manifest", { version: 2, collections: {} });
+
+        await expect(hasCompletedV2RemoteFileSync()).resolves.toBe(true);
+    });
+
+    test("uses V2-specific sync cursors", async () => {
+        await saveCollectionLastSyncTime({ id: 10 } as Collection, 123);
+
+        expect(store.data.get("files-v2:sync:v2:collection:10")).toBe(123);
+        expect(store.data.has("10-time")).toBe(false);
+    });
+
+    test("keeps old generation until active reader releases it", async () => {
+        await saveCollectionFiles([file(1, 10)]);
+        const oldManifest = store.data.get("files-v2:manifest") as {
+            collections: Record<string, { generation: string }>;
+        };
+        const oldGeneration = oldManifest.collections["10"]!.generation;
+        const oldChunk = `files-v2:${oldGeneration}:collection:10:chunk:0`;
+        let releaseChunk!: (value: EnteFile[]) => void;
+        const oldChunkRead = new Promise<EnteFile[]>((resolve) => {
+            releaseChunk = resolve;
+        });
+        let resolveChunkReadStarted!: () => void;
+        const chunkReadStarted = new Promise<void>((resolve) => {
+            resolveChunkReadStarted = resolve;
+        });
+        store.getItem.mockImplementation((key) => {
+            if (key == oldChunk) {
+                resolveChunkReadStarted();
+                return oldChunkRead;
+            }
+            return Promise.resolve(store.data.get(key));
+        });
+
+        const iterator = savedCollectionFileChunks();
+        const firstChunk = iterator.next();
+        await chunkReadStarted;
+
+        await saveCollectionFiles([file(2, 10)]);
+        expect(store.data.has(oldChunk)).toBe(true);
+
+        releaseChunk([file(1, 10)]);
+        await expect(firstChunk).resolves.toEqual({
+            done: false,
+            value: [file(1, 10)],
+        });
+        await iterator.return();
+        expect(store.data.has(oldChunk)).toBe(false);
+    });
+
+    test("removes old chunks only after publishing a replacement", async () => {
+        await saveCollectionFiles([file(1, 10)]);
+        const oldManifest = store.data.get("files-v2:manifest") as {
+            collections: Record<string, { generation: string }>;
+        };
+        const oldGeneration = oldManifest.collections["10"]!.generation;
+        const oldChunk = `files-v2:${oldGeneration}:collection:10:chunk:0`;
+
+        await saveCollectionFiles([file(2, 10)]);
+        const newManifest = store.data.get("files-v2:manifest") as {
+            collections: Record<string, { generation: string }>;
+        };
+        expect(newManifest.collections["10"]?.generation).not.toBe(
+            oldGeneration,
+        );
+        expect(store.data.has(oldChunk)).toBe(false);
+        await expect(savedCollectionFiles()).resolves.toEqual([file(2, 10)]);
+    });
+});

--- a/web/apps/photos/tests/pull.test.ts
+++ b/web/apps/photos/tests/pull.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test, vi } from "vitest";
+
+const {
+    searchDataSync,
+    videoProcessingSyncIfNeeded,
+    mlSync,
+    pullCollectionFileDiffs,
+    pullCollections,
+} = vi.hoisted(() => ({
+    searchDataSync: vi.fn(() => undefined),
+    videoProcessingSyncIfNeeded: vi.fn(() => undefined),
+    mlSync: vi.fn(),
+    pullCollectionFileDiffs: vi.fn(),
+    pullCollections: vi.fn(),
+}));
+
+vi.mock("ente-base/log", () => ({
+    default: { warn: vi.fn() },
+    logToDisk: vi.fn(),
+}));
+vi.mock("ente-gallery/components/viewer/data-source", () => ({
+    resetFileViewerDataSourceOnClose: vi.fn(),
+}));
+vi.mock("ente-gallery/services/video", () => ({
+    videoProcessingSyncIfNeeded,
+    videoPrunePermanentlyDeletedFileIDsIfNeeded: vi.fn(),
+}));
+vi.mock("ente-new/photos/services/collection", () => ({
+    movePendingRemovalActionsToUncategorized: vi.fn(),
+    pullCollectionFileDiffs,
+    pullCollectionFiles: vi.fn(),
+    pullCollections,
+}));
+vi.mock("ente-new/photos/services/ml", () => ({
+    isMLSupported: false,
+    mlSync,
+    pullMLStatus: vi.fn(),
+}));
+vi.mock("ente-new/photos/services/search", () => ({ searchDataSync }));
+vi.mock("ente-new/photos/services/settings", () => ({ pullSettings: vi.fn() }));
+vi.mock("ente-new/photos/services/trash", () => ({ pullTrash: vi.fn() }));
+vi.mock("../src/services/authenticated-session", () => ({
+    ensureAuthenticatedSession: vi.fn(),
+}));
+
+import { postPullFiles, pullFiles } from "../src/services/pull";
+
+describe("incremental remote file pull", () => {
+    test("syncs file diffs for automatic pulls", async () => {
+        const onCollectionFileChange = vi.fn();
+        const onDidUpdateCollectionFiles = vi.fn();
+        const collections = [{ id: 10 }] as never[];
+        pullCollections.mockResolvedValue(collections);
+        pullCollectionFileDiffs.mockResolvedValue(true);
+
+        await pullFiles({
+            onSetCollections: vi.fn(),
+            onSetCollectionFiles: vi.fn(),
+            onCollectionFileChange,
+            onSetTrashedItems: vi.fn(),
+            onDidUpdateCollectionFiles,
+            collectionFileSyncMode: "bootstrap",
+        });
+
+        expect(pullCollectionFileDiffs).toHaveBeenCalledWith(
+            collections,
+            onCollectionFileChange,
+            "bootstrap",
+        );
+        expect(onDidUpdateCollectionFiles).toHaveBeenCalledOnce();
+    });
+});
+
+describe("folder-watch remote pull", () => {
+    test("skips HLS backfill for watcher completion pulls", async () => {
+        await postPullFiles("watcher-upload");
+
+        expect(searchDataSync).toHaveBeenCalledOnce();
+        expect(videoProcessingSyncIfNeeded).not.toHaveBeenCalled();
+        expect(mlSync).toHaveBeenCalledWith("remote-pull:watcher-upload");
+    });
+
+    test("keeps HLS backfill for normal pulls", async () => {
+        await postPullFiles("post-upload");
+
+        expect(videoProcessingSyncIfNeeded).toHaveBeenCalledOnce();
+        expect(mlSync).toHaveBeenCalledWith("remote-pull:post-upload");
+    });
+
+    test.each(["gallery-mount", "gallery-periodic", "desktop-focus"])(
+        "skips automatic HLS backfill for %s",
+        async (source) => {
+            videoProcessingSyncIfNeeded.mockClear();
+            mlSync.mockClear();
+
+            await postPullFiles(source);
+
+            expect(videoProcessingSyncIfNeeded).not.toHaveBeenCalled();
+            expect(mlSync).not.toHaveBeenCalled();
+        },
+    );
+});

--- a/web/apps/photos/tests/upload.test.ts
+++ b/web/apps/photos/tests/upload.test.ts
@@ -1,3 +1,4 @@
+import { HTTPError } from "ente-base/http";
 import type { RawExifTags } from "ente-gallery/services/exif";
 import {
     parseDateFromDigitGroups,
@@ -10,6 +11,12 @@ import {
     parseXMPSidecarTags,
     tryParseXMPSidecar,
 } from "ente-gallery/services/upload/metadata-json";
+import {
+    settleUploadWorkers,
+    shouldAbortUploadOnError,
+    shouldReloadExistingFilesForUpload,
+    shouldSendMultipartPartChecksums,
+} from "ente-gallery/services/upload/upload-service";
 import { describe, expect, test } from "vitest";
 
 const dateCases = [
@@ -115,6 +122,67 @@ const xmpDescriptionTag = (description: string) => ({
     value: [xmpTag(description)],
     description,
     attributes: {},
+});
+
+describe("upload worker lifecycle", () => {
+    test("waits for sibling workers before propagating failure", async () => {
+        let resolveSibling!: () => void;
+        let siblingFinished = false;
+        const sibling = new Promise<void>((resolve) => {
+            resolveSibling = () => {
+                siblingFinished = true;
+                resolve();
+            };
+        });
+        const failure = new Error("upload failed");
+
+        let settled = false;
+        const result = settleUploadWorkers([Promise.reject(failure), sibling]);
+        void result.then(
+            () => (settled = true),
+            () => (settled = true),
+        );
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        resolveSibling();
+        await expect(result).rejects.toBe(failure);
+        expect(siblingFinished).toBe(true);
+    });
+});
+
+describe("folder-watch upload failure policy", () => {
+    test("fails fast only for HTTP errors during folder-watch uploads", () => {
+        const error = new HTTPError({
+            url: "https://example.test/file-upload",
+            status: 500,
+            statusText: "Internal Server Error",
+            headers: new Headers(),
+        } as Response);
+
+        expect(shouldAbortUploadOnError(error, true)).toBe(true);
+        expect(shouldAbortUploadOnError(error, false)).toBe(false);
+    });
+});
+
+describe("upload existing-file cache", () => {
+    test("reuses existing files across one watcher session", () => {
+        expect(shouldReloadExistingFilesForUpload(7, 7)).toBe(false);
+        expect(shouldReloadExistingFilesForUpload(7, 6)).toBe(true);
+        expect(shouldReloadExistingFilesForUpload(7, undefined)).toBe(true);
+        expect(shouldReloadExistingFilesForUpload(undefined, 7)).toBe(true);
+    });
+});
+
+describe("multipart upload memory policy", () => {
+    test("keeps checksums for normal uploads", () => {
+        expect(shouldSendMultipartPartChecksums(true, false)).toBe(true);
+        expect(shouldSendMultipartPartChecksums(false, true)).toBe(true);
+    });
+
+    test("skips checksum buffering for watcher uploads", () => {
+        expect(shouldSendMultipartPartChecksums(true, false, true)).toBe(false);
+    });
 });
 
 describe("upload filename metadata", () => {

--- a/web/apps/photos/tests/watch-lifecycle.test.ts
+++ b/web/apps/photos/tests/watch-lifecycle.test.ts
@@ -1,0 +1,271 @@
+import type { FolderWatch } from "ente-base/types/ipc";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    updateSyncedFiles: vi.fn(),
+    updateIgnoredFiles: vi.fn(),
+}));
+
+vi.mock("../src/services/upload-manager", () => ({
+    uploadManager: { cancelRunningUpload: vi.fn() },
+}));
+vi.mock("ente-new/photos/services/ml", () => ({
+    setMLClusterUpdatesDeferred: vi.fn(),
+}));
+vi.mock("ente-new/photos/services/collection", () => ({
+    removeFromOwnCollection: vi.fn(() => undefined),
+}));
+vi.mock("ente-new/photos/services/file", () => ({
+    computeAllCollectionFilesFromSaved: vi.fn(() => [
+        { id: 1, collectionID: 2 },
+    ]),
+}));
+
+const watch: FolderWatch = {
+    folderPath: "/watched",
+    collectionMapping: "parent",
+    isAccessible: true,
+    syncedFiles: [],
+    ignoredFiles: [],
+};
+
+const onRemoveDir = vi.fn();
+const electron = {
+    logToDisk: vi.fn(),
+    fs: { findFiles: vi.fn(() => []) },
+    watch: {
+        get: vi.fn(() => [watch]),
+        updateSyncedFiles: mocks.updateSyncedFiles,
+        updateIgnoredFiles: mocks.updateIgnoredFiles,
+        onAddFile: vi.fn(),
+        onRemoveFile: vi.fn(),
+        onRemoveDir,
+    },
+};
+
+vi.stubGlobal("electron", electron);
+
+const { default: watcher } = await import("../src/services/watch");
+
+afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    mocks.updateSyncedFiles.mockReset();
+    mocks.updateIgnoredFiles.mockReset();
+    onRemoveDir.mockReset();
+    watch.syncedFiles = [];
+    watch.ignoredFiles = [];
+});
+
+describe("folder watch lifecycle", () => {
+    test("retains upload bookkeeping when persistence fails", async () => {
+        vi.useFakeTimers();
+        mocks.updateSyncedFiles
+            .mockRejectedValueOnce(new Error("persist failed"))
+            .mockResolvedValue(undefined);
+
+        const upload = vi.fn();
+        const onPull = vi.fn();
+        watcher.init(upload, onPull);
+        await vi.advanceTimersByTimeAsync(0);
+        watcher.pushEvent({
+            action: "upload",
+            collectionName: "watched",
+            folderPath: watch.folderPath,
+            filePath: "/watched/photo.jpg",
+        });
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(upload).toHaveBeenCalledWith("watched", ["/watched/photo.jpg"]);
+
+        const file = { id: 1, collectionID: 2 };
+        const item = {
+            uploadItem: "/watched/photo.jpg",
+            pathPrefix: undefined,
+            localID: 1,
+            collectionID: 2,
+        };
+        watcher.onFileUpload(item, { type: "uploaded", file } as never);
+
+        await expect(watcher.allFileUploadsDone([item])).rejects.toThrow(
+            "persist failed",
+        );
+
+        if (watcher.isUploadRunning()) await watcher.allFileUploadsDone([item]);
+        expect(watcher.isUploadRunning()).toBe(false);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(upload).toHaveBeenCalledWith("watched", ["/watched/photo.jpg"]);
+        expect(mocks.updateSyncedFiles).toHaveBeenCalledOnce();
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+    });
+
+    test("clears active trash state when persistence fails", async () => {
+        vi.useFakeTimers();
+        mocks.updateSyncedFiles
+            .mockRejectedValueOnce(new Error("persist failed"))
+            .mockResolvedValue(undefined);
+
+        const upload = vi.fn();
+        watcher.init(upload, vi.fn());
+        await vi.advanceTimersByTimeAsync(0);
+        watch.syncedFiles = [
+            { path: "/watched/old.jpg", uploadedFileID: 1, collectionID: 2 },
+        ];
+        watcher.pushEvent({
+            action: "trash",
+            collectionName: "watched",
+            folderPath: watch.folderPath,
+            filePath: "/watched/old.jpg",
+        });
+        await vi.advanceTimersByTimeAsync(1000);
+
+        watcher.pushEvent({
+            action: "upload",
+            collectionName: "watched",
+            folderPath: watch.folderPath,
+            filePath: "/watched/new.jpg",
+        });
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(upload).toHaveBeenCalledWith("watched", ["/watched/new.jpg"]);
+        const item = {
+            uploadItem: "/watched/new.jpg",
+            pathPrefix: undefined,
+            localID: 1,
+            collectionID: 2,
+        };
+        watcher.onFileUpload(item, {
+            type: "uploaded",
+            file: { id: 1, collectionID: 2 },
+        } as never);
+        await watcher.allFileUploadsDone([item]);
+        await vi.advanceTimersByTimeAsync(1000);
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+    });
+
+    test("rescans retryable item failures after batch completion", async () => {
+        vi.useFakeTimers();
+        const rescan = vi.spyOn(watcher, "rescanAfterFailedUpload");
+        const upload = vi.fn();
+        watcher.init(upload, vi.fn());
+        await vi.advanceTimersByTimeAsync(0);
+        watcher.pushEvent({
+            action: "upload",
+            collectionName: "watched",
+            folderPath: watch.folderPath,
+            filePath: "/watched/retry.jpg",
+        });
+        await vi.advanceTimersByTimeAsync(1000);
+
+        const item = {
+            uploadItem: "/watched/retry.jpg",
+            pathPrefix: undefined,
+            localID: 1,
+            collectionID: 2,
+        };
+        watcher.onFileUpload(item, { type: "failed" });
+        await watcher.allFileUploadsDone([item]);
+        await vi.advanceTimersByTimeAsync(1000);
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+
+        expect(rescan).toHaveBeenCalledOnce();
+        rescan.mockRestore();
+    });
+
+    test("reruns pull requested while completion pull is running", async () => {
+        vi.useFakeTimers();
+        let resolveFirstPull!: () => void;
+        let resolveSecondPull!: () => void;
+        let resolveSecondPullStarted!: () => void;
+        const secondPullStarted = new Promise<void>((resolve) => {
+            resolveSecondPullStarted = resolve;
+        });
+        let pullCount = 0;
+        const onPull = vi.fn(() => {
+            pullCount++;
+            if (pullCount == 1)
+                return new Promise<void>((resolve) => {
+                    resolveFirstPull = resolve;
+                });
+            resolveSecondPullStarted();
+            return new Promise<void>((resolve) => {
+                resolveSecondPull = resolve;
+            });
+        });
+        const upload = vi.fn();
+        watcher.init(upload, onPull);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const firstItem = {
+            uploadItem: "/watched/first.jpg",
+            pathPrefix: undefined,
+            localID: 1,
+            collectionID: 2,
+        };
+        watcher.pushEvent({
+            action: "upload",
+            collectionName: "watched",
+            folderPath: watch.folderPath,
+            filePath: firstItem.uploadItem,
+        });
+        await vi.advanceTimersByTimeAsync(1000);
+        watcher.onFileUpload(firstItem, {
+            type: "uploaded",
+            file: { id: 1, collectionID: 2 },
+        } as never);
+        await watcher.allFileUploadsDone([firstItem]);
+        await Promise.resolve();
+        expect(onPull).toHaveBeenCalledOnce();
+
+        const secondItem = {
+            ...firstItem,
+            uploadItem: "/watched/second.jpg",
+            localID: 2,
+        };
+        watcher.pushEvent({
+            action: "upload",
+            collectionName: "watched",
+            folderPath: watch.folderPath,
+            filePath: secondItem.uploadItem,
+        });
+        await vi.advanceTimersByTimeAsync(1000);
+        watcher.onFileUpload(secondItem, {
+            type: "uploaded",
+            file: { id: 2, collectionID: 2 },
+        } as never);
+        await watcher.allFileUploadsDone([secondItem]);
+        expect(onPull).toHaveBeenCalledOnce();
+
+        resolveFirstPull();
+        await secondPullStarted;
+        expect(onPull).toHaveBeenCalledTimes(2);
+
+        resolveSecondPull();
+        await vi.runAllTimersAsync();
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+    });
+
+    test("drains root deletion state and triggers one pull", async () => {
+        const upload = vi.fn();
+        const onPull = vi.fn();
+        watcher.init(upload, onPull);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await new Promise((resolve) => setTimeout(resolve, 1100));
+
+        expect(onRemoveDir).toHaveBeenCalled();
+        const removeDir = onRemoveDir.mock.calls.at(-1)?.[0] as (
+            path: string,
+            folderWatch: FolderWatch,
+        ) => void;
+        removeDir(watch.folderPath, watch);
+        watcher.pushEvent({
+            action: "trash",
+            collectionName: "watched",
+            folderPath: watch.folderPath,
+            filePath: "/watched/photo.jpg",
+        });
+        await new Promise((resolve) => setTimeout(resolve, 1100));
+
+        expect(onPull).toHaveBeenCalledOnce();
+    });
+});

--- a/web/packages/gallery/services/files-db.ts
+++ b/web/packages/gallery/services/files-db.ts
@@ -126,16 +126,18 @@ export const LocalEnteFiles = z.array(LocalEnteFile);
 export const transformFilesIfNeeded = (files: EnteFile[]) =>
     isFilesTransformNeeded(files) ? files.map(transformFile) : files;
 
+export const transformFileIfNeeded = (file: EnteFile) =>
+    isFileTransformNeeded(file) ? transformFile(file) : file;
+
 // Avoid running the per-file migration across 200k clean records.
 const isFilesTransformNeeded = (
     files: (EnteFile & { isDeleted?: unknown })[],
-) =>
-    !!files.find(
-        (file) =>
-            "isDeleted" in file ||
-            !file.metadata.modificationTime ||
-            typeof file.metadata.fileType != "number",
-    );
+) => !!files.find(isFileTransformNeeded);
+
+const isFileTransformNeeded = (file: EnteFile & { isDeleted?: unknown }) =>
+    "isDeleted" in file ||
+    !file.metadata.modificationTime ||
+    typeof file.metadata.fileType != "number";
 
 const transformFile = (file: EnteFile & { isDeleted?: unknown }) => {
     const {

--- a/web/packages/gallery/services/upload/upload-service.ts
+++ b/web/packages/gallery/services/upload/upload-service.ts
@@ -1,8 +1,8 @@
+// TODO: Audit this file
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 import type { BytesOrB64 } from "ente-base/crypto/types";
-import {
-    streamEncryptionChunkOverhead,
-    streamEncryptionChunkSize,
-} from "ente-base/crypto/types";
+import { streamEncryptionChunkSize } from "ente-base/crypto/types";
 import type { CryptoWorker } from "ente-base/crypto/worker";
 import { ensureElectron } from "ente-base/electron";
 import { basename, nameAndExtension } from "ente-base/file-name";
@@ -80,17 +80,54 @@ import {
 
 const bitFlipErrorPrefix = "BitFlipDetected";
 
+/**
+ * A readable stream for a file, and its associated size and last modified time.
+ *
+ * This is the in-memory representation of the {@link UploadItem} type that we
+ * usually pass around. See: [Note: Reading a UploadItem]
+ */
 interface FileStream {
-    // Streams are single-use and always emit encryption-sized chunks.
+    /**
+     * A stream of the file's contents
+     *
+     * This stream is guaranteed to emit data in
+     * {@link streamEncryptionChunkSize} sized chunks (except the last chunk
+     * which can be smaller since a file would rarely align exactly to a
+     * {@link streamEncryptionChunkSize} multiple).
+     *
+     * Note: A stream can only be read once!
+     */
     stream: ReadableStream<Uint8Array>;
+    /**
+     * Number of chunks {@link stream} will emit, each
+     * {@link streamEncryptionChunkSize} sized (except the last one).
+     */
     chunkCount: number;
+    /**
+     * The size in bytes of the underlying file.
+     */
     fileSize: number;
+    /**
+     * The modification time of the file, in epoch milliseconds.
+     */
     lastModifiedMs: number;
+    /**
+     * Set to the underlying {@link File} when we also have access to it.
+     */
     file?: File;
 }
 
+/**
+ * If the stream we have is more than 5 {@link streamEncryptionChunkSize}
+ * chunks, then use multipart uploads for it, with each multipart-part
+ * containing 5 chunks.
+ *
+ * {@link streamEncryptionChunkSize} is 4 MB, and the number of chunks in a
+ * single upload part is 5, so each part is (up to) 20 MB.
+ */
 const multipartChunksPerPart = 5;
 
+/** Upload files to cloud storage */
 class UploadService {
     private uploadURLs: ObjectUploadURL[] = [];
     private pendingUploadCount = 0;
@@ -117,7 +154,7 @@ class UploadService {
             this.uploadURLs = [];
             return;
         }
-        await this.refillUploadURLs();
+        await this.refillUploadURLs(); /* prefetch */
     }
 
     reducePendingUploadCount() {
@@ -169,6 +206,10 @@ class UploadService {
             this.activeUploadURLRefill = undefined;
         }
 
+        // Ensure that the upload URLs we have are unique.
+        //
+        // Sanity check added when this was a new implementation. Have kept it
+        // around, but it can be removed too.
         if (
             this.uploadURLs.length !=
             new Set(this.uploadURLs.map((u) => u.url)).size
@@ -233,27 +274,16 @@ class UploadService {
             throw translateURLFetchErrorIfNeeded(e);
         });
     }
-
-    async fetchMultipartUploadURLsWithoutChecksums(
-        contentLength: number,
-        partLength: number,
-    ) {
-        if (this.publicAlbumsCredentials) {
-            throw new Error("Public uploads require part checksums");
-        }
-        return fetchMultipartUploadURLsWithMetadata({
-            contentLength,
-            partLength,
-        }).catch((e: unknown) => {
-            throw translateURLFetchErrorIfNeeded(e);
-        });
-    }
 }
 
+/** The singleton instance of {@link UploadService}. */
 const uploadService = new UploadService();
 
 export default uploadService;
 
+/**
+ * Return the file name for the given {@link uploadItem}.
+ */
 export const uploadItemFileName = (uploadItem: UploadItem) => {
     if (uploadItem instanceof File) return uploadItem.name;
     if (typeof uploadItem == "string") return basename(uploadItem);
@@ -261,17 +291,59 @@ export const uploadItemFileName = (uploadItem: UploadItem) => {
     return uploadItem.file.name;
 };
 
+/* -- Various intermediate types used during upload -- */
+
+export type ExternalParsedMetadata = ParsedMetadata & {
+    creationTime?: number | undefined;
+};
+
 export interface UploadAsset {
+    /**
+     * `true` if this is a live photo.
+     */
     isLivePhoto?: boolean;
+    /**
+     * The two parts of the live photo being uploaded.
+     *
+     * Valid for live photos.
+     */
     livePhotoAssets?: LivePhotoAssets;
+    /**
+     * The item being uploaded.
+     *
+     * Valid for non-live photos.
+     */
     uploadItem?: UploadItem;
+    /**
+     * The path prefix of the uploadItem (if not a live photo), or of the image
+     * component of the live photo (otherwise).
+     *
+     * The only expected scenario where this will not be present is when we're
+     * uploading an edited file (edited in the in-app image editor).
+     */
     pathPrefix: UploadPathPrefix | undefined;
-    externalParsedMetadata?: ParsedMetadata;
+    /**
+     * Metadata we know about a file externally. Valid for non-live photos.
+     *
+     * This is metadata that is not present within the file, but we have
+     * available from external sources. There is also a parsed metadata we
+     * obtain from JSON files. So together with the metadata present within the
+     * file itself, there are three places where the file's initial metadata can
+     * be filled in from.
+     *
+     * This will not be present for live photos.
+     */
+    externalParsedMetadata?: ExternalParsedMetadata;
 }
 
 interface ThumbnailedFile {
     fileStreamOrData: FileStream | Uint8Array<ArrayBuffer>;
+    /** The JPEG data of the generated thumbnail */
     thumbnail: Uint8Array<ArrayBuffer>;
+    /**
+     * `true` if this is a fallback (all black) thumbnail we're returning since
+     * thumbnail generation failed for some reason.
+     */
     hasStaticThumbnail: boolean;
 }
 
@@ -282,20 +354,43 @@ interface FileWithMetadata extends Omit<ThumbnailedFile, "hasStaticThumbnail"> {
 }
 
 interface EncryptedFileStream {
+    /**
+     * A stream of the file's encrypted contents
+     *
+     * This stream is guaranteed to emit data in
+     * {@link streamEncryptionChunkSize} chunks (except the last chunk which can
+     * be smaller since a file would rarely align exactly to a
+     * {@link streamEncryptionChunkSize} multiple).
+     */
     stream: ReadableStream<Uint8Array<ArrayBuffer>>;
+    /**
+     * Number of chunks {@link stream} will emit, each
+     * {@link streamEncryptionChunkSize} sized (except the last one).
+     */
     chunkCount: number;
-    encryptedSize: number;
 }
 
 interface EncryptedFilePieces {
+    /**
+     * The encrypted contents of the file (as bytes or a stream of bytes), and
+     * the decryption header that was used during encryption (base64 string).
+     */
     file: {
         encryptedData: Uint8Array<ArrayBuffer> | EncryptedFileStream;
         decryptionHeader: string;
     };
+    /**
+     * The encrypted contents of the file's thumbnail (as bytes), and the
+     * decryption header that was used during encryption (base64 string).
+     */
     thumbnail: {
         encryptedData: Uint8Array<ArrayBuffer>;
         decryptionHeader: string;
     };
+    /**
+     * The encrypted contents of the file's metadata (as a base64 string), and
+     * the decryption header that was used during encryption (base64 string).
+     */
     metadata: { encryptedData: string; decryptionHeader: string };
     pubMagicMetadata: RemoteMagicMetadata | undefined;
     localID: number;
@@ -303,12 +398,15 @@ interface EncryptedFilePieces {
 
 export interface PotentialLivePhotoAsset {
     fileName: string;
-    fileType: number;
+    fileType: number /* FileType | -1 */;
     collectionID: number;
     uploadItem: UploadItem;
     pathPrefix: UploadPathPrefix | undefined;
 }
 
+/**
+ * Check if the two given assets should be clubbed together as a live photo.
+ */
 export const areLivePhotoAssets = async (
     f: PotentialLivePhotoAsset,
     g: PotentialLivePhotoAsset,
@@ -325,7 +423,11 @@ export const areLivePhotoAssets = async (
     if (f.fileType == FileType.image && g.fileType == FileType.video) {
         fPrunedName = removePotentialLivePhotoSuffix(
             fName,
-            // Google can name the image half IMG_0001.mp4.jpg.
+            // A Google Live Photo image file can have video extension appended
+            // as suffix, so we pass that to removePotentialLivePhotoSuffix to
+            // remove it.
+            //
+            // Example: IMG_20210630_0001.mp4.jpg (Google Live Photo image file)
             gExt ? `.${gExt}` : undefined,
         );
         gPrunedName = removePotentialLivePhotoSuffix(gName);
@@ -341,8 +443,12 @@ export const areLivePhotoAssets = async (
 
     if (fPrunedName != gPrunedName) return false;
 
-    // The live-photo ZIP encoder cannot stream, so bound each component.
-    const maxAssetSize = 20 * 1024 * 1024;
+    // Also check that the size of an individual Live Photo asset is less than
+    // an (arbitrary) limit. This should be true in practice as the videos for a
+    // live photo are a few seconds long. Further on, the zipping library that
+    // we use doesn't support stream as a input.
+
+    const maxAssetSize = 20 * 1024 * 1024; /* 20MB */
     const fSize = await uploadItemSize(f.uploadItem);
     const gSize = await uploadItemSize(g.uploadItem);
     if (fSize > maxAssetSize || gSize > maxAssetSize) {
@@ -351,6 +457,11 @@ export const areLivePhotoAssets = async (
         );
         return false;
     }
+
+    // Finally, ensure that the creation times of the image and video are within
+    // some epsilon of each other. This is to avoid clubbing together unrelated
+    // items that coincidentally have the same name (this is not uncommon since,
+    // e.g. many cameras use a deterministic numbering scheme).
 
     const fParsedMetadataJSON = matchJSONMetadata(
         f.pathPrefix,
@@ -376,13 +487,24 @@ export const areLivePhotoAssets = async (
         gParsedMetadataJSON,
     );
 
-    // One component can lack timezone data, producing up to a one-day skew.
-    const thresholdSeconds = 24 * 60 * 60;
+    // The exact threshold to use is hard to decide. The times should be usually
+    // exact to minute, but it is possible that one of the items is missing the
+    // timezone while the other has it. Their dates (as shown by the app) would
+    // both be correct, just the UTC epochs will vary.
+    //
+    // Using a threshold of 1 day makes the app more robust to such timezone
+    // discrepancies while only marginally increasing the risk of false
+    // positives. But this is a heuristic that might not always be correct.
+    const thresholdSeconds = 24 * 60 * 60; /* 1 day */
     const haveSameishDate =
         fDate && gDate && Math.abs(fDate - gDate) / 1e6 < thresholdSeconds;
 
     if (!haveSameishDate) {
-        // Google Takeout omits JSON for the video half of a live photo.
+        // Google does not include the metadata JSON for the video part of the
+        // live photo in the Takeout, causing this date check to fail.
+        //
+        // So only incorporate this check if either neither file has a metadata
+        // JSON, or both have it.
         if (
             (!fParsedMetadataJSON && !gParsedMetadataJSON) ||
             (fParsedMetadataJSON && gParsedMetadataJSON)
@@ -391,13 +513,17 @@ export const areLivePhotoAssets = async (
         }
     }
 
+    // All checks pass. Club these two as a live photo.
     return true;
 };
 
 const removePotentialLivePhotoSuffix = (name: string, suffix?: string) => {
     const suffix_3 = "_3";
 
-    // icloud-photos-downloader appends this to live-photo filenames.
+    // The icloud-photos-downloader library appends _HVEC to the end of the
+    // filename in case of live photos.
+    //
+    // https://github.com/icloud-photos-downloader/icloud_photos_downloader
     const suffix_hvec = "_HVEC";
 
     let foundSuffix: string | undefined;
@@ -417,6 +543,9 @@ const removePotentialLivePhotoSuffix = (name: string, suffix?: string) => {
     return foundSuffix ? name.slice(0, foundSuffix.length * -1) : name;
 };
 
+/**
+ * Return the size of the given {@link uploadItem}.
+ */
 const uploadItemSize = async (uploadItem: UploadItem): Promise<number> => {
     if (uploadItem instanceof File) return uploadItem.size;
     if (typeof uploadItem == "string")
@@ -426,9 +555,26 @@ const uploadItemSize = async (uploadItem: UploadItem): Promise<number> => {
     return uploadItem.file.size;
 };
 
+/**
+ * Return the creation date for the given {@link uploadItem}.
+ *
+ * [Note: Duplicate retrieval of creation date for live photo clubbing]
+ *
+ * This function duplicates some logic of {@link extractImageOrVideoMetadata}.
+ * This duplication, while not good, is currently unavoidable with the way the
+ * code is structured since the live photo clubbing happens at an earlier time
+ * in the pipeline when we don't have the Exif data, but the Exif data is needed
+ * to determine the file's creation time (to ensure that we only club photos and
+ * videos with close by creation times, instead of just relying on file names).
+ *
+ * Note that unlike {@link extractImageOrVideoMetadata}, we don't try to
+ * fallback to the file's modification time. This is because for the purpose of
+ * live photo clubbing, we wish to use the creation date only in cases where we
+ * have it.
+ */
 const uploadItemCreationDate = async (
     uploadItem: UploadItem,
-    fileType: number,
+    fileType: number /* FileType */,
     parsedMetadataJSON: ParsedMetadataJSON | undefined,
 ) => {
     if (parsedMetadataJSON?.creationTime)
@@ -450,36 +596,180 @@ const uploadItemCreationDate = async (
     );
 };
 
+/**
+ * The message of the {@link Error} that is thrown when the user cancels an
+ * upload.
+ *
+ * As a convenience, the {@link isUploadCancelledError} matcher can be used to
+ * match such errors.
+ *
+ * [Note: Upload cancellation]
+ *
+ * 1. User cancels the upload by pressing the cancel button on the upload
+ *    progress indicator in the UI.
+ *
+ * 2. This sets the {@link shouldUploadBeCancelled} flag on
+ *    {@link UploadManager}.
+ *
+ * 3. Periodically the code that is performing the upload calls the
+ *    {@link abortIfCancelled} flag. This function is a no-op normally, but if
+ *    the {@link shouldUploadBeCancelled} is set then it throws an {@link Error}
+ *    with the message set to {@link uploadCancelledErrorMessage}.
+ *
+ * 4. The intermediate per-file try catch handlers do not intercept this error,
+ *    and it bubbles all the way to the top of the call stack, ending the upload.
+ */
 export const uploadCancelledErrorMessage = "Upload cancelled";
 
+/**
+ * A convenience function to check if the provided value is an {@link Error}
+ * with message {@link uploadCancelledErrorMessage}.
+ */
 export const isUploadCancelledError = (e: unknown) =>
     e instanceof Error && e.message == uploadCancelledErrorMessage;
 
+export const shouldAbortUploadOnError = (
+    error: unknown,
+    stopOnUploadError = false,
+) => stopOnUploadError && error instanceof HTTPError;
+
+/**
+ * The message of the {@link Error} that is thrown when the upload fails because
+ * the user's current session has expired (e.g. maybe they logged this client
+ * out from another session), and that they need to login again.
+ */
 export const sessionExpiredErrorMessage = "Session expired";
 
+/**
+ * The message of the {@link Error} that is thrown when the upload fails because
+ * the user's subscription has expired.
+ */
 export const subscriptionExpiredErrorMessage = "Subscription expired";
 
+/**
+ * The message of the {@link Error} that is thrown when the upload fails because
+ * the user's storage space has been exhausted.
+ */
 export const storageLimitExceededErrorMessage = "Storage limit exceeded";
 
+/**
+ * The message of the {@link Error} that is thrown when the PUT request for the
+ * upload of a part of file (as part of an overall multipart upload) fails
+ * because the response did not have the etag error.
+ *
+ * This usually happens because some browser extension is blocking access to the
+ * ETag header (even when it is present in the remote S3 response). In self
+ * hosted scenarios, this can also happen if the remote S3 bucket does not have
+ * the appropriate CORS rules to allow access to the etag header.
+ */
 const eTagMissingErrorMessage = "ETag header not present in response";
 
+/**
+ * The message of the {@link Error} that is thrown when the size of the file
+ * being uploaded exceeds the maximum allowed file size.
+ *
+ * The client already checks for the size of the file being uploaded, and aborts
+ * the request if the client side limit is exceeded. An error with this message
+ * is thrown if we remote side validation fails.
+ *
+ * The UI outcome is the same in both cases.
+ */
 const fileTooLargeErrorMessage = "File too large";
 
+/**
+ * Some state and callbacks used during upload that are not tied to a specific
+ * file being uploaded.
+ */
 interface UploadContext {
+    /**
+     * If `true`, then the upload does not go via the worker.
+     *
+     * See {@link shouldDisableCFUploadProxy} for more details.
+     */
     isCFUploadProxyDisabled: boolean;
-    deferMultipartChecksums: boolean;
-    isInternalUser: boolean;
+    isInternalUser?: boolean;
+    /**
+     * If true, defer optional multipart checksums until each part is streamed.
+     */
+    deferMultipartChecksums?: boolean;
+    /**
+     * If true, duplicate files already owned by the user are reused without
+     * being added to the current upload collection.
+     * This is used when the current collection is only an upload staging target.
+     */
     skipDuplicateAddToUploadCollection?: boolean;
+    /**
+     * If true, media originating from Google Photos partner sharing is
+     * uploaded. Otherwise it is skipped before reading the media file.
+     */
     includePartnerSharedFiles?: boolean;
+    /**
+     * If true, avoid buffering every encrypted multipart part to calculate
+     * checksums before requesting upload URLs.
+     */
+    skipMultipartChecksums?: boolean;
+    /**
+     * Stop current folder-watch batch after an HTTP upload failure instead of
+     * retaining more items while the endpoint is unhealthy.
+     */
+    stopOnUploadError?: boolean;
+    /**
+     * If present, then the upload is happening in the context of the public
+     * albums app and these are the credentials that should be used for
+     * performing API requests (instead of trying to obtain and use the
+     * credentials for the logged in user, as happens when we're running in the
+     * context of the photos app).
+     */
     publicAlbumsCredentials?: PublicAlbumsCredentials;
+    /**
+     * A function that the upload sequence should use to periodically check in
+     * and see if the upload has been cancelled by the user.
+     *
+     * If the upload has been cancelled, it will throw an exception with the
+     * message set to {@link uploadCancelledErrorMessage}.
+     *
+     * See: [Note: Upload cancellation]
+     */
     abortIfCancelled: () => void;
+    /**
+     * A function that gets called update the progress shown in the UI for a
+     * particular file as the parts of that file get uploaded.
+     *
+     * @param {fileLocalID} The local ID of the file whose progress we want to
+     * update.
+     *
+     * @param {percentage} The upload completion percentage, as a value between
+     * 0 and 100 (inclusive).
+     */
     updateUploadProgress: (fileLocalID: number, percentage: number) => void;
 }
+
+/**
+ * Upload the given {@link UploadableUploadItem}
+ *
+ * This is lower layer implementation of the upload. It is invoked by
+ * {@link UploadManager} after it has assembled all the relevant bits we need to
+ * go forth and upload.
+ *
+ * @param uploadContext Some general state and callbacks for the entire set of
+ * files being uploaded.
+ */
+export type ExistingFileFinder = (
+    metadata: FileMetadata,
+    collectionID: number,
+) => Promise<EnteFile[]>;
+
+export const settleUploadWorkers = async (workers: Promise<void>[]) => {
+    const results = await Promise.allSettled(workers);
+    for (const result of results) {
+        if (result.status == "rejected") throw result.reason;
+    }
+};
 
 export const upload = async (
     { collection, localID, fileName, ...uploadAsset }: UploadableUploadItem,
     uploaderName: string | undefined,
-    existingFiles: EnteFile[],
+    existingFiles: EnteFile[] | ExistingFileFinder,
     parsedMetadataJSONMap: Map<string, ParsedMetadataJSON>,
     worker: CryptoWorker,
     uploadContext: UploadContext,
@@ -504,6 +794,22 @@ export const upload = async (
                 return { type: "partnerShared" };
             }
         }
+
+        /*
+         * We read the file four times:
+         * 1. To determine its MIME type (only needs first few KBs).
+         * 2. To extract its metadata.
+         * 3. To calculate its hash.
+         * 4. To encrypt it.
+         *
+         * When we already have a File object the multiple reads are fine.
+         *
+         * When we're in the context of our desktop app and have a path, it
+         * might be possible to optimize further by using `ReadableStream.tee`
+         * to perform these steps simultaneously. However, that'll require
+         * restructuring the code so that these steps run in a parallel manner
+         * (tee will not work for strictly sequential reads of large streams).
+         */
 
         let assetDetails: ReadAssetDetailsResult;
 
@@ -536,9 +842,9 @@ export const upload = async (
             worker,
         );
 
-        const matches = existingFiles.filter((file) =>
-            areFilesSame(file, metadata),
-        );
+        const matches = Array.isArray(existingFiles)
+            ? existingFiles.filter((file) => areFilesSame(file, metadata))
+            : await existingFiles(metadata, collection.id);
 
         const anyMatch = matches.length > 0 ? matches[0] : undefined;
 
@@ -551,12 +857,16 @@ export const upload = async (
             }
 
             if (skipDuplicateAddToUploadCollection) {
+                // The real target collection is updated after the upload batch.
+                // Report duplicate reuse as a success without creating a staging
+                // collection symlink.
                 return {
                     type: "addedSymlink",
                     file: matchInSameCollection ?? anyMatch,
                 };
             }
 
+            // Any of the matching files can be used to add a symlink.
             const symlink = Object.assign({}, anyMatch);
             symlink.collectionID = collection.id;
             await addToCollection(collection, [symlink]);
@@ -617,17 +927,23 @@ export const upload = async (
             file: await decryptRemoteFile(uploadedFile, collection.key),
         };
     } catch (e) {
-        if (isUploadCancelledError(e)) {
+        if (
+            isUploadCancelledError(e) ||
+            shouldAbortUploadOnError(e, uploadContext.stopOnUploadError)
+        ) {
+            /* stop the upload */
             throw e;
         }
 
         log.error(`Upload failed for ${fileName}`, e);
         switch (e instanceof Error && e.message) {
+            /* stop the upload */
             case sessionExpiredErrorMessage:
             case subscriptionExpiredErrorMessage:
             case storageLimitExceededErrorMessage:
                 throw e;
 
+            /* file specific */
             case eTagMissingErrorMessage:
                 return { type: "blocked" };
             case fileTooLargeErrorMessage:
@@ -638,6 +954,16 @@ export const upload = async (
     }
 };
 
+/**
+ * Convert specific HTTP errors during an API call to remote endpoints for
+ * fetching new upload URLs into error with known messages (if applicable).
+ *
+ * Can be used with the following functions:
+ *
+ * - {@link fetchUploadURLs}
+ * - {@link fetchMultipartUploadURLs}
+ *
+ */
 const translateURLFetchErrorIfNeeded = (e: unknown) => {
     if (e instanceof HTTPError) {
         switch (e.res.status) {
@@ -652,6 +978,76 @@ const translateURLFetchErrorIfNeeded = (e: unknown) => {
     return e;
 };
 
+/**
+ * Read the given file or path or zip item into an in-memory representation.
+ *
+ * [Note: Reading a UploadItem]
+ *
+ * The file can be either a web
+ * [File](https://developer.mozilla.org/en-US/docs/Web/API/File), the absolute
+ * path to a file on desk, a combination of these two, or a entry in a zip file
+ * on the user's local file system.
+ *
+ * tl;dr; There are four cases:
+ *
+ * 1. web / File
+ * 2. desktop / File (+ path)
+ * 3. desktop / path
+ * 4. desktop / ZipItem
+ *
+ * For the when and why, read on.
+ *
+ * The code that accesses files (e.g. uplaads) gets invoked in two contexts:
+ *
+ * 1. web: the normal mode, when we're running in as a web app in the browser.
+ *
+ * 2. desktop: when we're running inside our desktop app.
+ *
+ * In the web context, we'll always get a File, since within the browser we
+ * cannot programmatically construct paths to or arbitrarily access files on the
+ * user's file system.
+ *
+ * > Note that even if we were to somehow have an absolute path at hand, we
+ *   cannot programmatically create such File objects to arbitrary absolute
+ *   paths on user's local file system for security reasons.
+ *
+ * So in the web context, this will always be a File we get as a result of an
+ * explicit user interaction (e.g. drag and drop or using a file selector).
+ *
+ * In the desktop context, this can be either a File (+ path), or a path, or an
+ * entry within a zip file.
+ *
+ * 2. If the user provided us this file via some user interaction (say a drag
+ *    and a drop), this'll still be a File. But unlike in the web context, we
+ *    also have access to the full path of this file.
+ *
+ * 3. In addition, when running in the desktop app we have the ability to
+ *    initiate programmatic access absolute paths on the user's file system. For
+ *    example, if the user asks us to watch certain folders on their disk for
+ *    changes, we'll be able to pick up new images being added, and in such
+ *    cases, the parameter here will be a path. Another example is when resuming
+ *    an previously interrupted upload - we'll only have the path at hand in
+ *    such cases, not the original File object since the app subsequently
+ *    restarted.
+ *
+ * 4. The user might've also initiated an upload of a zip file (or we might be
+ *    resuming one). In such cases we will get a tuple (path to the zip file on
+ *    the local file system, and the name of the entry within that zip file).
+ *
+ * Case 3 and 4, when we're provided a path, are simple. We don't have a choice,
+ * since we cannot still programmatically construct a File object (we can
+ * construct it on the Node.js layer, but it can't then be transferred over the
+ * IPC boundary). So all our operations use the path itself.
+ *
+ * Case 2 involves a choice on a use-case basis. Neither File nor the path is a
+ * better choice for all use cases.
+ *
+ * > The advantage of the File object is that the browser has already read it
+ *   into memory for us. The disadvantage comes in the case where we need to
+ *   communicate with the native Node.js layer of our desktop app. Since this
+ *   communication happens over IPC, the File's contents need to be serialized
+ *   and copied, which is a bummer for large videos etc.
+ */
 const readUploadItem = async (uploadItem: UploadItem): Promise<FileStream> => {
     let underlyingStream: ReadableStream;
     let file: File | undefined;
@@ -681,6 +1077,9 @@ const readUploadItem = async (uploadItem: UploadItem): Promise<FileStream> => {
     const N = streamEncryptionChunkSize;
     const chunkCount = Math.ceil(fileSize / streamEncryptionChunkSize);
 
+    // Pipe the underlying stream through a transformer that emits
+    // streamEncryptionChunkSize-ed chunks (except the last one, which can be
+    // smaller).
     let pending: Uint8Array | undefined;
     const transformer = new TransformStream<Uint8Array, Uint8Array>({
         transform(
@@ -718,14 +1117,20 @@ interface ReadAssetDetailsResult {
     lastModifiedMs: number;
 }
 
+/**
+ * Read the associated file(s) to determine the type, size and last modified
+ * time of the given {@link asset}.
+ */
 const readAssetDetails = async ({
     isLivePhoto,
     livePhotoAssets,
     uploadItem,
 }: UploadAsset): Promise<ReadAssetDetailsResult> =>
     isLivePhoto
-        ? readLivePhotoDetails(livePhotoAssets!)
-        : readImageOrVideoDetails(uploadItem!);
+        ? // @ts-ignore
+          readLivePhotoDetails(livePhotoAssets)
+        : // @ts-ignore
+          readImageOrVideoDetails(uploadItem);
 
 const readLivePhotoDetails = async ({ image, video }: LivePhotoAssets) => {
     const img = await readImageOrVideoDetails(image);
@@ -734,6 +1139,8 @@ const readLivePhotoDetails = async ({ image, video }: LivePhotoAssets) => {
     return {
         fileTypeInfo: {
             fileType: FileType.livePhoto,
+            // Use the extension of the image component as the extension of the
+            // live photo.
             extension: img.fileTypeInfo.extension,
         },
         fileSize: img.fileSize + vid.fileSize,
@@ -741,10 +1148,21 @@ const readLivePhotoDetails = async ({ image, video }: LivePhotoAssets) => {
     };
 };
 
+/**
+ * Read the beginning of the given file (or its path), or use its filename as a
+ * fallback, to determine its MIME type. From that, construct and return a
+ * {@link FileTypeInfo}.
+ *
+ * While we're at it, also return the size of the file, and its last modified
+ * time (expressed as epoch milliseconds).
+ *
+ * @param uploadItem See: [Note: Reading a UploadItem]
+ */
 const readImageOrVideoDetails = async (uploadItem: UploadItem) => {
     const { stream, fileSize, lastModifiedMs } =
         await readUploadItem(uploadItem);
 
+    // @ts-ignore
     const fileTypeInfo = await detectFileTypeInfoFromChunk(async () => {
         const reader = stream.getReader();
         const chunk = (await reader.read()).value;
@@ -755,6 +1173,14 @@ const readImageOrVideoDetails = async (uploadItem: UploadItem) => {
     return { fileTypeInfo, fileSize, lastModifiedMs };
 };
 
+/**
+ * Read the entirety of a readable stream.
+ *
+ * It is not recommended to use this for large (say, multi-hundred MB) files. It
+ * is provided as a syntactic shortcut for cases where we already know that the
+ * size of the stream will be reasonable enough to be read in its entirety
+ * without us running out of memory.
+ */
 const readEntireStream = async (
     stream: ReadableStream,
 ): Promise<Uint8Array<ArrayBuffer>> =>
@@ -765,6 +1191,10 @@ interface ExtractAssetMetadataResult {
     publicMagicMetadata: FilePublicMagicMetadataData;
 }
 
+/**
+ * Compute the hash, extract Exif or other metadata, and merge in data from the
+ * {@link parsedMetadataJSONMap} for the assets. Return the resultant metadatum.
+ */
 const extractAssetMetadata = async (
     {
         isLivePhoto,
@@ -781,7 +1211,8 @@ const extractAssetMetadata = async (
 ): Promise<ExtractAssetMetadataResult> =>
     isLivePhoto
         ? await extractLivePhotoMetadata(
-              livePhotoAssets!,
+              // @ts-ignore
+              livePhotoAssets,
               pathPrefix,
               lastModifiedMs,
               collectionID,
@@ -789,7 +1220,8 @@ const extractAssetMetadata = async (
               worker,
           )
         : await extractImageOrVideoMetadata(
-              uploadItem!,
+              // @ts-ignore
+              uploadItem,
               pathPrefix,
               externalParsedMetadata,
               fileType,
@@ -838,7 +1270,7 @@ const extractLivePhotoMetadata = async (
 const extractImageOrVideoMetadata = async (
     uploadItem: UploadItem,
     pathPrefix: UploadPathPrefix | undefined,
-    externalParsedMetadata: ParsedMetadata | undefined,
+    externalParsedMetadata: ExternalParsedMetadata | undefined,
     fileType: FileType,
     lastModifiedMs: number,
     collectionID: number,
@@ -847,7 +1279,7 @@ const extractImageOrVideoMetadata = async (
 ) => {
     const fileName = uploadItemFileName(uploadItem);
 
-    let parsedMetadata: ParsedMetadata | undefined;
+    let parsedMetadata: (ParsedMetadata & ExternalParsedMetadata) | undefined;
     if (fileType == FileType.image) {
         parsedMetadata = await tryExtractImageMetadata(
             uploadItem,
@@ -861,11 +1293,17 @@ const extractImageOrVideoMetadata = async (
         );
     }
 
+    // The `UploadAsset` itself might have metadata associated with a-priori, if
+    // so, merge the data we read from the file's contents into it.
     if (externalParsedMetadata) {
         parsedMetadata = { ...externalParsedMetadata, ...parsedMetadata };
     }
 
     const hash = await computeHash(uploadItem, worker);
+
+    // Some of this logic is duplicated in `uploadItemCreationDate`.
+    //
+    // See: [Note: Duplicate retrieval of creation date for live photo clubbing]
 
     const parsedMetadataJSON = matchJSONMetadata(
         pathPrefix,
@@ -899,12 +1337,21 @@ const extractImageOrVideoMetadata = async (
             tryParseEpochMicrosecondsFromFileName(fileName) ?? modificationTime;
     }
 
+    // Video duration
     let duration: number | undefined;
     if (fileType == FileType.video) {
         duration = await tryDetermineVideoDuration(uploadItem);
     }
 
-    // Malformed Exif has produced non-numeric dimensions in real uploads.
+    // To avoid introducing malformed data into the metadata fields (which the
+    // other clients might not expect and handle), we have extra "ensure" checks
+    // here that act as a safety valve if somehow the TypeScript type is lying.
+    //
+    // There is no deterministic sample we found that necessitated adding these
+    // extra checks, but we did get one user with a list in the width field of
+    // the metadata (it should've been an integer). The most probable theory is
+    // that somehow it made its way in through malformed Exif.
+
     const metadata: FileMetadata = {
         fileType,
         title: fileName,
@@ -955,6 +1402,9 @@ const tryExtractImageMetadata = async (
 ): Promise<ParsedMetadata | undefined> => {
     let file: File;
     if (typeof uploadItem == "string" || Array.isArray(uploadItem)) {
+        // The library we use for extracting Exif from images, ExifReader,
+        // doesn't support streams. But unlike videos, for images it is
+        // reasonable to read the entire stream into memory here.
         const { response } = await readStream(ensureElectron(), uploadItem);
         const path = typeof uploadItem == "string" ? uploadItem : uploadItem[1];
         const opts = lastModifiedMs ? { lastModified: lastModifiedMs } : {};
@@ -994,6 +1444,19 @@ const tryDetermineVideoDuration = async (uploadItem: UploadItem) => {
     }
 };
 
+/**
+ * Compute the hash of an item we're attempting to upload.
+ *
+ * The hash is retained in the file metadata, and is also used to detect
+ * duplicates during upload.
+ *
+ * This process can take a noticable amount of time. As an extreme case, for a
+ * 10 GB upload item, this can take a 2-3 minutes.
+ *
+ * @param uploadItem The {@link UploadItem} we're attempting to upload.
+ *
+ * @param worker A {@link CryptoWorker} to use for computing the hash.
+ */
 const computeHash = async (uploadItem: UploadItem, worker: CryptoWorker) => {
     const { stream, chunkCount } = await readUploadItem(uploadItem);
     const hashState = await worker.chunkHashInit();
@@ -1010,13 +1473,23 @@ const computeHash = async (uploadItem: UploadItem, worker: CryptoWorker) => {
     return await worker.chunkHashFinal(hashState);
 };
 
+/**
+ * Return true if the given file is the same as provided metadata.
+ *
+ * Note that the metadata includes the hash of the file's contents (when
+ * available), so this also in effect compares the contents of the files, not
+ * just the "meta" information about them.
+ */
 const areFilesSame = (fFile: EnteFile, gm: FileMetadata) => {
     const fm = fFile.metadata;
 
+    // File name is different.
     if (fileFileName(fFile) != gm.title) return false;
 
+    // File type is different.
     if (fm.fileType != gm.fileType) return false;
 
+    // Name and type is same, compare hash.
     const fh = metadataHash(fm);
     const gh = metadataHash(gm);
     return fh && gh && fh == gh;
@@ -1027,8 +1500,10 @@ const readAsset = async (
     { isLivePhoto, uploadItem, livePhotoAssets }: UploadAsset,
 ): Promise<ThumbnailedFile> =>
     isLivePhoto
-        ? await readLivePhoto(livePhotoAssets!, fileTypeInfo)
-        : await readImageOrVideo(uploadItem!, fileTypeInfo);
+        ? // @ts-ignore
+          await readLivePhoto(livePhotoAssets, fileTypeInfo)
+        : // @ts-ignore
+          await readImageOrVideo(uploadItem, fileTypeInfo);
 
 const readLivePhoto = async (
     livePhotoAssets: LivePhotoAssets,
@@ -1040,12 +1515,20 @@ const readLivePhoto = async (
         hasStaticThumbnail,
     } = await augmentWithThumbnail(
         livePhotoAssets.image,
+        // For live photos, the extension field in the file type info is the
+        // extension of the image component of the live photo.
         { fileType: FileType.image, extension: fileTypeInfo.extension },
         await readUploadItem(livePhotoAssets.image),
     );
     const videoFileStreamOrData = await readUploadItem(livePhotoAssets.video);
 
-    // The ZIP encoder accepts blobs or bytes, not streams. The size was bounded above.
+    // The JS zip library that encodeLivePhoto uses does not support
+    // ReadableStreams, so pass the file (blob) if we have one, otherwise read
+    // the entire stream into memory and pass the resultant data.
+    //
+    // This is a reasonable behaviour since the videos corresponding to live
+    // photos are only a couple of seconds long (we've already done a pre-flight
+    // check during areLivePhotoAssets to ensure their size is small).
     const fileOrData = async (sd: FileStream | Uint8Array<ArrayBuffer>) => {
         const fos = async ({ file, stream }: FileStream) =>
             file ? file : await readEntireStream(stream);
@@ -1072,6 +1555,18 @@ const readImageOrVideo = async (
     return augmentWithThumbnail(uploadItem, fileTypeInfo, fileStream);
 };
 
+/**
+ * Augment the given {@link dataOrStream} with thumbnail information.
+ *
+ * This is a companion method for {@link readUploadItem}, and can be used to
+ * convert the result of {@link readUploadItem} into an {@link ThumbnailedFile}.
+ *
+ * @param uploadItem The {@link UploadItem} where the given {@link fileStream}
+ * came from.
+ *
+ * Note: The `fileStream` in the returned {@link ThumbnailedFile} may be
+ * different from the one passed to the function.
+ */
 const augmentWithThumbnail = async (
     uploadItem: UploadItem,
     fileTypeInfo: FileTypeInfo,
@@ -1083,6 +1578,7 @@ const augmentWithThumbnail = async (
 
     const electron = globalThis.electron;
 
+    // 1. Native thumbnail generation using items's (effective) path.
     if (electron && !(uploadItem instanceof File)) {
         try {
             thumbnail = await generateThumbnailNative(
@@ -1098,13 +1594,29 @@ const augmentWithThumbnail = async (
     if (!thumbnail) {
         let blob: Blob | undefined;
         if (uploadItem instanceof File) {
+            // 2. Browser based thumbnail generation for File (blobs).
             blob = uploadItem;
         } else {
-            // Never buffer an unbounded video after native thumbnailing fails.
+            // 3. Browser based thumbnail generation for paths.
+            //
+            // We can only get here when we're running in our desktop app (since
+            // only that works with non-File uploadItems), and the thumbnail
+            // generation failed.
+            //
+            // There are no expected scenarios when this should happen.
+            //
+            // The fallback in this case involves reading the entire stream into
+            // memory, and passing that data across the IPC boundary in a single
+            // go (i.e. not in a streaming manner). This is risky for videos of
+            // unbounded sizes, and since anyways we are not expected to come
+            // here for videos, so we only apply this fallback for images.
+
             if (fileTypeInfo.fileType == FileType.image) {
                 const data = await readEntireStream(fileStream.stream);
                 blob = new Blob([data]);
 
+                // The Readable stream cannot be read twice, so use the data
+                // directly for subsequent steps.
                 fileData = data;
             } else {
                 const fileName = uploadItemFileName(uploadItem);
@@ -1230,7 +1742,7 @@ const encryptBytesWithOptionalVerification = async (
 };
 
 const encryptFileStream = async (
-    { stream, chunkCount, fileSize }: FileStream,
+    { stream, chunkCount }: FileStream,
     fileKey: BytesOrB64,
     worker: CryptoWorker,
     shouldVerify: boolean,
@@ -1247,7 +1759,10 @@ const encryptFileStream = async (
         async pull(controller) {
             const { value, done } = await fileStreamReader.read();
             if (done) {
-                // readUploadItem promised exactly chunkCount chunks.
+                // TransformStream in readUploadItem guarantees that we'll get
+                // encryption sized `chunkCount` chunks. Below we close the
+                // controller on the last chunk. So we shouldn't be getting a
+                // `done` here.
                 controller.close();
                 throw new Error("Unexpected stream state");
             }
@@ -1289,12 +1804,7 @@ const encryptFileStream = async (
     });
     return {
         decryptionHeader,
-        encryptedData: {
-            stream: encryptedFileStream,
-            chunkCount,
-            encryptedSize:
-                fileSize + chunkCount * streamEncryptionChunkOverhead,
-        },
+        encryptedData: { stream: encryptedFileStream, chunkCount },
     };
 };
 
@@ -1326,6 +1836,12 @@ const uploadToBucket = async (
 
     const requestRetrier = createAbortableRetryEnsuringHTTPOk(abortIfCancelled);
 
+    // The bulk of the network time during upload is taken in uploading the
+    // actual encrypted objects to remote S3, but after that there is another
+    // API request we need to make to "finalize" the file (on museum). This
+    // should be quick usually, but it's a different network route altogether
+    // and we can't know for sure how long it'll take. So keep aside a small
+    // approximate percentage for this last step.
     const maxPercent = Math.floor(95 + 5 * Math.random());
 
     let fileObjectKey: string;
@@ -1336,6 +1852,8 @@ const uploadToBucket = async (
         !(encryptedData instanceof Uint8Array) &&
         encryptedData.chunkCount >= multipartChunksPerPart
     ) {
+        // We have a stream, and it is more than multipartChunksPerPart
+        // chunks long, so use a multipart upload to upload it.
         ({ objectKey: fileObjectKey, fileSize } =
             await uploadStreamUsingMultipart(
                 localID,
@@ -1418,6 +1936,22 @@ const uploadToBucket = async (
     };
 };
 
+/**
+ * A factory method that returns a function which will act like variant of
+ * {@link retryEnsuringHTTPOk} and also understands the cancellation mechanism
+ * used by the upload subsystem.
+ *
+ * @param abortIfCancelled A function that aborts the operation by throwing a
+ * error with the message set to {@link uploadCancelledErrorMessage} if the user
+ * has cancelled the upload.
+ *
+ * @return A function of type {@link HTTPRequestRetrier} that can be used to
+ * retry requests. This function will retry requests (obtained afresh each time
+ * by calling the provided {@link request} function) in the same manner as
+ * {@link retryEnsuringHTTPOk}. Additionally, it will call
+ * {@link abortIfCancelled} before each attempt, and also bypass the retries
+ * when the abort happens on such cancellations.
+ */
 const createAbortableRetryEnsuringHTTPOk =
     (abortIfCancelled: () => void): HTTPRequestRetrier =>
     (request, opts) =>
@@ -1436,6 +1970,18 @@ const createAbortableRetryEnsuringHTTPOk =
             },
         );
 
+export const shouldSendMultipartPartChecksums = (
+    checksumEnabled: boolean,
+    isPublicAlbum: boolean,
+    skipMultipartChecksums = false,
+) => !skipMultipartChecksums && (checksumEnabled || isPublicAlbum);
+
+export const shouldReloadExistingFilesForUpload = (
+    watcherSessionID: number | undefined,
+    loadedWatcherSessionID: number | undefined,
+) =>
+    watcherSessionID == undefined || watcherSessionID != loadedWatcherSessionID;
+
 const uploadStreamUsingMultipart = async (
     fileLocalID: number,
     dataStream: EncryptedFileStream,
@@ -1446,11 +1992,17 @@ const uploadStreamUsingMultipart = async (
 ) => {
     const { isCFUploadProxyDisabled, abortIfCancelled, updateUploadProgress } =
         uploadContext;
-    const shouldSendPartChecksums =
-        checksumEnabled || !!uploadContext.publicAlbumsCredentials;
+    // Watcher uploads keep encryption verification, but skip optional per-part
+    // checksum prebuffering; normal uploads retain checksum protection.
+    const shouldSendPartChecksums = shouldSendMultipartPartChecksums(
+        checksumEnabled,
+        !!uploadContext.publicAlbumsCredentials,
+        uploadContext.skipMultipartChecksums,
+    );
     const deferPartChecksums =
-        uploadContext.deferMultipartChecksums &&
-        !uploadContext.publicAlbumsCredentials;
+        !!uploadContext.deferMultipartChecksums &&
+        !uploadContext.publicAlbumsCredentials &&
+        !uploadContext.skipMultipartChecksums;
 
     const { stream } = dataStream;
     const streamReader = stream.getReader();
@@ -1520,7 +2072,7 @@ const uploadStreamUsingMultipart = async (
 
             updateUploadProgress(fileLocalID, percentPerPart * partNumber);
             completedParts.push({ partNumber, eTag });
-            parts[index] = new Uint8Array(0);
+            parts[index] = new Uint8Array(0); // release memory
         }
 
         const completionURL = multipartUploadURLs.completeURL;
@@ -1541,20 +2093,8 @@ const uploadStreamUsingMultipart = async (
         return { objectKey: multipartUploadURLs.objectKey, fileSize };
     }
 
-    const partLength = Math.min(
-        dataStream.encryptedSize,
-        multipartChunksPerPart *
-            (streamEncryptionChunkSize + streamEncryptionChunkOverhead),
-    );
-    const multipartUploadURLs = deferPartChecksums
-        ? await uploadService.fetchMultipartUploadURLsWithoutChecksums(
-              dataStream.encryptedSize,
-              partLength,
-          )
-        : await uploadService.fetchMultipartUploadURLs(uploadPartCount);
-    if (multipartUploadURLs.partURLs.length != uploadPartCount) {
-        throw new Error("Unexpected multipart upload URL count");
-    }
+    const multipartUploadURLs =
+        await uploadService.fetchMultipartUploadURLs(uploadPartCount);
 
     const percentPerPart = maxPercent / uploadPartCount;
     let fileSize = 0;
@@ -1568,10 +2108,10 @@ const uploadStreamUsingMultipart = async (
         const partNumber = index + 1;
         const partData = await nextMultipartUploadPart(streamReader);
         fileSize += partData.length;
+
         const checksum = deferPartChecksums
             ? computeMd5Base64(partData)
             : undefined;
-
         const eTag = !isCFUploadProxyDisabled
             ? await putFilePartViaWorker(
                   partUploadURL,
@@ -1608,6 +2148,11 @@ const uploadStreamUsingMultipart = async (
     return { objectKey: multipartUploadURLs.objectKey, fileSize };
 };
 
+/**
+ * Construct byte arrays, up to 20 MB each, containing the contents of (up to)
+ * the next 5 {@link streamEncryptionChunkSize} chunks read from the given
+ * {@link streamReader}.
+ */
 const nextMultipartUploadPart = async (
     streamReader: ReadableStreamDefaultReader<Uint8Array>,
 ) => {
@@ -1620,6 +2165,9 @@ const nextMultipartUploadPart = async (
     return mergeUint8Arrays(chunks);
 };
 
+/**
+ * Finalize an upload by creating an {@link EnteFile} on remote.
+ */
 const createRemoteFile = async (
     newFileRequest: PostEnteFileRequest,
     uploadContext: UploadContext,

--- a/web/packages/new/photos/services/collection.ts
+++ b/web/packages/new/photos/services/collection.ts
@@ -3,6 +3,7 @@ import { blobCache } from "ente-base/blob-cache";
 import { boxSeal, encryptBox, generateKey } from "ente-base/crypto";
 import { haveWindow } from "ente-base/env";
 import { authenticatedRequestHeaders, ensureOk } from "ente-base/http";
+import log from "ente-base/log";
 import { apiURL } from "ente-base/origins";
 import { ensureMasterKeyFromSession } from "ente-base/session";
 import { groupFilesByCollectionID } from "ente-gallery/utils/file";
@@ -36,11 +37,19 @@ import { batch, splitByPredicate } from "ente-utils/array";
 import { z } from "zod";
 import { batched, type UpdateMagicMetadataRequest } from "./file";
 import {
+    ensureV2FileManifest,
+    hasCompletedV2RemoteFileSync,
+    markV2RemoteFileSyncComplete,
+    mergeCollectionFilesForCollection,
+    prepareV2RemoteFileSync,
+    removeCollectionFilesForCollections,
     removeCollectionIDLastSyncTime,
     saveCollectionFiles,
+    saveCollectionFilesForCollection,
     saveCollectionLastSyncTime,
     saveCollections,
     saveCollectionsUpdationTime,
+    savedCollectionFileCollectionIDs,
     savedCollectionFiles,
     savedCollectionLastSyncTime,
     savedCollections,
@@ -270,7 +279,9 @@ export const pullCollectionFiles = async (
 
             files = otherFiles.concat([...thisCollectionFilesByID.values()]);
 
-            await saveCollectionFiles(files);
+            await saveCollectionFilesForCollection(collection.id, [
+                ...thisCollectionFilesByID.values(),
+            ]);
             await saveCollectionLastSyncTime(collection, sinceTime);
             onSetCollectionFiles?.(files);
             didUpdateFiles = true;
@@ -285,6 +296,130 @@ export const pullCollectionFiles = async (
     return didUpdateFiles;
 };
 
+export interface CollectionFileChange {
+    collectionID: number;
+    updatedFiles: EnteFile[];
+    deletedFileIDs: number[];
+    collectionDeleted?: boolean;
+}
+
+/** Pull collection diffs without materializing existing library files. */
+export const pullCollectionFileDiffs = async (
+    collections: Collection[],
+    onChange?: (change: CollectionFileChange) => void,
+    mode: "incremental" | "bootstrap" = "incremental",
+) => {
+    let didUpdateFiles = false;
+    let changedCollections = 0;
+    let pages = 0;
+    let updatedFileCount = 0;
+    let deletedFileCount = 0;
+    let skippedAtCursor = 0;
+    let zeroCursorCollections = 0;
+    let emptyFirstPageCollections = 0;
+    const reconciliationComplete = await hasCompletedV2RemoteFileSync();
+    const bootstrap = !reconciliationComplete;
+    const notifyChange =
+        bootstrap || mode == "bootstrap" ? undefined : onChange;
+    if (bootstrap) await prepareV2RemoteFileSync();
+    const collectionIDs = new Set(
+        collections.map((collection) => collection.id),
+    );
+    const staleCollectionIDs = (
+        await savedCollectionFileCollectionIDs()
+    ).filter((id) => !collectionIDs.has(id));
+
+    await removeCollectionFilesForCollections(staleCollectionIDs);
+    await Promise.all(
+        staleCollectionIDs.map((collectionID) =>
+            removeCollectionIDLastSyncTime(collectionID),
+        ),
+    );
+    for (const collectionID of staleCollectionIDs) {
+        notifyChange?.({
+            collectionID,
+            updatedFiles: [],
+            deletedFileIDs: [],
+            collectionDeleted: true,
+        });
+        didUpdateFiles = true;
+    }
+
+    for (const collection of collections) {
+        let sinceTime = bootstrap
+            ? 0
+            : ((await savedCollectionLastSyncTime(collection)) ?? 0);
+        if (!bootstrap && sinceTime == collection.updationTime) {
+            skippedAtCursor++;
+            continue;
+        }
+        if (sinceTime == 0) zeroCursorCollections++;
+        changedCollections++;
+
+        let firstPage = true;
+        while (true) {
+            const { diff, hasMore } = await getCollectionDiff(
+                collection.id,
+                sinceTime,
+            );
+            pages++;
+            if (!diff.length) {
+                if (firstPage && sinceTime == 0) emptyFirstPageCollections++;
+                break;
+            }
+            firstPage = false;
+
+            const updatedFiles: EnteFile[] = [];
+            const deletedFileIDs: number[] = [];
+            for (const change of diff) {
+                sinceTime = Math.max(sinceTime, change.updationTime);
+                if (change.isDeleted) {
+                    deletedFileIDs.push(change.id);
+                } else {
+                    updatedFiles.push(
+                        await decryptRemoteFile(change, collection.key),
+                    );
+                }
+            }
+
+            const merged = await mergeCollectionFilesForCollection(
+                collection.id,
+                updatedFiles,
+                deletedFileIDs,
+            );
+            for (const file of merged.updatedFiles)
+                await clearCachedThumbnail(file);
+            updatedFileCount += merged.updatedFiles.length;
+            deletedFileCount += merged.deletedFileIDs.length;
+            await saveCollectionLastSyncTime(collection, sinceTime);
+            if (
+                merged.updatedFiles.length > 0 ||
+                merged.deletedFileIDs.length > 0
+            ) {
+                notifyChange?.({
+                    collectionID: collection.id,
+                    updatedFiles: merged.updatedFiles,
+                    deletedFileIDs: merged.deletedFileIDs,
+                });
+                didUpdateFiles = true;
+            }
+
+            if (!hasMore) break;
+        }
+
+        await saveCollectionLastSyncTime(collection, collection.updationTime);
+    }
+
+    if (bootstrap) {
+        await ensureV2FileManifest();
+        await markV2RemoteFileSyncComplete();
+    }
+    log.info(
+        `Incremental file pull: mode=${mode}, bootstrap=${bootstrap}, marker=${reconciliationComplete}, ${collections.length} collections, ${changedCollections} changed, ${skippedAtCursor} skipped-at-cursor, ${zeroCursorCollections} zero-cursor, ${emptyFirstPageCollections} empty-first-page, ${pages} diff pages, ${updatedFileCount} updated, ${deletedFileCount} deleted`,
+    );
+    return didUpdateFiles;
+};
+
 const getCollectionDiff = async (collectionID: number, sinceTime: number) => {
     const res = await fetch(
         await apiURL("/collections/v2/diff", { collectionID, sinceTime }),
@@ -292,6 +427,11 @@ const getCollectionDiff = async (collectionID: number, sinceTime: number) => {
     );
     ensureOk(res);
     return FileDiffResponse.parse(await res.json());
+};
+
+const clearCachedThumbnail = async (file: EnteFile) => {
+    const thumbnailCache = await blobCache("thumbs");
+    await thumbnailCache.delete(file.id.toString());
 };
 
 const clearCachedThumbnailIfContentChanged = async (

--- a/web/packages/new/photos/services/file.ts
+++ b/web/packages/new/photos/services/file.ts
@@ -34,10 +34,16 @@ export const computeAllCollectionFilesFromSaved = async () =>
 export const computeNormalCollectionFilesFromSaved = async (
     currentUserID?: number,
 ) => {
+    const collectionFiles = await savedCollectionFiles();
+    return filterNormalCollectionFiles(collectionFiles, currentUserID);
+};
+
+const filterNormalCollectionFiles = async (
+    collectionFiles: EnteFile[],
+    currentUserID?: number,
+) => {
     const hiddenCollections = await savedHiddenCollections(currentUserID);
     const hiddenCollectionIDs = new Set(hiddenCollections.map((c) => c.id));
-
-    const collectionFiles = await savedCollectionFiles();
     const hiddenFileIDs = new Set(
         collectionFiles
             .filter((f) => hiddenCollectionIDs.has(f.collectionID))

--- a/web/packages/new/photos/services/ml/index.ts
+++ b/web/packages/new/photos/services/ml/index.ts
@@ -170,6 +170,10 @@ export const pullMLStatus = async () => {
 
 export const mlSync = async (reason: ClusterFacesReason = "ml-sync") => {
     if (!_state.isMLEnabled) return;
+    if (mlWorkDeferred) {
+        pendingMLSyncReason = reason;
+        return;
+    }
     if (_state.isSyncing) return;
     _state.isSyncing = true;
 
@@ -189,6 +193,11 @@ export const mlSync = async (reason: ClusterFacesReason = "ml-sync") => {
 };
 
 const updateClustersAndPeople = async (reason: ClusterFacesReason) => {
+    if (mlWorkDeferred) {
+        clusterUpdatePending = true;
+        return;
+    }
+
     const masterKey = await ensureMasterKeyFromSession();
 
     await pullUserEntities("cgroup", masterKey);
@@ -204,13 +213,51 @@ const debounceUpdateClustersAndPeople = pDebounce(
     30 * 1e3,
 );
 
+let clusterUpdatesDeferred = false;
+let clusterUpdatePending = false;
+let mlWorkDeferred = false;
+let pendingMLSyncReason: ClusterFacesReason | undefined;
+let pendingMLSyncTimer: ReturnType<typeof setTimeout> | undefined;
+
+// Let gallery reducer state settle before starting a deferred full-library pass.
+const pendingMLSyncDelay = 1000;
+const schedulePendingMLSync = () => {
+    if (mlWorkDeferred || !pendingMLSyncReason || pendingMLSyncTimer) return;
+
+    pendingMLSyncTimer = setTimeout(() => {
+        pendingMLSyncTimer = undefined;
+        if (mlWorkDeferred || !pendingMLSyncReason) return;
+
+        const reason = pendingMLSyncReason;
+        pendingMLSyncReason = undefined;
+        void mlSync(reason);
+    }, pendingMLSyncDelay);
+};
+
+/** Defer expensive ML work while folder-watch work is active. */
+export const setMLClusterUpdatesDeferred = (deferred: boolean) => {
+    if (deferred && !mlWorkDeferred) void terminateMLWorker();
+    mlWorkDeferred = deferred;
+    clusterUpdatesDeferred = deferred;
+    if (!deferred && clusterUpdatePending) {
+        clusterUpdatePending = false;
+        void debounceUpdateClustersAndPeople("live-upload-index");
+    }
+    if (!deferred) schedulePendingMLSync();
+};
+
 const workerDidLoseElectronPort = () => {
     log.error("Discarding the ML worker since its utility process exited");
     void terminateMLWorker();
 };
 
-const workerDidUnawaitedIndex = () =>
+const workerDidUnawaitedIndex = () => {
+    if (clusterUpdatesDeferred) {
+        clusterUpdatePending = true;
+        return;
+    }
     void debounceUpdateClustersAndPeople("live-upload-index");
+};
 
 export const indexNewUpload = (
     file: EnteFile,

--- a/web/packages/new/photos/services/photos-fdb.ts
+++ b/web/packages/new/photos/services/photos-fdb.ts
@@ -3,7 +3,7 @@ import {
     LocalEnteFile,
     localForage,
     LocalTimestamp,
-    transformFilesIfNeeded,
+    transformFileIfNeeded,
 } from "ente-gallery/services/files-db";
 import type { Collection } from "ente-media/collection";
 import type { EnteFile } from "ente-media/file";
@@ -44,43 +44,543 @@ export const saveTrashItemCollectionKeys = async (
     await localForage.setItem("deleted-collection", cks);
 };
 
-export const savedCollectionFiles = async (): Promise<EnteFile[]> => {
-    // Zod parsing 200k self-written records costs about a second.
-    let files = (await localForage.getItem<EnteFile[]>("files")) ?? [];
+const filesManifestKey = "files-v2:manifest";
+const filesLegacyIgnoredKey = "files-v2:legacy-ignored";
+const filesV2SyncCompleteKey = "files-v2:sync:v2:complete";
+const filesChunkSize = 512;
 
-    // Previously hidden files were stored separately. If that key is present,
-    // also read those files, and migrate them (save the concatenation to disk
-    // and delete the corresponding DB key).
-    //
-    // This migration was added Jun 2025, v1.7.14-beta (tag: Migration).
-    const previousHiddenFiles =
-        await localForage.getItem<EnteFile[]>("hidden-files");
-    if (previousHiddenFiles) {
-        files = files.concat(previousHiddenFiles);
-        await saveCollectionFiles(files);
-        await localForage.removeItem("hidden-files");
-        await localForage.removeItem("hidden-collection-ids");
+const FileCollectionManifest = z.object({
+    generation: z.string(),
+    chunkCount: z.number().int().nonnegative(),
+});
+
+const FilesManifest = z.object({
+    version: z.literal(2),
+    collections: z.record(z.string(), FileCollectionManifest),
+});
+
+type FileCollectionManifest = z.infer<typeof FileCollectionManifest>;
+type FilesManifest = z.infer<typeof FilesManifest>;
+
+let fileGeneration = 0;
+
+const newFileGeneration = () =>
+    `${Date.now()}-${fileGeneration++}-${globalThis.crypto.randomUUID()}`;
+
+const fileChunkKey = (
+    collectionID: number,
+    generation: string,
+    chunkIndex: number,
+) => `files-v2:${generation}:collection:${collectionID}:chunk:${chunkIndex}`;
+
+const readFilesManifest = async (): Promise<FilesManifest | undefined> => {
+    const parsed = FilesManifest.safeParse(
+        await localForage.getItem(filesManifestKey),
+    );
+    return parsed.success ? parsed.data : undefined;
+};
+
+const generationReaders = new Map<string, number>();
+const retiredGenerations = new Map<
+    string,
+    { collectionID: number; entry: FileCollectionManifest }
+>();
+
+const generationKey = (collectionID: number, generation: string) =>
+    `${collectionID}:${generation}`;
+
+const acquireGenerationReaders = (manifest: FilesManifest) => {
+    const keys = Object.entries(manifest.collections).map(([id, entry]) =>
+        generationKey(Number(id), entry.generation),
+    );
+    for (const key of keys)
+        generationReaders.set(key, (generationReaders.get(key) ?? 0) + 1);
+    return async () => {
+        for (const key of keys) {
+            const readers = (generationReaders.get(key) ?? 1) - 1;
+            if (readers > 0) generationReaders.set(key, readers);
+            else {
+                generationReaders.delete(key);
+                const retired = retiredGenerations.get(key);
+                if (retired) {
+                    retiredGenerations.delete(key);
+                    await removeCollectionChunks(
+                        retired.collectionID,
+                        retired.entry,
+                    );
+                }
+            }
+        }
+    };
+};
+
+const retireCollectionChunks = async (
+    collectionID: number,
+    entry: FileCollectionManifest,
+) => {
+    const key = generationKey(collectionID, entry.generation);
+    if ((generationReaders.get(key) ?? 0) > 0) {
+        retiredGenerations.set(key, { collectionID, entry });
+        return;
+    }
+    await removeCollectionChunks(collectionID, entry);
+};
+
+const ignoreLegacyFilesIfNeeded = async () => {
+    const legacyFilesIgnored = await localForage.getItem(filesLegacyIgnoredKey);
+    const keys = await localForage.keys();
+    const hasLegacyFiles =
+        keys.includes("files") || keys.includes("hidden-files");
+    const keysToRemove = keys.filter(
+        (key) =>
+            /^-?\d+-time$/.test(key) ||
+            /^files-v2:sync:v\d+:collection:-?\d+$/.test(key) ||
+            /^files-v2:sync:v\d+:complete$/.test(key) ||
+            key == "files" ||
+            key == "hidden-files" ||
+            key == "files-v2:remote-reconciled" ||
+            key == "hidden-collection-ids",
+    );
+    if (!legacyFilesIgnored && !hasLegacyFiles && keysToRemove.length == 0)
+        return;
+
+    // Publish the marker only after cleanup succeeds so a failed cleanup is
+    // retried on the next startup. Also clear stale sync times when a previous
+    // migration marker exists but the v2 manifest is gone or invalid.
+    await Promise.all(keysToRemove.map((key) => localForage.removeItem(key)));
+    if (!legacyFilesIgnored)
+        await localForage.setItem(filesLegacyIgnoredKey, true);
+};
+
+const writeCollectionChunks = async (
+    collectionID: number,
+    files: EnteFile[],
+): Promise<FileCollectionManifest> => {
+    const generation = newFileGeneration();
+    const chunkCount = Math.ceil(files.length / filesChunkSize);
+
+    for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++) {
+        const start = chunkIndex * filesChunkSize;
+        const chunk = files
+            .slice(start, start + filesChunkSize)
+            .map(transformFileIfNeeded);
+        await localForage.setItem(
+            fileChunkKey(collectionID, generation, chunkIndex),
+            chunk,
+        );
     }
 
-    return transformFilesIfNeeded(files);
+    return { generation, chunkCount };
+};
+
+const removeCollectionChunks = async (
+    collectionID: number,
+    entry: FileCollectionManifest,
+) => {
+    for (let chunkIndex = 0; chunkIndex < entry.chunkCount; chunkIndex++)
+        await localForage.removeItem(
+            fileChunkKey(collectionID, entry.generation, chunkIndex),
+        );
+};
+
+let orphanSweepQueued = false;
+const ensureOrphanChunksSwept = async () => {
+    if (orphanSweepQueued) {
+        await fileManifestWrite;
+        return;
+    }
+    orphanSweepQueued = true;
+    const sweep = fileManifestWrite.then(async () => {
+        const manifest = await readFilesManifest();
+        if (!manifest) return;
+
+        const liveKeys = new Set(
+            Object.entries(manifest.collections).flatMap(([id, entry]) =>
+                Array.from({ length: entry.chunkCount }, (_, index) =>
+                    fileChunkKey(Number(id), entry.generation, index),
+                ),
+            ),
+        );
+        const chunkPattern = /^files-v2:(.+):collection:(-?\d+):chunk:\d+$/;
+        const keys = await localForage.keys();
+        await Promise.all(
+            keys
+                .filter((key) => {
+                    if (liveKeys.has(key)) return false;
+                    const match = chunkPattern.exec(key);
+                    if (!match) return false;
+                    const [, generation, collectionID] = match;
+                    if (!generation || !collectionID) return false;
+                    return !retiredGenerations.has(
+                        generationKey(Number(collectionID), generation),
+                    );
+                })
+                .map((key) => localForage.removeItem(key)),
+        );
+    });
+    fileManifestWrite = sweep.then(
+        () => {
+            orphanSweepQueued = false;
+        },
+        () => {
+            orphanSweepQueued = false;
+        },
+    );
+    await sweep;
+};
+
+const saveCollectionFileGroupsUnsafe = async (
+    groups: ReadonlyMap<number, EnteFile[]>,
+    replaceAll: boolean,
+) => {
+    const previousManifest = await readFilesManifest();
+    const previousCollections = previousManifest?.collections ?? {};
+    const nextCollections: Record<string, FileCollectionManifest> = replaceAll
+        ? {}
+        : { ...previousCollections };
+
+    for (const [collectionID, files] of groups) {
+        const key = collectionID.toString();
+        if (files.length == 0) Reflect.deleteProperty(nextCollections, key);
+        else
+            nextCollections[key] = await writeCollectionChunks(
+                collectionID,
+                files,
+            );
+    }
+
+    await localForage.setItem(filesManifestKey, {
+        version: 2,
+        collections: nextCollections,
+    });
+
+    for (const [collectionID, previousEntry] of Object.entries(
+        previousCollections,
+    )) {
+        const nextEntry = nextCollections[collectionID];
+        if (nextEntry?.generation != previousEntry.generation)
+            await retireCollectionChunks(Number(collectionID), previousEntry);
+    }
+};
+
+let fileManifestWrite = Promise.resolve();
+
+const enqueueFileManifestWrite = <T>(operation: () => Promise<T>) => {
+    const write = fileManifestWrite.then(operation);
+    fileManifestWrite = write.then(
+        () => undefined,
+        () => undefined,
+    );
+    return write;
+};
+
+const saveCollectionFileGroups = (
+    groups: ReadonlyMap<number, EnteFile[]>,
+    replaceAll: boolean,
+) =>
+    enqueueFileManifestWrite(() =>
+        saveCollectionFileGroupsUnsafe(groups, replaceAll),
+    );
+
+export const prepareV2RemoteFileSync = () =>
+    enqueueFileManifestWrite(ignoreLegacyFilesIfNeeded);
+
+const collectionFileChunks = async function* (manifest: FilesManifest) {
+    const release = acquireGenerationReaders(manifest);
+    try {
+        for (const [collectionID, entry] of Object.entries(
+            manifest.collections,
+        )) {
+            for (
+                let chunkIndex = 0;
+                chunkIndex < entry.chunkCount;
+                chunkIndex++
+            ) {
+                const chunk = await localForage.getItem<EnteFile[]>(
+                    fileChunkKey(
+                        Number(collectionID),
+                        entry.generation,
+                        chunkIndex,
+                    ),
+                );
+                if (chunk) {
+                    for (
+                        let start = 0;
+                        start < chunk.length;
+                        start += filesChunkSize
+                    )
+                        yield chunk
+                            .slice(start, start + filesChunkSize)
+                            .map(transformFileIfNeeded);
+                }
+            }
+        }
+    } finally {
+        await release();
+    }
+};
+
+const loadSavedCollectionFiles = async (
+    manifest: FilesManifest | undefined,
+): Promise<EnteFile[]> => {
+    if (!manifest) {
+        // Never deserialize the legacy monolithic record. The next remote pull
+        // starts from scratch after its per-collection sync times are cleared.
+        await ignoreLegacyFilesIfNeeded();
+        return [];
+    }
+
+    const files: EnteFile[] = [];
+    for await (const chunk of collectionFileChunks(manifest))
+        files.push(...chunk);
+    return files;
+};
+
+export const savedCollectionFileChunks = async function* () {
+    await ensureOrphanChunksSwept();
+    await fileManifestWrite;
+    const manifest = await readFilesManifest();
+    if (!manifest) {
+        await ignoreLegacyFilesIfNeeded();
+        return;
+    }
+
+    for await (const chunk of collectionFileChunks(manifest)) yield chunk;
+};
+
+export const savedCollectionFileCollectionIDs = async (): Promise<number[]> => {
+    await fileManifestWrite;
+    const manifest = await readFilesManifest();
+    return manifest ? Object.keys(manifest.collections).map(Number) : [];
+};
+
+export const savedCollectionFileChunksForCollections = async function* (
+    collectionIDs: number[],
+) {
+    await ensureOrphanChunksSwept();
+    await fileManifestWrite;
+    const manifest = await readFilesManifest();
+    if (!manifest) return;
+
+    const requestedIDs = new Set(collectionIDs.map(String));
+    const collections = Object.fromEntries(
+        Object.entries(manifest.collections).filter(([id]) =>
+            requestedIDs.has(id),
+        ),
+    );
+    for await (const chunk of collectionFileChunks({ version: 2, collections }))
+        yield chunk;
+};
+
+export const savedCollectionFilesForCollection = async (
+    collectionID: number,
+): Promise<EnteFile[]> => {
+    const files: EnteFile[] = [];
+    for await (const chunk of savedCollectionFileChunksForCollections([
+        collectionID,
+    ]))
+        files.push(...chunk);
+    return files;
+};
+
+export const savedCollectionFileByID = async (
+    collectionID: number,
+    fileID: number,
+): Promise<EnteFile | undefined> => {
+    for await (const chunk of savedCollectionFileChunksForCollections([
+        collectionID,
+    ])) {
+        const file = chunk.find(({ id }) => id == fileID);
+        if (file) return file;
+    }
+    return undefined;
+};
+
+export const savedCollectionFiles = async (): Promise<EnteFile[]> => {
+    await ensureOrphanChunksSwept();
+    await fileManifestWrite;
+    const manifest = await readFilesManifest();
+    if (!manifest) return loadSavedCollectionFiles(manifest);
+
+    return loadSavedCollectionFiles(manifest);
 };
 
 export const saveCollectionFiles = async (files: EnteFile[]) => {
-    await localForage.setItem("files", transformFilesIfNeeded(files));
+    const groups = new Map<number, EnteFile[]>();
+    for (const file of files) {
+        const collectionFiles = groups.get(file.collectionID) ?? [];
+        collectionFiles.push(file);
+        groups.set(file.collectionID, collectionFiles);
+    }
+    await saveCollectionFileGroups(groups, true);
 };
 
+export const saveCollectionFilesForCollection = async (
+    collectionID: number,
+    files: EnteFile[],
+) => {
+    await saveCollectionFileGroups(new Map([[collectionID, files]]), false);
+};
+
+const mergeCollectionFilesForCollectionUnsafe = async (
+    collectionID: number,
+    updatedFiles: EnteFile[],
+    deletedFileIDs: number[],
+) => {
+    const manifest = await readFilesManifest();
+    const key = collectionID.toString();
+    const previousEntry = manifest?.collections[key];
+    const generation = newFileGeneration();
+    const updatedByID = new Map(updatedFiles.map((file) => [file.id, file]));
+    const deletedIDs = new Set(deletedFileIDs);
+    let chunkIndex = 0;
+    let pendingFiles: EnteFile[] = [];
+    const changedFiles: EnteFile[] = [];
+    const removedFileIDs: number[] = [];
+
+    const flush = async () => {
+        if (pendingFiles.length == 0) return;
+        await localForage.setItem(
+            fileChunkKey(collectionID, generation, chunkIndex++),
+            pendingFiles.map(transformFileIfNeeded),
+        );
+        pendingFiles = [];
+    };
+
+    const append = async (file: EnteFile) => {
+        if (deletedIDs.has(file.id)) {
+            removedFileIDs.push(file.id);
+            updatedByID.delete(file.id);
+            return;
+        }
+
+        const replacement = updatedByID.get(file.id);
+        if (replacement) {
+            if (replacement.updationTime != file.updationTime)
+                changedFiles.push(replacement);
+            pendingFiles.push(replacement);
+            updatedByID.delete(file.id);
+        } else {
+            pendingFiles.push(file);
+        }
+        if (pendingFiles.length == filesChunkSize) await flush();
+    };
+
+    if (previousEntry) {
+        for await (const chunk of collectionFileChunks({
+            version: 2,
+            collections: { [key]: previousEntry },
+        }))
+            for (const file of chunk) await append(file);
+    }
+
+    for (const file of updatedByID.values()) {
+        changedFiles.push(file);
+        pendingFiles.push(file);
+        if (pendingFiles.length == filesChunkSize) await flush();
+    }
+    await flush();
+
+    const nextCollections = { ...(manifest?.collections ?? {}) };
+    if (chunkIndex == 0) Reflect.deleteProperty(nextCollections, key);
+    else nextCollections[key] = { generation, chunkCount: chunkIndex };
+
+    await localForage.setItem(filesManifestKey, {
+        version: 2,
+        collections: nextCollections,
+    });
+    if (previousEntry)
+        await retireCollectionChunks(collectionID, previousEntry);
+    return { updatedFiles: changedFiles, deletedFileIDs: removedFileIDs };
+};
+
+export const mergeCollectionFilesForCollection = (
+    collectionID: number,
+    updatedFiles: EnteFile[],
+    deletedFileIDs: number[],
+) =>
+    enqueueFileManifestWrite(() =>
+        mergeCollectionFilesForCollectionUnsafe(
+            collectionID,
+            updatedFiles,
+            deletedFileIDs,
+        ),
+    );
+
+const invalidateV2RemoteFileSync = () =>
+    localForage.removeItem(filesV2SyncCompleteKey);
+
+export const hasCompletedV2RemoteFileSync = async () => {
+    await fileManifestWrite;
+    if ((await localForage.getItem(filesV2SyncCompleteKey)) !== true)
+        return false;
+
+    const manifest = await readFilesManifest();
+    if (!manifest) {
+        await invalidateV2RemoteFileSync();
+        return false;
+    }
+
+    for (const [collectionID, entry] of Object.entries(manifest.collections)) {
+        for (let chunkIndex = 0; chunkIndex < entry.chunkCount; chunkIndex++) {
+            const chunk = await localForage.getItem<unknown>(
+                fileChunkKey(
+                    Number(collectionID),
+                    entry.generation,
+                    chunkIndex,
+                ),
+            );
+            if (!Array.isArray(chunk)) {
+                await invalidateV2RemoteFileSync();
+                return false;
+            }
+        }
+    }
+
+    return true;
+};
+
+export const ensureV2FileManifest = () =>
+    enqueueFileManifestWrite(async () => {
+        if (!(await readFilesManifest()))
+            await localForage.setItem(filesManifestKey, {
+                version: 2,
+                collections: {},
+            });
+    });
+
+export const markV2RemoteFileSyncComplete = () =>
+    enqueueFileManifestWrite(() =>
+        localForage.setItem(filesV2SyncCompleteKey, true),
+    );
+
+export const removeCollectionFilesForCollections = async (
+    collectionIDs: number[],
+) => {
+    if (collectionIDs.length == 0) return;
+    await saveCollectionFileGroups(
+        new Map(collectionIDs.map((id) => [id, [] as EnteFile[]])),
+        false,
+    );
+};
+
+const v2CollectionSyncTimeKey = (collectionID: number) =>
+    `files-v2:sync:v2:collection:${collectionID}`;
+
 export const savedCollectionLastSyncTime = async (collection: Collection) =>
-    LocalTimestamp.parse(await localForage.getItem(`${collection.id}-time`));
+    LocalTimestamp.parse(
+        await localForage.getItem(v2CollectionSyncTimeKey(collection.id)),
+    );
 
 export const saveCollectionLastSyncTime = async (
     collection: Collection,
     time: number,
 ) => {
-    await localForage.setItem(`${collection.id}-time`, time);
+    await localForage.setItem(v2CollectionSyncTimeKey(collection.id), time);
 };
 
 export const removeCollectionIDLastSyncTime = async (collectionID: number) => {
-    await localForage.removeItem(`${collectionID}-time`);
+    await localForage.removeItem(v2CollectionSyncTimeKey(collectionID));
 };
 
 const LocalTrashItem = z.looseObject({


### PR DESCRIPTION
## Problem

Large desktop folder-watch uploads could exhaust renderer memory and leave gallery state inconsistent. 

## Fix

- Shard local persistence into validated manifests/chunks with zero-cursor recovery.
- Bound upload, duplicate lookup, watcher, and gallery memory.
- Use one bounded background gallery hydrator.
- Preserve upload retries, progress, deduplication, and watcher synchronization.
- Refresh gallery once after watcher uploads complete.
