### PR TITLE
[web][photos] Add close button for the download toast

### DIFF
--- a/web/packages/base/components/Notification.tsx
+++ b/web/packages/base/components/Notification.tsx
@@ -67,6 +67,10 @@ export interface NotificationAttributes {
      */
     endIcon?: React.ReactNode;
     /**
+     * If true, show the default close button after the custom {@link endIcon}.
+     */
+    showCloseButtonWithEndIcon?: boolean;
+    /**
      * Optional handler when {@link endIcon} is clicked.
      *
      * If not provided, clicks on the end icon behave the same as clicking the
@@ -140,6 +144,7 @@ export const Notification: React.FC<NotificationProps> = ({
         title,
         caption,
         endIcon,
+        showCloseButtonWithEndIcon,
         onClick,
         onEndIconClick,
     } = attributes;
@@ -244,7 +249,7 @@ export const Notification: React.FC<NotificationProps> = ({
                         )}
                     </Stack>
 
-                    {endIcon ? (
+                    {endIcon && (
                         <IconButton
                             component="div"
                             onClick={handleEndIconClick}
@@ -252,7 +257,8 @@ export const Notification: React.FC<NotificationProps> = ({
                         >
                             {endIcon}
                         </IconButton>
-                    ) : (
+                    )}
+                    {(!endIcon || showCloseButtonWithEndIcon) && (
                         <IconButton
                             // Buttons cannot be nested in buttons, so we use a div
                             // here instead.

--- a/web/packages/gallery/components/DownloadStatusNotifications.tsx
+++ b/web/packages/gallery/components/DownloadStatusNotifications.tsx
@@ -312,6 +312,7 @@ export const DownloadStatusNotifications: React.FC<
                             onEndIconClick: canRetry
                                 ? () => group.retry?.()
                                 : undefined,
+                            showCloseButtonWithEndIcon: canRetry,
                         }}
                     />
                 );


### PR DESCRIPTION
## Description

Currently, the download toast only has a retry button. If a file is corrupted or can't be downloaded even after n retries, there's no way to close the toast right now other than refreshing the page itself.