### PR TITLE
[web][photos] Hide archived albums from showing in gallery horizontal bar

### DIFF
--- a/desktop/changes/close-failed-download-notifications.md
+++ b/desktop/changes/close-failed-download-notifications.md
@@ -1,0 +1,1 @@
+- Added Close button to the download notification toast.

--- a/desktop/changes/hide-archived-albums-from-gallery-bar.md
+++ b/desktop/changes/hide-archived-albums-from-gallery-bar.md
@@ -1,0 +1,1 @@
+- Hide archived albums from the main Gallery album bar.

--- a/desktop/changes/import-google-photos-favorites.md
+++ b/desktop/changes/import-google-photos-favorites.md
@@ -1,0 +1,1 @@
+- Choose whether to import Google Photos favorites into Ente Favorites.

--- a/desktop/changes/redesign-stop-upload-dialog.md
+++ b/desktop/changes/redesign-stop-upload-dialog.md
@@ -1,0 +1,1 @@
+- Redesigned stop-upload confirmation dialog.

--- a/desktop/changes/redesign-upload-completion-dialog.md
+++ b/desktop/changes/redesign-upload-completion-dialog.md
@@ -1,0 +1,1 @@
+- Redesigned upload completion dialog.

--- a/desktop/changes/redesigned-upload-progress.md
+++ b/desktop/changes/redesigned-upload-progress.md
@@ -1,0 +1,1 @@
+- Redesigned upload progress with completed, skipped, and failed file tracking.

--- a/desktop/changes/review-upload-before-starting.md
+++ b/desktop/changes/review-upload-before-starting.md
@@ -1,0 +1,1 @@
+- Review photo, video, and album counts before uploading.

--- a/desktop/changes/skip-google-photos-partner-shared-files.md
+++ b/desktop/changes/skip-google-photos-partner-shared-files.md
@@ -1,1 +1,1 @@
-- Skip partner-shared files when importing from Google Photos.
+- Import or skip partner-shared photos during Google Photos Takeout.

--- a/web/apps/photos/src/components/Collections/GalleryBarAndListHeader.tsx
+++ b/web/apps/photos/src/components/Collections/GalleryBarAndListHeader.tsx
@@ -319,7 +319,9 @@ export const GalleryBarAndListHeader: React.FC<
                 onShowAllAlbums={showAllAlbums}
                 onShowAllPeople={showAllPeople}
                 collectionSummaries={sortedCollectionSummaries.filter(
-                    (cs) => !cs.attributes.has("hideFromCollectionBar"),
+                    (cs) =>
+                        !cs.attributes.has("hideFromCollectionBar") &&
+                        (mode != "albums" || !cs.attributes.has("archived")),
                 )}
             />
 


### PR DESCRIPTION
## Description

Archived albums are now shown in a more consolidated manner in the Archive section, so they've been removed from here.

**Note:** Archived albums are only hidden from the horizontal bar. everywhere else this was previously used should still work fine, since the reducer itself is unchanged - the filtering happens during rendering instead.

fixes #11640 