### PR TITLE
[web][photos] Fix first file unfavouriting without indexedDB synced

### DIFF
--- a/web/packages/new/photos/services/collection.ts
+++ b/web/packages/new/photos/services/collection.ts
@@ -780,6 +780,8 @@ const userOwnedEquivalentFilesByHashAndType = (
 // Bridges shared favorite toggles before the remote add/move has been pulled
 // into local DB.
 const pendingFavoriteFilesByHashAndType = new Map<string, EnteFile>();
+let pendingUserFavoritesCollection: Collection | undefined;
+let pendingUserFavoritesCollectionPromise: Promise<Collection> | undefined;
 
 /**
  *
@@ -1882,19 +1884,38 @@ export const createUncategorizedCollection = () =>
  *
  * Reads local state but does not modify it. The effects are on remote.
  */
-const savedOrCreateUserFavoritesCollection = async () =>
-    (await savedUserFavoritesCollection()) ?? createFavoritesCollection();
+const savedOrCreateUserFavoritesCollection = async () => {
+    const favoritesCollection = await savedUserFavoritesCollection();
+    if (favoritesCollection) return favoritesCollection;
+
+    pendingUserFavoritesCollectionPromise ??= createFavoritesCollection()
+        .then((collection) => {
+            pendingUserFavoritesCollection = collection;
+            return collection;
+        })
+        .finally(() => {
+            pendingUserFavoritesCollectionPromise = undefined;
+        });
+
+    return pendingUserFavoritesCollectionPromise;
+};
 
 /**
- * Return the user's own favorites collection if present in the local database.
+ * Return the user's own favorites collection if present in the local database,
+ * or one created during this session before the next remote pull.
  */
 export const savedUserFavoritesCollection = async () => {
     const userID = ensureLocalUser().id;
     const collections = await savedCollections();
-    return collections.find(
-        (collection) =>
-            // See: [Note: User and shared favorites]
-            collection.type == "favorites" && collection.owner.id == userID,
+    return (
+        collections.find(
+            (collection) =>
+                // See: [Note: User and shared favorites]
+                collection.type == "favorites" && collection.owner.id == userID,
+        ) ??
+        (pendingUserFavoritesCollection?.owner.id == userID
+            ? pendingUserFavoritesCollection
+            : undefined)
     );
 };
 


### PR DESCRIPTION
## Description

When a user creates a new account with no favorites collection, uploads a file, and favorites it from the file viewer - the favorites collection gets created only on the server. IndexedDB isn't updated since that sync happens on file viewer closure.

If the user unfavorites the file without closing the file viewer, the code checks the local IndexedDB for the favorites collection, which isn't there yet (pull hasn't happened). This causes the "Something went wrong" modal to pop up.

**Fix:** introduced two temp variables to hold the reference to the collection and the promise. if IndexedDB returns undefined/null, we check these instead of showing the error and do the unfavoriting.