### PR TITLE
[mob][photos] Add missing r4khul change attributions

### DIFF
--- a/mobile/apps/photos/changes/home-widget-customization.md
+++ b/mobile/apps/photos/changes/home-widget-customization.md
@@ -1,1 +1,1 @@
-- Tapping an unconfigured home screen widget now opens its customization screen.
+- Tapping an unconfigured home screen widget now opens its customization screen. (@r4khul)

--- a/mobile/apps/photos/changes/video-mute-control.md
+++ b/mobile/apps/photos/changes/video-mute-control.md
@@ -1,1 +1,1 @@
-- Added a mute button to the video player that remembers your preference.
+- Added a mute button to the video player that remembers your preference. (@r4khul)


### PR DESCRIPTION
## What changed

- Added `(@r4khul)` to the home widget customization change entry.
- Added `(@r4khul)` to the persistent video mute change entry.

## Why

These entries describe changes contributed by `r4khul`, but their attribution suffixes were missing. Adding them makes the entries consistent with the related video editor change entry and ensures the contributor is credited in generated release notes.

## Validation

- Confirmed all three post-`photos-v1.3.59` change entries for `r4khul` now end with `(@r4khul)`.
- Ran `git diff --check`.
