### PR TITLE
[mobile][photos] Preserve device trash local IDs

### DIFF
--- a/mobile/apps/photos/lib/db/trash_db.dart
+++ b/mobile/apps/photos/lib/db/trash_db.dart
@@ -182,13 +182,13 @@ class TrashDB {
     );
   }
 
-  Future<void> markTrashedOnDevice(Map<int, String> localIDs) async {
+  Future<void> markTrashedOnDevice(List<(int, String)> localIDs) async {
     if (localIDs.isEmpty) return;
     final db = await instance.database;
     await db.transaction((transaction) async {
-      for (final entries in localIDs.entries.toList().chunks(400)) {
+      for (final entries in localIDs.chunks(400)) {
         final batch = transaction.batch();
-        for (final entry in entries) {
+        for (final (uploadedFileID, localID) in entries) {
           batch.rawInsert(
             '''
           INSERT INTO $tableName (
@@ -204,7 +204,7 @@ class TrashDB {
             $columnLocalID = excluded.$columnLocalID,
             $columnIsTrashedOnDevice = 1
         ''',
-            [entry.key, entry.value],
+            [uploadedFileID, localID],
           );
         }
         await batch.commit(noResult: true);

--- a/mobile/apps/photos/lib/db/trash_db.dart
+++ b/mobile/apps/photos/lib/db/trash_db.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
@@ -123,39 +124,31 @@ class TrashDB {
     final startTime = DateTime.now();
     final db = await instance.database;
     await db.transaction((transaction) async {
-      final uploadedFileIDs = trashFiles
-          .map((trash) => trash.uploadedFileID!)
-          .join(',');
-      final rowsTrashedOnDevice = await transaction.query(
-        tableName,
-        columns: [columnUploadedFileID, columnLocalID],
-        where:
-            '$columnIsTrashedOnDevice = 1 AND $columnUploadedFileID IN ($uploadedFileIDs)',
-      );
-      final localIDsTrashedOnDevice = <int, String?>{
-        for (final row in rowsTrashedOnDevice)
+      final localIDs = <int, String?>{
+        for (final row in await transaction.query(
+          tableName,
+          columns: [columnUploadedFileID, columnLocalID],
+          where:
+              '$columnIsTrashedOnDevice = 1 AND $columnUploadedFileID '
+              'IN (${trashFiles.map((trash) => trash.uploadedFileID!).join(',')})',
+        ))
           row[columnUploadedFileID] as int: row[columnLocalID] as String?,
       };
-      var batch = transaction.batch();
-      int batchCounter = 0;
-      for (TrashFile trash in trashFiles) {
-        if (localIDsTrashedOnDevice.containsKey(trash.uploadedFileID)) {
-          trash.localID = localIDsTrashedOnDevice[trash.uploadedFileID];
-          trash.isTrashedOnDevice = true;
+      for (final trashFileBatch in trashFiles.chunks(400)) {
+        final batch = transaction.batch();
+        for (final trash in trashFileBatch) {
+          if (localIDs.containsKey(trash.uploadedFileID)) {
+            trash.localID = localIDs[trash.uploadedFileID];
+            trash.isTrashedOnDevice = true;
+          }
+          batch.insert(
+            tableName,
+            _getRowForTrash(trash),
+            conflictAlgorithm: ConflictAlgorithm.replace,
+          );
         }
-        if (batchCounter == 400) {
-          await batch.commit(noResult: true);
-          batch = transaction.batch();
-          batchCounter = 0;
-        }
-        batch.insert(
-          tableName,
-          _getRowForTrash(trash),
-          conflictAlgorithm: ConflictAlgorithm.replace,
-        );
-        batchCounter++;
+        await batch.commit(noResult: true);
       }
-      await batch.commit(noResult: true);
     });
     final endTime = DateTime.now();
     final duration = Duration(
@@ -189,13 +182,11 @@ class TrashDB {
     );
   }
 
-  Future<void> insertTrashedOnDevice(
-    Map<int, String> localIDsByUploadedID,
-  ) async {
-    if (localIDsByUploadedID.isEmpty) return;
+  Future<void> markTrashedOnDevice(Map<int, String> localIDs) async {
+    if (localIDs.isEmpty) return;
     final db = await instance.database;
     final batch = db.batch();
-    for (final entry in localIDsByUploadedID.entries) {
+    for (final entry in localIDs.entries) {
       batch.rawInsert(
         '''
           INSERT INTO $tableName (

--- a/mobile/apps/photos/lib/db/trash_db.dart
+++ b/mobile/apps/photos/lib/db/trash_db.dart
@@ -14,7 +14,7 @@ import 'package:sqflite/sqflite.dart';
 // during restore, all file attributes will be fetched & stored as required.
 class TrashDB {
   static const _databaseName = "ente.trash.db";
-  static const _databaseVersion = 1;
+  static const _databaseVersion = 2;
   static final Logger _logger = Logger("TrashDB");
   static const tableName = 'trash';
 
@@ -31,6 +31,7 @@ class TrashDB {
 
   static const columnCreationTime = 'creation_time';
   static const columnLocalID = 'local_id';
+  static const columnIsTrashedOnDevice = 'is_trashed_on_device';
 
   // standard file metadata, which isn't editable
   static const columnFileMetadata = 'file_metadata';
@@ -55,6 +56,7 @@ class TrashDB {
           $columnThumbnailDecryptionHeader TEXT,
           $columnUpdationTime INTEGER,
           $columnLocalID TEXT,
+          $columnIsTrashedOnDevice INTEGER NOT NULL DEFAULT 0,
           $columnCreationTime INTEGER NOT NULL,
           $columnFileMetadata TEXT DEFAULT '{}',
           $columnMMdEncodedJson TEXT DEFAULT '{}',
@@ -66,6 +68,14 @@ class TrashDB {
       CREATE INDEX IF NOT EXISTS delete_by_time_index ON $tableName($columnTrashDeleteBy);
       CREATE INDEX IF NOT EXISTS updated_at_time_index ON $tableName($columnTrashUpdatedAt);
       ''');
+  }
+
+  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    if (oldVersion < 2) {
+      await db.execute(
+        'ALTER TABLE $tableName ADD COLUMN $columnIsTrashedOnDevice INTEGER NOT NULL DEFAULT 0',
+      );
+    }
   }
 
   TrashDB._privateConstructor();
@@ -91,6 +101,7 @@ class TrashDB {
       path,
       version: _databaseVersion,
       onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
     );
   }
 
@@ -108,11 +119,29 @@ class TrashDB {
   }
 
   Future<void> insertMultiple(List<TrashFile> trashFiles) async {
+    if (trashFiles.isEmpty) return;
     final startTime = DateTime.now();
     final db = await instance.database;
+    final uploadedFileIDs = trashFiles
+        .map((trash) => trash.uploadedFileID!)
+        .join(',');
+    final rowsTrashedOnDevice = await db.query(
+      tableName,
+      columns: [columnUploadedFileID, columnLocalID],
+      where:
+          '$columnIsTrashedOnDevice = 1 AND $columnUploadedFileID IN ($uploadedFileIDs)',
+    );
+    final localIDsTrashedOnDevice = <int, String?>{
+      for (final row in rowsTrashedOnDevice)
+        row[columnUploadedFileID] as int: row[columnLocalID] as String?,
+    };
     var batch = db.batch();
     int batchCounter = 0;
     for (TrashFile trash in trashFiles) {
+      if (localIDsTrashedOnDevice.containsKey(trash.uploadedFileID)) {
+        trash.localID = localIDsTrashedOnDevice[trash.uploadedFileID];
+        trash.isTrashedOnDevice = true;
+      }
       if (batchCounter == 400) {
         await batch.commit(noResult: true);
         batch = db.batch();
@@ -156,6 +185,22 @@ class TrashDB {
       where: '$columnUploadedFileID = ?',
       whereArgs: [file.uploadedFileID],
     );
+  }
+
+  Future<int> markTrashedOnDevice(Map<int, String> localIDsByUploadedID) async {
+    if (localIDsByUploadedID.isEmpty) return 0;
+    final db = await instance.database;
+    final batch = db.batch();
+    for (final entry in localIDsByUploadedID.entries) {
+      batch.update(
+        tableName,
+        {columnLocalID: entry.value, columnIsTrashedOnDevice: 1},
+        where: '$columnUploadedFileID = ?',
+        whereArgs: [entry.key],
+      );
+    }
+    final results = await batch.commit();
+    return results.whereType<int>().fold<int>(0, (sum, count) => sum + count);
   }
 
   Future<FileLoadResult> getTrashedFiles(
@@ -205,6 +250,7 @@ class TrashDB {
     final fileMetadata = row[columnFileMetadata] ?? '{}';
     trashFile.applyMetadata(jsonDecode(fileMetadata));
     trashFile.localID = row[columnLocalID];
+    trashFile.isTrashedOnDevice = row[columnIsTrashedOnDevice] == 1;
 
     trashFile.mMdVersion = row[columnMMdVersion] ?? 0;
     trashFile.mMdEncodedJson = row[columnMMdEncodedJson] ?? '{}';
@@ -236,6 +282,7 @@ class TrashDB {
     row[columnUpdationTime] = trash.updationTime;
 
     row[columnLocalID] = trash.localID;
+    row[columnIsTrashedOnDevice] = trash.isTrashedOnDevice ? 1 : 0;
     row[columnCreationTime] = trash.creationTime;
     row[columnFileMetadata] = jsonEncode(trash.metadata);
 

--- a/mobile/apps/photos/lib/db/trash_db.dart
+++ b/mobile/apps/photos/lib/db/trash_db.dart
@@ -122,39 +122,41 @@ class TrashDB {
     if (trashFiles.isEmpty) return;
     final startTime = DateTime.now();
     final db = await instance.database;
-    final uploadedFileIDs = trashFiles
-        .map((trash) => trash.uploadedFileID!)
-        .join(',');
-    final rowsTrashedOnDevice = await db.query(
-      tableName,
-      columns: [columnUploadedFileID, columnLocalID],
-      where:
-          '$columnIsTrashedOnDevice = 1 AND $columnUploadedFileID IN ($uploadedFileIDs)',
-    );
-    final localIDsTrashedOnDevice = <int, String?>{
-      for (final row in rowsTrashedOnDevice)
-        row[columnUploadedFileID] as int: row[columnLocalID] as String?,
-    };
-    var batch = db.batch();
-    int batchCounter = 0;
-    for (TrashFile trash in trashFiles) {
-      if (localIDsTrashedOnDevice.containsKey(trash.uploadedFileID)) {
-        trash.localID = localIDsTrashedOnDevice[trash.uploadedFileID];
-        trash.isTrashedOnDevice = true;
-      }
-      if (batchCounter == 400) {
-        await batch.commit(noResult: true);
-        batch = db.batch();
-        batchCounter = 0;
-      }
-      batch.insert(
+    await db.transaction((transaction) async {
+      final uploadedFileIDs = trashFiles
+          .map((trash) => trash.uploadedFileID!)
+          .join(',');
+      final rowsTrashedOnDevice = await transaction.query(
         tableName,
-        _getRowForTrash(trash),
-        conflictAlgorithm: ConflictAlgorithm.replace,
+        columns: [columnUploadedFileID, columnLocalID],
+        where:
+            '$columnIsTrashedOnDevice = 1 AND $columnUploadedFileID IN ($uploadedFileIDs)',
       );
-      batchCounter++;
-    }
-    await batch.commit(noResult: true);
+      final localIDsTrashedOnDevice = <int, String?>{
+        for (final row in rowsTrashedOnDevice)
+          row[columnUploadedFileID] as int: row[columnLocalID] as String?,
+      };
+      var batch = transaction.batch();
+      int batchCounter = 0;
+      for (TrashFile trash in trashFiles) {
+        if (localIDsTrashedOnDevice.containsKey(trash.uploadedFileID)) {
+          trash.localID = localIDsTrashedOnDevice[trash.uploadedFileID];
+          trash.isTrashedOnDevice = true;
+        }
+        if (batchCounter == 400) {
+          await batch.commit(noResult: true);
+          batch = transaction.batch();
+          batchCounter = 0;
+        }
+        batch.insert(
+          tableName,
+          _getRowForTrash(trash),
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+        batchCounter++;
+      }
+      await batch.commit(noResult: true);
+    });
     final endTime = DateTime.now();
     final duration = Duration(
       microseconds:
@@ -187,20 +189,32 @@ class TrashDB {
     );
   }
 
-  Future<int> markTrashedOnDevice(Map<int, String> localIDsByUploadedID) async {
-    if (localIDsByUploadedID.isEmpty) return 0;
+  Future<void> insertTrashedOnDevice(
+    Map<int, String> localIDsByUploadedID,
+  ) async {
+    if (localIDsByUploadedID.isEmpty) return;
     final db = await instance.database;
     final batch = db.batch();
     for (final entry in localIDsByUploadedID.entries) {
-      batch.update(
-        tableName,
-        {columnLocalID: entry.value, columnIsTrashedOnDevice: 1},
-        where: '$columnUploadedFileID = ?',
-        whereArgs: [entry.key],
+      batch.rawInsert(
+        '''
+          INSERT INTO $tableName (
+            $columnUploadedFileID,
+            $columnCollectionID,
+            $columnTrashUpdatedAt,
+            $columnTrashDeleteBy,
+            $columnCreationTime,
+            $columnLocalID,
+            $columnIsTrashedOnDevice
+          ) VALUES (?, -1, 0, 0, 0, ?, 1)
+          ON CONFLICT($columnUploadedFileID) DO UPDATE SET
+            $columnLocalID = excluded.$columnLocalID,
+            $columnIsTrashedOnDevice = 1
+        ''',
+        [entry.key, entry.value],
       );
     }
-    final results = await batch.commit();
-    return results.whereType<int>().fold<int>(0, (sum, count) => sum + count);
+    await batch.commit(noResult: true);
   }
 
   Future<FileLoadResult> getTrashedFiles(
@@ -213,7 +227,9 @@ class TrashDB {
     final order = (asc ?? false ? 'ASC' : 'DESC');
     final results = await db.query(
       tableName,
-      where: '$columnCreationTime >= ? AND $columnCreationTime <= ?',
+      where:
+          '$columnCollectionID != -1 AND '
+          '$columnCreationTime >= ? AND $columnCreationTime <= ?',
       whereArgs: [startTime, endTime],
       orderBy: '$columnCreationTime ' + order,
       limit: limit,

--- a/mobile/apps/photos/lib/db/trash_db.dart
+++ b/mobile/apps/photos/lib/db/trash_db.dart
@@ -185,10 +185,12 @@ class TrashDB {
   Future<void> markTrashedOnDevice(Map<int, String> localIDs) async {
     if (localIDs.isEmpty) return;
     final db = await instance.database;
-    final batch = db.batch();
-    for (final entry in localIDs.entries) {
-      batch.rawInsert(
-        '''
+    await db.transaction((transaction) async {
+      for (final entries in localIDs.entries.toList().chunks(400)) {
+        final batch = transaction.batch();
+        for (final entry in entries) {
+          batch.rawInsert(
+            '''
           INSERT INTO $tableName (
             $columnUploadedFileID,
             $columnCollectionID,
@@ -202,10 +204,12 @@ class TrashDB {
             $columnLocalID = excluded.$columnLocalID,
             $columnIsTrashedOnDevice = 1
         ''',
-        [entry.key, entry.value],
-      );
-    }
-    await batch.commit(noResult: true);
+            [entry.key, entry.value],
+          );
+        }
+        await batch.commit(noResult: true);
+      }
+    });
   }
 
   Future<FileLoadResult> getTrashedFiles(

--- a/mobile/apps/photos/lib/db/trash_db.dart
+++ b/mobile/apps/photos/lib/db/trash_db.dart
@@ -199,7 +199,7 @@ class TrashDB {
             $columnCreationTime,
             $columnLocalID,
             $columnIsTrashedOnDevice
-          ) VALUES (?, -1, 0, 0, 0, ?, 1)
+          ) VALUES (?, 0, 0, -1, 0, ?, 1)
           ON CONFLICT($columnUploadedFileID) DO UPDATE SET
             $columnLocalID = excluded.$columnLocalID,
             $columnIsTrashedOnDevice = 1
@@ -223,7 +223,7 @@ class TrashDB {
     final results = await db.query(
       tableName,
       where:
-          '$columnCollectionID != -1 AND '
+          '$columnTrashDeleteBy != -1 AND '
           '$columnCreationTime >= ? AND $columnCreationTime <= ?',
       whereArgs: [startTime, endTime],
       orderBy: '$columnCreationTime ' + order,

--- a/mobile/apps/photos/lib/db/trash_db.dart
+++ b/mobile/apps/photos/lib/db/trash_db.dart
@@ -172,13 +172,13 @@ class TrashDB {
     );
   }
 
-  Future<int> update(TrashFile file) async {
+  Future<int> unsetLocalIDForFile(int? uploadedFileID) async {
     final db = await instance.database;
     return await db.update(
       tableName,
-      _getRowForTrash(file),
-      where: '$columnUploadedFileID = ?',
-      whereArgs: [file.uploadedFileID],
+      {columnLocalID: null},
+      where: '$columnUploadedFileID = ? AND $columnIsTrashedOnDevice = 0',
+      whereArgs: [uploadedFileID],
     );
   }
 

--- a/mobile/apps/photos/lib/models/file/trash_file.dart
+++ b/mobile/apps/photos/lib/models/file/trash_file.dart
@@ -1,6 +1,10 @@
 import 'package:photos/models/file/file.dart';
 
 class TrashFile extends EnteFile {
+  // Keep the deleting device's localID when it moves the asset to system trash,
+  // instead of replacing it with the upload-time localID from server metadata.
+  bool isTrashedOnDevice = false;
+
   // time when file was put in the trash for first time
   late int createdAt;
 

--- a/mobile/apps/photos/lib/module/download/file.dart
+++ b/mobile/apps/photos/lib/module/download/file.dart
@@ -15,6 +15,7 @@ import 'package:photos/core/constants.dart';
 import "package:photos/models/file/extensions/file_props.dart";
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
+import "package:photos/models/file/trash_file.dart";
 import 'package:photos/module/download/decrypt.dart';
 import 'package:photos/module/live_photo/download.dart';
 
@@ -35,8 +36,9 @@ Future<File?> getFile(
   bool isOrigin = false,
   bool forGalleryDownload = false, // only relevant for live photos
 }) async {
+  final isRemoteTrashFile = (file is TrashFile && file.uploadedFileID != null);
   try {
-    if (file.isRemoteOnlyFile) {
+    if (file.isRemoteOnlyFile || isRemoteTrashFile) {
       return getFileFromServer(
         file,
         liveVideo: liveVideo,

--- a/mobile/apps/photos/lib/module/metadata/exif.dart
+++ b/mobile/apps/photos/lib/module/metadata/exif.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import 'package:photos/models/file/file.dart';
 import "package:photos/models/file/file_type.dart";
+import "package:photos/models/file/trash_file.dart";
 import "package:photos/models/location/location.dart";
 import "package:photos/models/metadata/file_magic.dart";
 import 'package:photos/module/download/file.dart';
@@ -42,12 +43,14 @@ Future<Map<String, IfdTag>> getExif(EnteFile file) async {
     if (!shouldReadExif(file)) {
       return <String, IfdTag>{};
     }
+    final isRemoteTrashFile =
+        (file is TrashFile && file.uploadedFileID != null);
     final File? originFile = await getFile(file, isOrigin: true);
     if (originFile == null) {
       throw Exception("Failed to fetch origin file");
     }
     final exif = await readExifAsync(originFile);
-    if (!file.isRemoteOnlyFile && Platform.isIOS) {
+    if (!(file.isRemoteOnlyFile || isRemoteTrashFile) && Platform.isIOS) {
       await originFile.delete();
     }
     return exif;

--- a/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
@@ -107,7 +107,7 @@ class TrashSyncService {
 
   Future<void> trashFilesOnServer(
     List<TrashRequest> trashRequestItems, {
-    Map<int, String> localIDsByUploadedID = const {},
+    Map<int, String> deviceLocalIDs = const {},
   }) async {
     final includedFileIDs = <int>{};
     final uniqueItems = <TrashRequest>[];
@@ -141,18 +141,11 @@ class TrashSyncService {
         }
       }
     }
-    final batchedItems = uniqueItems.chunks(batchSize);
-    for (final batch in batchedItems) {
-      final batchLocalIDsByUploadedID = <int, String>{};
-      for (final item in batch) {
-        final localID = localIDsByUploadedID[item.fileID];
-        if (localID != null) {
-          batchLocalIDsByUploadedID[item.fileID] = localID;
-        }
-      }
-      await _trashDB.insertTrashedOnDevice(batchLocalIDsByUploadedID);
-      final items = batch.map((item) => item.toJson()).toList();
-      await _trashFiles(items);
+    for (final batch in uniqueItems.chunks(batchSize)) {
+      await _trashDB.markTrashedOnDevice({
+        for (final item in batch) item.fileID: ?deviceLocalIDs[item.fileID],
+      });
+      await _trashFiles(batch.map((item) => item.toJson()).toList());
     }
   }
 

--- a/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
@@ -142,9 +142,11 @@ class TrashSyncService {
       }
     }
     for (final batch in uniqueItems.chunks(batchSize)) {
-      await _trashDB.markTrashedOnDevice({
-        for (final item in batch) item.fileID: ?deviceLocalIDs[item.fileID],
-      });
+      await _trashDB.markTrashedOnDevice([
+        for (final item in batch)
+          if (deviceLocalIDs[item.fileID] case final localID?)
+            (item.fileID, localID),
+      ]);
       await _trashFiles(batch.map((item) => item.toJson()).toList());
     }
   }

--- a/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
@@ -244,6 +244,17 @@ class TrashSyncService {
     await _gateway.trashFiles(items);
   }
 
+  Future<void> markTrashedOnDevice(
+    Map<int, String> localIDsByUploadedID,
+  ) async {
+    final markedCount = await _trashDB.markTrashedOnDevice(
+      localIDsByUploadedID,
+    );
+    if (markedCount > 0) {
+      Bus.instance.fire(TrashUpdatedEvent());
+    }
+  }
+
   Future<void> deleteFromTrash(List<EnteFile> files) async {
     final uniqueFileIds = files.map((e) => e.uploadedFileID!).toSet().toList();
     final batchedFileIDs = uniqueFileIds.chunks(batchSize);

--- a/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
@@ -244,15 +244,10 @@ class TrashSyncService {
     await _gateway.trashFiles(items);
   }
 
-  Future<void> markTrashedOnDevice(
+  Future<void> insertTrashedOnDevice(
     Map<int, String> localIDsByUploadedID,
   ) async {
-    final markedCount = await _trashDB.markTrashedOnDevice(
-      localIDsByUploadedID,
-    );
-    if (markedCount > 0) {
-      Bus.instance.fire(TrashUpdatedEvent());
-    }
+    await _trashDB.insertTrashedOnDevice(localIDsByUploadedID);
   }
 
   Future<void> deleteFromTrash(List<EnteFile> files) async {

--- a/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
@@ -105,7 +105,10 @@ class TrashSyncService {
     return _prefs.getInt(kLastTrashSyncTime) ?? 0;
   }
 
-  Future<void> trashFilesOnServer(List<TrashRequest> trashRequestItems) async {
+  Future<void> trashFilesOnServer(
+    List<TrashRequest> trashRequestItems, {
+    Map<int, String> localIDsByUploadedID = const {},
+  }) async {
     final includedFileIDs = <int>{};
     final uniqueItems = <TrashRequest>[];
     final ownedCollectionIDs = CollectionsService.instance
@@ -140,6 +143,14 @@ class TrashSyncService {
     }
     final batchedItems = uniqueItems.chunks(batchSize);
     for (final batch in batchedItems) {
+      final batchLocalIDsByUploadedID = <int, String>{};
+      for (final item in batch) {
+        final localID = localIDsByUploadedID[item.fileID];
+        if (localID != null) {
+          batchLocalIDsByUploadedID[item.fileID] = localID;
+        }
+      }
+      await _trashDB.insertTrashedOnDevice(batchLocalIDsByUploadedID);
       final items = batch.map((item) => item.toJson()).toList();
       await _trashFiles(items);
     }
@@ -242,12 +253,6 @@ class TrashSyncService {
 
   Future<void> _trashFiles(List<Map<String, dynamic>> items) async {
     await _gateway.trashFiles(items);
-  }
-
-  Future<void> insertTrashedOnDevice(
-    Map<int, String> localIDsByUploadedID,
-  ) async {
-    await _trashDB.insertTrashedOnDevice(localIDsByUploadedID);
   }
 
   Future<void> deleteFromTrash(List<EnteFile> files) async {

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -440,6 +440,11 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
       return null;
     }
 
+    // File is a non-system-only trash file, load thumbnail from remote
+    if (widget.file is TrashFile && widget.file.uploadedFileID != null) {
+      return null;
+    }
+
     final completer = Completer<Uint8List?>();
 
     late TaskQueue<String> relevantTaskQueue;

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -337,10 +337,13 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
           if (thumbData == null) {
             if (widget.file.isUploaded) {
               _logger.info("Removing localID reference for " + widget.file.tag);
-              widget.file.localID = null;
-              if (widget.file.isTrash) {
-                unawaited(TrashDB.instance.update(widget.file as TrashFile));
+              if (widget.file is TrashFile) {
+                if (!(widget.file as TrashFile).isTrashedOnDevice) {
+                  widget.file.localID = null;
+                  unawaited(TrashDB.instance.update(widget.file as TrashFile));
+                }
               } else {
+                widget.file.localID = null;
                 unawaited(FilesDB.instance.update(widget.file));
               }
               _loadNetworkImage();

--- a/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/thumbnail_widget.dart
@@ -340,7 +340,11 @@ class _ThumbnailWidgetState extends State<ThumbnailWidget> {
               if (widget.file is TrashFile) {
                 if (!(widget.file as TrashFile).isTrashedOnDevice) {
                   widget.file.localID = null;
-                  unawaited(TrashDB.instance.update(widget.file as TrashFile));
+                  unawaited(
+                    TrashDB.instance.unsetLocalIDForFile(
+                      widget.file.uploadedFileID!,
+                    ),
+                  );
                 }
               } else {
                 widget.file.localID = null;

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -18,6 +18,7 @@ import "package:photos/events/reset_zoom_of_photo_view_event.dart";
 import "package:photos/events/retry_failed_image_load_event.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import 'package:photos/models/file/file.dart';
+import 'package:photos/models/file/trash_file.dart';
 import 'package:photos/module/download/file.dart';
 import 'package:photos/module/download/thumbnail.dart';
 import "package:photos/module/metadata/exif.dart";
@@ -485,8 +486,11 @@ class _ZoomableImageState extends State<ZoomableImage> {
         } else {
           _logger.info("File was deleted " + _photo.toString());
           if (_photo.uploadedFileID != null) {
-            _photo.localID = null;
-            FilesDB.instance.update(_photo);
+            if (_photo is! TrashFile ||
+                !(_photo as TrashFile).isTrashedOnDevice) {
+              _photo.localID = null;
+              FilesDB.instance.update(_photo);
+            }
             _loadNetworkImage();
           } else {
             FilesDB.instance.deleteLocalFile(_photo);

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_image.dart
@@ -204,7 +204,9 @@ class _ZoomableImageState extends State<ZoomableImage> {
 
   @override
   Widget build(BuildContext context) {
-    if (_photo.isRemoteOnlyFile) {
+    if (_photo.isRemoteOnlyFile ||
+        (_photo is TrashFile && (_photo as TrashFile).isTrashedOnDevice) &&
+            _photo.uploadedFileID != null) {
       _loadNetworkImage();
     } else {
       _loadLocalImage(context);

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -134,8 +134,10 @@ Future<void> deleteFilesFromEverywhere(
               result.trashedIDs.contains(file.localID))
             file.uploadedFileID!: file.localID!,
       };
-      await trashSyncService.insertTrashedOnDevice(trashedLocalIDsByUploadedID);
-      await trashSyncService.trashFilesOnServer(uploadedFilesToBeTrashed);
+      await trashSyncService.trashFilesOnServer(
+        uploadedFilesToBeTrashed,
+        localIDsByUploadedID: trashedLocalIDsByUploadedID,
+      );
       await FilesDB.instance.deleteMultipleUploadedFiles(fileIDs);
     } catch (e) {
       _logger.severe(e);

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -134,9 +134,8 @@ Future<void> deleteFilesFromEverywhere(
               result.trashedIDs.contains(file.localID))
             file.uploadedFileID!: file.localID!,
       };
+      await trashSyncService.insertTrashedOnDevice(trashedLocalIDsByUploadedID);
       await trashSyncService.trashFilesOnServer(uploadedFilesToBeTrashed);
-      await trashSyncService.syncTrash();
-      await trashSyncService.markTrashedOnDevice(trashedLocalIDsByUploadedID);
       await FilesDB.instance.deleteMultipleUploadedFiles(fileIDs);
     } catch (e) {
       _logger.severe(e);

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -127,16 +127,13 @@ Future<void> deleteFilesFromEverywhere(
       final fileIDs = uploadedFilesToBeTrashed
           .map((item) => item.fileID)
           .toList();
-      final trashedLocalIDsByUploadedID = <int, String>{
-        for (final file in deletedFiles)
-          if (file.uploadedFileID != null &&
-              file.localID != null &&
-              result.trashedIDs.contains(file.localID))
-            file.uploadedFileID!: file.localID!,
-      };
       await trashSyncService.trashFilesOnServer(
         uploadedFilesToBeTrashed,
-        localIDsByUploadedID: trashedLocalIDsByUploadedID,
+        deviceLocalIDs: {
+          for (final file in deletedFiles)
+            if (result.trashedIDs.contains(file.localID))
+              ?file.uploadedFileID: ?file.localID,
+        },
       );
       await FilesDB.instance.deleteMultipleUploadedFiles(fileIDs);
     } catch (e) {

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -127,7 +127,16 @@ Future<void> deleteFilesFromEverywhere(
       final fileIDs = uploadedFilesToBeTrashed
           .map((item) => item.fileID)
           .toList();
+      final trashedLocalIDsByUploadedID = <int, String>{
+        for (final file in deletedFiles)
+          if (file.uploadedFileID != null &&
+              file.localID != null &&
+              result.trashedIDs.contains(file.localID))
+            file.uploadedFileID!: file.localID!,
+      };
       await trashSyncService.trashFilesOnServer(uploadedFilesToBeTrashed);
+      await trashSyncService.syncTrash();
+      await trashSyncService.markTrashedOnDevice(trashedLocalIDsByUploadedID);
       await FilesDB.instance.deleteMultipleUploadedFiles(fileIDs);
     } catch (e) {
       _logger.severe(e);


### PR DESCRIPTION
When a file that was uploaded by device A is deleted by device B (together with a local downloaded copy), the local ID stored in Trash DB is from device A, which is useless on device B.

With move to trash on android, we need to keep track of the local ID of the trashed file, so we can later on restore/delete it.

This makes device B store the local ID of the local copy that was trashed, device A's Trash DB is unaffected and it's local ID column will still have the local ID from device A's local copy of the file.

The code also sets local ID to null if any image fails to load, for trash files specifically we do not do this, and fix the rest of the code paths that depend on this behavior to fallback to loading the image from network if its a trash file specifically.

