### PR TITLE
[mob][photos] Format EXIF values in file details

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/file_details_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_details_widget.dart
@@ -401,15 +401,15 @@ class _FileDetailsWidgetState extends State<FileDetailsWidget> {
 
   void _generateExifForDetails(Map<String, IfdTag> exif) {
     if (exif["EXIF FocalLength"] != null) {
-      _exifData["focalLength"] =
-          (exif["EXIF FocalLength"]!.values.toList()[0] as Ratio).numerator /
-          (exif["EXIF FocalLength"]!.values.toList()[0] as Ratio).denominator;
+      _exifData["focalLength"] = _formatExifRatio(
+        exif["EXIF FocalLength"]!.values.toList()[0] as Ratio,
+      );
     }
 
     if (exif["EXIF FNumber"] != null) {
-      _exifData["fNumber"] =
-          (exif["EXIF FNumber"]!.values.toList()[0] as Ratio).numerator /
-          (exif["EXIF FNumber"]!.values.toList()[0] as Ratio).denominator;
+      _exifData["fNumber"] = _formatExifRatio(
+        exif["EXIF FNumber"]!.values.toList()[0] as Ratio,
+      );
     }
     final imageWidth = _firstPositiveDimensionTag(exif, const [
       "EXIF ExifImageWidth",
@@ -442,6 +442,14 @@ class _FileDetailsWidgetState extends State<FileDetailsWidget> {
     if (exif["EXIF ISOSpeedRatings"] != null) {
       _exifData['ISO'] = exif["EXIF ISOSpeedRatings"].toString();
     }
+  }
+
+  String _formatExifRatio(Ratio ratio) {
+    if (ratio.denominator == 0) {
+      return ratio.toString();
+    }
+    final value = ratio.numerator / ratio.denominator;
+    return value.toStringAsFixed(2).replaceFirst(RegExp(r"\.?0+$"), "");
   }
 
   /// Formats exposure time from EXIF data into a human-readable string.


### PR DESCRIPTION
Formats aperture and focal length values to at most two decimal places in file details.

Before/After
<img width="300" height="650" alt="Simulator Screenshot - iPhone 17 - 2026-08-05 at 14 43 55" src="https://github.com/user-attachments/assets/e739aa2d-11b5-4a7f-be1c-87518a8ed9d6" />.    <img width="300" height="650" alt="Simulator Screenshot - iPhone 17 - 2026-08-05 at 14 41 57" src="https://github.com/user-attachments/assets/5b22ad24-44bc-44d4-94a5-6986154624a9" />
