### PR TITLE
[mobile][photos] Preserve EXIF metadata in edited photos

### DIFF
--- a/mobile/apps/photos/changes/preserve-edited-photo-metadata.md
+++ b/mobile/apps/photos/changes/preserve-edited-photo-metadata.md
@@ -1,0 +1,1 @@
+- Edited photos now keep their EXIF metadata, with lossless rotation and flip edits when possible.

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_page.dart
@@ -20,7 +20,6 @@ import "package:photos/events/local_photos_updated_event.dart";
 import 'package:photos/models/file/file.dart' as ente;
 import "package:photos/models/location/location.dart";
 import "package:photos/module/metadata/local_file.dart";
-import "package:photos/service_locator.dart";
 import "package:photos/services/sync/sync_service.dart";
 import "package:photos/ui/components/action_sheet_widget.dart";
 import "package:photos/ui/components/buttons/button_widget.dart";
@@ -70,20 +69,14 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
       quality: 95,
       format: CompressFormat.jpeg,
     );
-    if (flagService.internalUser) {
-      try {
-        final image = img.decodePng(bytes);
-        if (image != null) {
-          await copyEXIF(
-            widget.originalFile,
-            image,
-            copyRenderingFields: false,
-          );
-          result = img.encodeJpg(image, quality: 95);
-        }
-      } catch (e, s) {
-        _logger.warning("Image Editor: copyEXIF failed", e, s);
+    try {
+      final image = img.decodePng(bytes);
+      if (image != null) {
+        await copyEXIF(widget.originalFile, image, copyRenderingFields: false);
+        result = img.encodeJpg(image, quality: 95);
       }
+    } catch (e, s) {
+      _logger.warning("Image Editor: copyEXIF failed", e, s);
     }
     return result;
   }
@@ -96,9 +89,7 @@ class _ImageEditorPageState extends State<ImageEditorPage> {
     bool hasStoppedChangeNotify = false;
 
     try {
-      final losslessTransform = flagService.internalUser
-          ? getLosslessTransform(editorState)
-          : null;
+      final losslessTransform = getLosslessTransform(editorState);
       final losslessBytes = losslessTransform == null
           ? null
           : await tryTransformFileLossless(


### PR DESCRIPTION
## What changed

- preserve selected EXIF fields when edited photos are re-encoded
- allow lossless rotate and flip edits for all users when the source is a JPEG and the edit can be stored in EXIF orientation
- remove the now-unused feature flag import
- add a Photos release-note entry

## Why

These image-editor paths were limited to internal users. As a result, other users could lose photo metadata after an edit and could not use the lossless orientation path.

## User impact

Edited photos now keep supported camera, time, and location metadata. Rotate-only and flip-only JPEG edits can also keep the original image data when the edit meets the lossless-path rules.

## Checks

- `git diff --check`
- `fvm dart format --output=none --set-exit-if-changed lib/ui/tools/editor/image_editor/image_editor_page.dart`
- `fvm flutter gen-l10n`
- `fvm flutter analyze lib/ui/tools/editor/image_editor/image_editor_page.dart`