### PR TITLE
[mobile][photos] Skip notification prompt when ritual days are off

### DIFF
--- a/mobile/apps/photos/lib/ui/rituals/ritual_editor_dialog.dart
+++ b/mobile/apps/photos/lib/ui/rituals/ritual_editor_dialog.dart
@@ -541,7 +541,8 @@ Future<void> _showRitualEditor(BuildContext context, {Ritual? ritual}) async {
                                       ),
                                       onPressed: canSave
                                           ? () async {
-                                              if (sendReminderEnabled &&
+                                              if (!allDaysOff &&
+                                                  sendReminderEnabled &&
                                                   !await NotificationService
                                                       .instance
                                                       .hasGrantedPermissions() &&


### PR DESCRIPTION
## What changed

Skip the notification permission check when all ritual days are turned off.

## Why

The ritual editor hides the reminder switch and shows the notifications-off hint when no days are active, but `sendReminderEnabled` can still be true. Saving then asks for notification access even though the scheduler will skip every day. If access is denied, the save is also blocked.

This guard keeps the saved reminder preference while avoiding a permission request that cannot lead to a scheduled reminder.

## User impact

Users can create or update a ritual with all days turned off without being sent through the notification permission flow.

## Checks

- `fvm dart format --output=none --set-exit-if-changed lib/ui/rituals/ritual_editor_dialog.dart`
- `fvm flutter analyze lib/ui/rituals/ritual_editor_dialog.dart`