### PR TITLE
[ensu] add chat rename feature in desktop

### DIFF
--- a/rust/apps/ensu/changes/rename-chat-sessions.md
+++ b/rust/apps/ensu/changes/rename-chat-sessions.md
@@ -1,0 +1,1 @@
+- Rename chats from the sidebar in Desktop.

--- a/web/apps/ensu/src/components/chat/ChatSidebar.tsx
+++ b/web/apps/ensu/src/components/chat/ChatSidebar.tsx
@@ -1,4 +1,4 @@
-import type { ChatSession } from "@/services/chat/store";
+import { sessionTitleFromText, type ChatSession } from "@/services/chat/store";
 import {
     ArrowLeft01Icon,
     ArrowRight01Icon,
@@ -73,36 +73,72 @@ export const ChatSidebar = memo(
     }: ChatSidebarProps) => {
         const [editingSessionId, setEditingSessionId] = useState<string>();
         const [editingTitle, setEditingTitle] = useState("");
-        const editingSessionIdRef = useRef<string | undefined>(undefined);
+        const [savingRenameToken, setSavingRenameToken] = useState<number>();
+        const activeRenameRef = useRef<
+            | { sessionId: string; originalTitle: string; token: number }
+            | undefined
+        >(undefined);
+        const nextRenameTokenRef = useRef(0);
+        const savingRenameTokensRef = useRef(new Set<number>());
 
         const startRename = (sessionId: string, title: string) => {
-            editingSessionIdRef.current = sessionId;
+            activeRenameRef.current = {
+                sessionId,
+                originalTitle: sessionTitleFromText(title, "New chat"),
+                token: ++nextRenameTokenRef.current,
+            };
             setEditingSessionId(sessionId);
             setEditingTitle(title);
         };
 
-        const cancelRename = (sessionId?: string) => {
+        const cancelRename = (sessionId?: string, token?: number) => {
+            const activeRename = activeRenameRef.current;
             if (
                 sessionId !== undefined &&
-                editingSessionIdRef.current !== sessionId
+                activeRename?.sessionId !== sessionId
             ) {
                 return;
             }
-            editingSessionIdRef.current = undefined;
+            if (token !== undefined && activeRename?.token !== token) return;
+
+            activeRenameRef.current = undefined;
             setEditingSessionId(undefined);
             setEditingTitle("");
         };
 
         const saveRename = async () => {
-            const sessionId = editingSessionId;
-            if (!sessionId) return;
-            const title = editingTitle.trim();
-            if (!title) {
-                cancelRename(sessionId);
+            const activeRename = activeRenameRef.current;
+            if (
+                !editingSessionId ||
+                activeRename?.sessionId !== editingSessionId ||
+                savingRenameTokensRef.current.has(activeRename.token)
+            ) {
                 return;
             }
-            if (await renameSession(sessionId, title)) {
-                cancelRename(sessionId);
+
+            const { sessionId, originalTitle, token } = activeRename;
+            if (!editingTitle.trim()) {
+                cancelRename(sessionId, token);
+                return;
+            }
+
+            const title = sessionTitleFromText(editingTitle, "New chat");
+            if (title === originalTitle) {
+                cancelRename(sessionId, token);
+                return;
+            }
+
+            savingRenameTokensRef.current.add(token);
+            setSavingRenameToken(token);
+            try {
+                if (await renameSession(sessionId, title)) {
+                    cancelRename(sessionId, token);
+                }
+            } finally {
+                savingRenameTokensRef.current.delete(token);
+                setSavingRenameToken((currentToken) =>
+                    currentToken === token ? undefined : currentToken,
+                );
             }
         };
 
@@ -372,6 +408,15 @@ export const ChatSidebar = memo(
                                                 session.sessionUuid ? (
                                                     <InputBase
                                                         autoFocus
+                                                        disabled={
+                                                            savingRenameToken ===
+                                                            activeRenameRef
+                                                                .current?.token
+                                                        }
+                                                        inputProps={{
+                                                            "aria-label":
+                                                                "Chat title",
+                                                        }}
                                                         value={editingTitle}
                                                         onChange={(event) =>
                                                             setEditingTitle(

--- a/web/apps/ensu/src/components/chat/ChatSidebar.tsx
+++ b/web/apps/ensu/src/components/chat/ChatSidebar.tsx
@@ -21,7 +21,7 @@ import {
     Typography,
 } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
-import React, { memo, useState } from "react";
+import React, { memo, useRef, useState } from "react";
 
 type IconProps = { size: number; strokeWidth: number };
 
@@ -43,7 +43,7 @@ export interface ChatSidebarProps {
     groupedSessions: Array<[string, ChatSession[]]>;
     currentSessionId?: string;
     handleSelectSession: (sessionId: string) => void;
-    renameSession: (sessionId: string, title: string) => Promise<void>;
+    renameSession: (sessionId: string, title: string) => Promise<boolean>;
     requestDeleteSession: (sessionId: string) => void;
     openSettingsModal: () => void;
 }
@@ -73,26 +73,37 @@ export const ChatSidebar = memo(
     }: ChatSidebarProps) => {
         const [editingSessionId, setEditingSessionId] = useState<string>();
         const [editingTitle, setEditingTitle] = useState("");
+        const editingSessionIdRef = useRef<string | undefined>(undefined);
 
         const startRename = (sessionId: string, title: string) => {
+            editingSessionIdRef.current = sessionId;
             setEditingSessionId(sessionId);
             setEditingTitle(title);
         };
 
-        const cancelRename = () => {
+        const cancelRename = (sessionId?: string) => {
+            if (
+                sessionId !== undefined &&
+                editingSessionIdRef.current !== sessionId
+            ) {
+                return;
+            }
+            editingSessionIdRef.current = undefined;
             setEditingSessionId(undefined);
             setEditingTitle("");
         };
 
         const saveRename = async () => {
-            if (!editingSessionId) return;
+            const sessionId = editingSessionId;
+            if (!sessionId) return;
             const title = editingTitle.trim();
             if (!title) {
-                cancelRename();
+                cancelRename(sessionId);
                 return;
             }
-            await renameSession(editingSessionId, title);
-            cancelRename();
+            if (await renameSession(sessionId, title)) {
+                cancelRename(sessionId);
+            }
         };
 
         return (

--- a/web/apps/ensu/src/components/chat/ChatSidebar.tsx
+++ b/web/apps/ensu/src/components/chat/ChatSidebar.tsx
@@ -314,10 +314,13 @@ export const ChatSidebar = memo(
                                     <ListItemButton
                                         key={session.sessionUuid}
                                         selected={
-                                        session.sessionUuid === currentSessionId
+                                            session.sessionUuid ===
+                                            currentSessionId
                                         }
                                         onClick={() =>
-                                        handleSelectSession(session.sessionUuid)
+                                            handleSelectSession(
+                                                session.sessionUuid,
+                                            )
                                         }
                                         sx={{
                                             alignItems: "flex-start",
@@ -333,13 +336,15 @@ export const ChatSidebar = memo(
                                                     pointerEvents: "auto",
                                                 },
                                             "&:hover": {
-                                            backgroundColor: "fill.faintHover",
+                                                backgroundColor:
+                                                    "fill.faintHover",
                                             },
                                             "&.Mui-selected": {
                                                 backgroundColor: "fill.faint",
                                             },
                                             "&.Mui-selected:hover": {
-                                            backgroundColor: "fill.faintHover",
+                                                backgroundColor:
+                                                    "fill.faintHover",
                                             },
                                         }}
                                     >
@@ -401,9 +406,12 @@ export const ChatSidebar = memo(
                                                             variant="small"
                                                             sx={{
                                                                 fontWeight: 600,
-                                                        fontFamily: "inherit",
-                                                        whiteSpace: "nowrap",
-                                                        overflow: "hidden",
+                                                                fontFamily:
+                                                                    "inherit",
+                                                                whiteSpace:
+                                                                    "nowrap",
+                                                                overflow:
+                                                                    "hidden",
                                                                 textOverflow:
                                                                     "ellipsis",
                                                             }}
@@ -419,7 +427,8 @@ export const ChatSidebar = memo(
                                                         fontFamily: "inherit",
                                                         display: "-webkit-box",
                                                         WebkitLineClamp: 1,
-                                                        WebkitBoxOrient: "vertical",
+                                                        WebkitBoxOrient:
+                                                            "vertical",
                                                         overflow: "hidden",
                                                     }}
                                                 >
@@ -492,7 +501,9 @@ export const ChatSidebar = memo(
                                 borderColor: "divider",
                                 bgcolor: "background.paper",
                                 boxShadow: "0px 10px 24px rgba(0, 0, 0, 0.08)",
-                            "&:hover": { backgroundColor: "fill.faintHover" },
+                                "&:hover": {
+                                    backgroundColor: "fill.faintHover",
+                                },
                             }}
                         >
                             <Typography

--- a/web/apps/ensu/src/components/chat/ChatSidebar.tsx
+++ b/web/apps/ensu/src/components/chat/ChatSidebar.tsx
@@ -4,6 +4,7 @@ import {
     ArrowRight01Icon,
     Cancel01Icon,
     Delete01Icon,
+    Edit01Icon,
     PlusSignIcon,
     Search01Icon,
 } from "@hugeicons/core-free-icons";
@@ -20,7 +21,7 @@ import {
     Typography,
 } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
-import React, { memo } from "react";
+import React, { memo, useState } from "react";
 
 type IconProps = { size: number; strokeWidth: number };
 
@@ -42,6 +43,7 @@ export interface ChatSidebarProps {
     groupedSessions: Array<[string, ChatSession[]]>;
     currentSessionId?: string;
     handleSelectSession: (sessionId: string) => void;
+    renameSession: (sessionId: string, title: string) => Promise<void>;
     requestDeleteSession: (sessionId: string) => void;
     openSettingsModal: () => void;
 }
@@ -65,341 +67,448 @@ export const ChatSidebar = memo(
         groupedSessions,
         currentSessionId,
         handleSelectSession,
+        renameSession,
         requestDeleteSession,
         openSettingsModal,
-    }: ChatSidebarProps) => (
-        <Stack
-            sx={{
-                width: "100%",
-                height: "100%",
-                bgcolor: "background.default",
-            }}
-        >
-            <List
+    }: ChatSidebarProps) => {
+        const [editingSessionId, setEditingSessionId] = useState<string>();
+        const [editingTitle, setEditingTitle] = useState("");
+
+        const startRename = (sessionId: string, title: string) => {
+            setEditingSessionId(sessionId);
+            setEditingTitle(title);
+        };
+
+        const cancelRename = () => {
+            setEditingSessionId(undefined);
+            setEditingTitle("");
+        };
+
+        const saveRename = async () => {
+            if (!editingSessionId) return;
+            const title = editingTitle.trim();
+            if (!title) {
+                cancelRename();
+                return;
+            }
+            await renameSession(editingSessionId, title);
+            cancelRename();
+        };
+
+        return (
+            <Stack
                 sx={{
-                    flex: 1,
-                    overflowY: "auto",
-                    px: 1,
-                    overscrollBehaviorY: "contain",
-                    scrollbarWidth: "thin",
-                    "&::-webkit-scrollbar": { width: "8px" },
-                    "&::-webkit-scrollbar-thumb": {
-                        backgroundColor: "divider",
-                        borderRadius: "999px",
-                    },
-                    "&::-webkit-scrollbar-track": {
-                        backgroundColor: "transparent",
-                    },
+                    width: "100%",
+                    height: "100%",
+                    bgcolor: "background.default",
                 }}
             >
-                <Stack
-                    direction="row"
+                <List
                     sx={{
-                        alignItems: "center",
-                        justifyContent: "flex-start",
-                        gap: 1,
-                        my: 1,
+                        flex: 1,
+                        overflowY: "auto",
                         px: 1,
-                        width: "100%",
+                        overscrollBehaviorY: "contain",
+                        scrollbarWidth: "thin",
+                        "&::-webkit-scrollbar": { width: "8px" },
+                        "&::-webkit-scrollbar-thumb": {
+                            backgroundColor: "divider",
+                            borderRadius: "999px",
+                        },
+                        "&::-webkit-scrollbar-track": {
+                            backgroundColor: "transparent",
+                        },
                     }}
                 >
-                    {showSessionSearch ? (
-                        <>
-                            <Box
-                                sx={{
-                                    flex: 1,
-                                    display: "flex",
-                                    alignItems: "center",
-                                    justifyContent: "flex-start",
-                                    gap: 1,
-                                    px: 1.5,
-                                    height: 40,
-                                    borderRadius: 2,
-                                    bgcolor: "fill.faint",
-                                    textAlign: "left",
-                                }}
-                            >
-                                <HugeiconsIcon
-                                    icon={Search01Icon}
-                                    {...tinyIconProps}
-                                />
-                                <InputBase
-                                    placeholder="Search chats"
-                                    autoFocus
-                                    value={sessionSearch}
-                                    onChange={(event) =>
-                                        setSessionSearch(event.target.value)
-                                    }
-                                    inputProps={{
-                                        style: { textAlign: "left" },
-                                    }}
+                    <Stack
+                        direction="row"
+                        sx={{
+                            alignItems: "center",
+                            justifyContent: "flex-start",
+                            gap: 1,
+                            my: 1,
+                            px: 1,
+                            width: "100%",
+                        }}
+                    >
+                        {showSessionSearch ? (
+                            <>
+                                <Box
                                     sx={{
                                         flex: 1,
-                                        color: "text.base",
-                                        fontFamily: "inherit",
-                                        fontSize: "13px",
+                                        display: "flex",
+                                        alignItems: "center",
+                                        justifyContent: "flex-start",
+                                        gap: 1,
+                                        px: 1.5,
+                                        height: 40,
+                                        borderRadius: 2,
+                                        bgcolor: "fill.faint",
                                         textAlign: "left",
-                                        "& input": { textAlign: "left" },
                                     }}
-                                />
-                            </Box>
-                            <IconButton
-                                aria-label="Close search"
-                                sx={drawerIconButtonSx}
-                                onClick={handleCloseSessionSearch}
-                            >
-                                <HugeiconsIcon
-                                    icon={Cancel01Icon}
-                                    {...tinyIconProps}
-                                />
-                            </IconButton>
-                            <IconButton
-                                aria-label={
-                                    drawerCollapsed
-                                        ? "Expand drawer"
-                                        : "Collapse drawer"
-                                }
-                                sx={drawerIconButtonSx}
-                                onClick={
-                                    drawerCollapsed
-                                        ? handleOpenDrawer
-                                        : handleCollapseDrawer
-                                }
-                            >
-                                <HugeiconsIcon
-                                    icon={
-                                        drawerCollapsed
-                                            ? ArrowRight01Icon
-                                            : ArrowLeft01Icon
-                                    }
-                                    {...smallIconProps}
-                                />
-                            </IconButton>
-                        </>
-                    ) : (
-                        <>
-                            <Button
-                                onClick={handleOpenSessionSearch}
-                                variant="outlined"
-                                startIcon={
+                                >
                                     <HugeiconsIcon
                                         icon={Search01Icon}
                                         {...tinyIconProps}
                                     />
-                                }
-                                sx={{
-                                    flex: 1,
-                                    minWidth: 0,
-                                    height: 40,
-                                    minHeight: 40,
-                                    px: 1.5,
-                                    textTransform: "none",
-                                    fontWeight: 600,
-                                    fontSize: "13px",
-                                    whiteSpace: "nowrap",
-                                    textOverflow: "ellipsis",
-                                    overflow: "hidden",
-                                    borderRadius: 2,
-                                    borderColor: "divider",
-                                    color: "text.base",
-                                    bgcolor: "fill.faint",
-                                    flexWrap: "nowrap",
-                                    justifyContent: "flex-start",
-                                    textAlign: "left",
-                                    "& .MuiButton-startIcon": {
-                                        marginRight: 0.75,
-                                        marginLeft: 0,
-                                    },
-                                    "&:hover": {
-                                        bgcolor: "fill.faintHover",
-                                        borderColor: "divider",
-                                    },
-                                }}
-                            >
-                                <Box
-                                    component="span"
-                                    sx={{
-                                        whiteSpace: "nowrap",
-                                        overflow: "hidden",
-                                        textOverflow: "ellipsis",
-                                    }}
-                                >
-                                    Search
+                                    <InputBase
+                                        placeholder="Search chats"
+                                        autoFocus
+                                        value={sessionSearch}
+                                        onChange={(event) =>
+                                            setSessionSearch(event.target.value)
+                                        }
+                                        inputProps={{
+                                            style: { textAlign: "left" },
+                                        }}
+                                        sx={{
+                                            flex: 1,
+                                            color: "text.base",
+                                            fontFamily: "inherit",
+                                            fontSize: "13px",
+                                            textAlign: "left",
+                                            "& input": { textAlign: "left" },
+                                        }}
+                                    />
                                 </Box>
-                            </Button>
-                            <Tooltip title="New Chat">
                                 <IconButton
-                                    aria-label="New Chat"
-                                    onClick={handleNewChat}
+                                    aria-label="Close search"
                                     sx={drawerIconButtonSx}
+                                    onClick={handleCloseSessionSearch}
                                 >
                                     <HugeiconsIcon
-                                        icon={PlusSignIcon}
+                                        icon={Cancel01Icon}
                                         {...tinyIconProps}
                                     />
                                 </IconButton>
-                            </Tooltip>
-                            <IconButton
-                                aria-label={
-                                    drawerCollapsed
-                                        ? "Expand drawer"
-                                        : "Collapse drawer"
-                                }
-                                sx={drawerIconButtonSx}
-                                onClick={
-                                    drawerCollapsed
-                                        ? handleOpenDrawer
-                                        : handleCollapseDrawer
-                                }
-                            >
-                                <HugeiconsIcon
-                                    icon={
+                                <IconButton
+                                    aria-label={
                                         drawerCollapsed
-                                            ? ArrowRight01Icon
-                                            : ArrowLeft01Icon
+                                            ? "Expand drawer"
+                                            : "Collapse drawer"
                                     }
-                                    {...smallIconProps}
-                                />
-                            </IconButton>
-                        </>
-                    )}
-                </Stack>
-
-                {groupedSessions.map(([label, group]) => (
-                    <Box key={label} sx={{ pb: 1 }}>
-                        <Typography
-                            variant="mini"
-                            sx={{
-                                px: 1,
-                                pt: 2,
-                                pb: 0.5,
-                                letterSpacing: "0.12em",
-                                color: "text.muted",
-                            }}
-                        >
-                            {label}
-                        </Typography>
-                        {group.map((session) => {
-                            const sessionTitle =
-                                session.title?.trim() || "New chat";
-                            return (
-                                <ListItemButton
-                                    key={session.sessionUuid}
-                                    selected={
-                                        session.sessionUuid === currentSessionId
+                                    sx={drawerIconButtonSx}
+                                    onClick={
+                                        drawerCollapsed
+                                            ? handleOpenDrawer
+                                            : handleCollapseDrawer
                                     }
-                                    onClick={() =>
-                                        handleSelectSession(session.sessionUuid)
+                                >
+                                    <HugeiconsIcon
+                                        icon={
+                                            drawerCollapsed
+                                                ? ArrowRight01Icon
+                                                : ArrowLeft01Icon
+                                        }
+                                        {...smallIconProps}
+                                    />
+                                </IconButton>
+                            </>
+                        ) : (
+                            <>
+                                <Button
+                                    onClick={handleOpenSessionSearch}
+                                    variant="outlined"
+                                    startIcon={
+                                        <HugeiconsIcon
+                                            icon={Search01Icon}
+                                            {...tinyIconProps}
+                                        />
                                     }
                                     sx={{
-                                        alignItems: "flex-start",
-                                        py: 1.5,
+                                        flex: 1,
+                                        minWidth: 0,
+                                        height: 40,
+                                        minHeight: 40,
+                                        px: 1.5,
+                                        textTransform: "none",
+                                        fontWeight: 600,
+                                        fontSize: "13px",
+                                        whiteSpace: "nowrap",
+                                        textOverflow: "ellipsis",
+                                        overflow: "hidden",
                                         borderRadius: 2,
-                                        my: 0.5,
+                                        borderColor: "divider",
+                                        color: "text.base",
+                                        bgcolor: "fill.faint",
+                                        flexWrap: "nowrap",
+                                        justifyContent: "flex-start",
+                                        textAlign: "left",
+                                        "& .MuiButton-startIcon": {
+                                            marginRight: 0.75,
+                                            marginLeft: 0,
+                                        },
                                         "&:hover": {
-                                            backgroundColor: "fill.faintHover",
-                                        },
-                                        "&.Mui-selected": {
-                                            backgroundColor: "fill.faint",
-                                        },
-                                        "&.Mui-selected:hover": {
-                                            backgroundColor: "fill.faintHover",
+                                            bgcolor: "fill.faintHover",
+                                            borderColor: "divider",
                                         },
                                     }}
                                 >
-                                    <Stack
-                                        direction="row"
+                                    <Box
+                                        component="span"
                                         sx={{
-                                            width: "100%",
-                                            alignItems: "flex-start",
-                                            gap: 1,
+                                            whiteSpace: "nowrap",
+                                            overflow: "hidden",
+                                            textOverflow: "ellipsis",
                                         }}
                                     >
-                                        <Box sx={{ flex: 1, minWidth: 0 }}>
-                                            <Tooltip title={sessionTitle}>
-                                                <Typography
-                                                    variant="small"
-                                                    sx={{
-                                                        fontWeight: 600,
+                                        Search
+                                    </Box>
+                                </Button>
+                                <Tooltip title="New Chat">
+                                    <IconButton
+                                        aria-label="New Chat"
+                                        onClick={handleNewChat}
+                                        sx={drawerIconButtonSx}
+                                    >
+                                        <HugeiconsIcon
+                                            icon={PlusSignIcon}
+                                            {...tinyIconProps}
+                                        />
+                                    </IconButton>
+                                </Tooltip>
+                                <IconButton
+                                    aria-label={
+                                        drawerCollapsed
+                                            ? "Expand drawer"
+                                            : "Collapse drawer"
+                                    }
+                                    sx={drawerIconButtonSx}
+                                    onClick={
+                                        drawerCollapsed
+                                            ? handleOpenDrawer
+                                            : handleCollapseDrawer
+                                    }
+                                >
+                                    <HugeiconsIcon
+                                        icon={
+                                            drawerCollapsed
+                                                ? ArrowRight01Icon
+                                                : ArrowLeft01Icon
+                                        }
+                                        {...smallIconProps}
+                                    />
+                                </IconButton>
+                            </>
+                        )}
+                    </Stack>
+
+                    {groupedSessions.map(([label, group]) => (
+                        <Box key={label} sx={{ pb: 1 }}>
+                            <Typography
+                                variant="mini"
+                                sx={{
+                                    px: 1,
+                                    pt: 2,
+                                    pb: 0.5,
+                                    letterSpacing: "0.12em",
+                                    color: "text.muted",
+                                }}
+                            >
+                                {label}
+                            </Typography>
+                            {group.map((session) => {
+                                const sessionTitle =
+                                    session.title?.trim() || "New chat";
+                                return (
+                                    <ListItemButton
+                                        key={session.sessionUuid}
+                                        selected={
+                                        session.sessionUuid === currentSessionId
+                                        }
+                                        onClick={() =>
+                                        handleSelectSession(session.sessionUuid)
+                                        }
+                                        sx={{
+                                            alignItems: "flex-start",
+                                            py: 1.5,
+                                            borderRadius: 2,
+                                            my: 0.5,
+                                            "&:hover .chat-session-rename-button, &:focus-within .chat-session-rename-button":
+                                                {
+                                                    width: 36,
+                                                    minWidth: 36,
+                                                    px: 1,
+                                                    opacity: 1,
+                                                    pointerEvents: "auto",
+                                                },
+                                            "&:hover": {
+                                            backgroundColor: "fill.faintHover",
+                                            },
+                                            "&.Mui-selected": {
+                                                backgroundColor: "fill.faint",
+                                            },
+                                            "&.Mui-selected:hover": {
+                                            backgroundColor: "fill.faintHover",
+                                            },
+                                        }}
+                                    >
+                                        <Stack
+                                            direction="row"
+                                            sx={{
+                                                width: "100%",
+                                                alignItems: "flex-start",
+                                                gap: 1,
+                                            }}
+                                        >
+                                            <Box sx={{ flex: 1, minWidth: 0 }}>
+                                                {editingSessionId ===
+                                                session.sessionUuid ? (
+                                                    <InputBase
+                                                        autoFocus
+                                                        value={editingTitle}
+                                                        onChange={(event) =>
+                                                            setEditingTitle(
+                                                                event.target
+                                                                    .value,
+                                                            )
+                                                        }
+                                                        onClick={(event) =>
+                                                            event.stopPropagation()
+                                                        }
+                                                        onKeyDown={(event) => {
+                                                            if (
+                                                                event.key ===
+                                                                "Enter"
+                                                            ) {
+                                                                event.preventDefault();
+                                                                void saveRename();
+                                                            } else if (
+                                                                event.key ===
+                                                                "Escape"
+                                                            ) {
+                                                                event.preventDefault();
+                                                                cancelRename();
+                                                            }
+                                                        }}
+                                                        onBlur={() =>
+                                                            void saveRename()
+                                                        }
+                                                        sx={{
+                                                            width: "100%",
+                                                            color: "text.base",
+                                                            fontWeight: 600,
+                                                            fontFamily:
+                                                                "inherit",
+                                                            fontSize: "13px",
+                                                        }}
+                                                    />
+                                                ) : (
+                                                    <Tooltip
+                                                        title={sessionTitle}
+                                                    >
+                                                        <Typography
+                                                            variant="small"
+                                                            sx={{
+                                                                fontWeight: 600,
                                                         fontFamily: "inherit",
                                                         whiteSpace: "nowrap",
                                                         overflow: "hidden",
-                                                        textOverflow:
-                                                            "ellipsis",
+                                                                textOverflow:
+                                                                    "ellipsis",
+                                                            }}
+                                                        >
+                                                            {sessionTitle}
+                                                        </Typography>
+                                                    </Tooltip>
+                                                )}
+                                                <Typography
+                                                    variant="mini"
+                                                    sx={{
+                                                        color: "text.muted",
+                                                        fontFamily: "inherit",
+                                                        display: "-webkit-box",
+                                                        WebkitLineClamp: 1,
+                                                        WebkitBoxOrient: "vertical",
+                                                        overflow: "hidden",
                                                     }}
                                                 >
-                                                    {sessionTitle}
+                                                    {session.lastMessagePreview ??
+                                                        "Nothing here"}
                                                 </Typography>
-                                            </Tooltip>
-                                            <Typography
-                                                variant="mini"
+                                            </Box>
+                                            <IconButton
+                                                className="chat-session-rename-button"
+                                                aria-label="Rename chat"
                                                 sx={{
-                                                    color: "text.muted",
-                                                    fontFamily: "inherit",
-                                                    display: "-webkit-box",
-                                                    WebkitLineClamp: 1,
-                                                    WebkitBoxOrient: "vertical",
+                                                    ...actionButtonSx,
+                                                    width: 0,
+                                                    minWidth: 0,
+                                                    px: 0,
+                                                    opacity: 0,
+                                                    pointerEvents: "none",
                                                     overflow: "hidden",
+                                                    transition:
+                                                        "width 0.15s ease, opacity 0.15s ease",
+                                                }}
+                                                onClick={(event) => {
+                                                    event.stopPropagation();
+                                                    startRename(
+                                                        session.sessionUuid,
+                                                        sessionTitle,
+                                                    );
                                                 }}
                                             >
-                                                {session.lastMessagePreview ??
-                                                    "Nothing here"}
-                                            </Typography>
-                                        </Box>
-                                        <IconButton
-                                            aria-label="Delete chat"
-                                            sx={actionButtonSx}
-                                            onClick={(event) => {
-                                                event.stopPropagation();
-                                                requestDeleteSession(
-                                                    session.sessionUuid,
-                                                );
-                                            }}
-                                        >
-                                            <HugeiconsIcon
-                                                icon={Delete01Icon}
-                                                {...actionIconProps}
-                                            />
-                                        </IconButton>
-                                    </Stack>
-                                </ListItemButton>
-                            );
-                        })}
-                    </Box>
-                ))}
-            </List>
+                                                <HugeiconsIcon
+                                                    icon={Edit01Icon}
+                                                    {...actionIconProps}
+                                                />
+                                            </IconButton>
+                                            <IconButton
+                                                aria-label="Delete chat"
+                                                sx={actionButtonSx}
+                                                onClick={(event) => {
+                                                    event.stopPropagation();
+                                                    requestDeleteSession(
+                                                        session.sessionUuid,
+                                                    );
+                                                }}
+                                            >
+                                                <HugeiconsIcon
+                                                    icon={Delete01Icon}
+                                                    {...actionIconProps}
+                                                />
+                                            </IconButton>
+                                        </Stack>
+                                    </ListItemButton>
+                                );
+                            })}
+                        </Box>
+                    ))}
+                </List>
 
-            {!drawerCollapsed && (
-                <Stack sx={{ p: 1 }}>
-                    <ListItemButton
-                        onClick={openSettingsModal}
-                        sx={{
-                            alignItems: "center",
-                            gap: 1,
-                            px: 2,
-                            py: 1.25,
-                            width: "100%",
-                            borderRadius: 2,
-                            border: "1px solid",
-                            borderColor: "divider",
-                            bgcolor: "background.paper",
-                            boxShadow: "0px 10px 24px rgba(0, 0, 0, 0.08)",
+                {!drawerCollapsed && (
+                    <Stack sx={{ p: 1 }}>
+                        <ListItemButton
+                            onClick={openSettingsModal}
+                            sx={{
+                                alignItems: "center",
+                                gap: 1,
+                                px: 2,
+                                py: 1.25,
+                                width: "100%",
+                                borderRadius: 2,
+                                border: "1px solid",
+                                borderColor: "divider",
+                                bgcolor: "background.paper",
+                                boxShadow: "0px 10px 24px rgba(0, 0, 0, 0.08)",
                             "&:hover": { backgroundColor: "fill.faintHover" },
-                        }}
-                    >
-                        <Typography
-                            variant="small"
-                            sx={{ flex: 1, fontWeight: 600 }}
+                            }}
                         >
-                            Settings
-                        </Typography>
-                        <HugeiconsIcon
-                            icon={ArrowRight01Icon}
-                            {...smallIconProps}
-                        />
-                    </ListItemButton>
-                </Stack>
-            )}
-        </Stack>
-    ),
+                            <Typography
+                                variant="small"
+                                sx={{ flex: 1, fontWeight: 600 }}
+                            >
+                                Settings
+                            </Typography>
+                            <HugeiconsIcon
+                                icon={ArrowRight01Icon}
+                                {...smallIconProps}
+                            />
+                        </ListItemButton>
+                    </Stack>
+                )}
+            </Stack>
+        );
+    },
 );

--- a/web/apps/ensu/src/pages/chat.tsx
+++ b/web/apps/ensu/src/pages/chat.tsx
@@ -1857,8 +1857,9 @@ const Page: React.FC = () => {
         async (sessionUuid: string, title: string) => {
             if (!chatKey) return;
             try {
-                await updateSessionTitle(sessionUuid, title, chatKey);
-                updateSessionTitleInState(sessionUuid, title.trim());
+                const safeTitle = sessionTitleFromText(title, "New chat");
+                await updateSessionTitle(sessionUuid, safeTitle, chatKey);
+                updateSessionTitleInState(sessionUuid, safeTitle);
             } catch (error) {
                 onGenericError(error);
             }

--- a/web/apps/ensu/src/pages/chat.tsx
+++ b/web/apps/ensu/src/pages/chat.tsx
@@ -1853,6 +1853,19 @@ const Page: React.FC = () => {
         [],
     );
 
+    const handleRenameSession = useCallback(
+        async (sessionUuid: string, title: string) => {
+            if (!chatKey) return;
+            try {
+                await updateSessionTitle(sessionUuid, title, chatKey);
+                updateSessionTitleInState(sessionUuid, title.trim());
+            } catch (error) {
+                onGenericError(error);
+            }
+        },
+        [chatKey, onGenericError, updateSessionTitleInState],
+    );
+
     const maybeGenerateSessionTitle = useCallback(
         async ({
             sessionUuid,
@@ -3890,6 +3903,7 @@ const Page: React.FC = () => {
             groupedSessions={groupedSessions}
             currentSessionId={currentSessionId}
             handleSelectSession={handleSelectSession}
+            renameSession={handleRenameSession}
             requestDeleteSession={requestDeleteSession}
             openSettingsModal={openSettingsModal}
         />

--- a/web/apps/ensu/src/pages/chat.tsx
+++ b/web/apps/ensu/src/pages/chat.tsx
@@ -1942,6 +1942,10 @@ const Page: React.FC = () => {
                 );
                 if (!firstUser) return;
 
+                const automaticFallbackTitle = sessionTitleFromText(
+                    firstUser.text,
+                    "New chat",
+                );
                 const userText = parseDocumentBlocks(firstUser.text).text;
                 const assistantText = stripHiddenPartsText(firstAssistant.text);
 
@@ -1960,6 +1964,17 @@ const Page: React.FC = () => {
 
                 await queueSessionTitleUpdate(sessionUuid, async () => {
                     if (manuallyRenamedSessionIdsRef.current.has(sessionUuid)) {
+                        return;
+                    }
+
+                    const latestSession = (await listSessions(chatKey)).find(
+                        (session) => session.sessionUuid === sessionUuid,
+                    );
+                    if (
+                        manuallyRenamedSessionIdsRef.current.has(sessionUuid) ||
+                        !latestSession ||
+                        latestSession.title !== automaticFallbackTitle
+                    ) {
                         return;
                     }
 

--- a/web/apps/ensu/src/pages/chat.tsx
+++ b/web/apps/ensu/src/pages/chat.tsx
@@ -1963,16 +1963,6 @@ const Page: React.FC = () => {
                         return;
                     }
 
-                    const latestSession = (await listSessions(chatKey)).find(
-                        (session) => session.sessionUuid === sessionUuid,
-                    );
-                    if (
-                        manuallyRenamedSessionIdsRef.current.has(sessionUuid) ||
-                        latestSession?.title.toLowerCase() !== "new chat"
-                    ) {
-                        return;
-                    }
-
                     await updateSessionTitle(sessionUuid, title, chatKey);
                     updateSessionTitleInState(sessionUuid, title);
                 });

--- a/web/apps/ensu/src/pages/chat.tsx
+++ b/web/apps/ensu/src/pages/chat.tsx
@@ -664,6 +664,8 @@ const Page: React.FC = () => {
         previousSelection?: string | null;
     } | null>(null);
     const sessionSummaryInFlightRef = useRef(false);
+    const manuallyRenamedSessionIdsRef = useRef(new Set<string>());
+    const sessionTitleUpdateQueueRef = useRef(new Map<string, Promise<void>>());
     const inputRef = useRef<HTMLTextAreaElement | null>(null);
     const attachmentPreviewUrlsRef = useRef<Record<string, string>>({});
     const pendingPreviewUrlsRef = useRef<Record<string, string>>({});
@@ -1853,18 +1855,61 @@ const Page: React.FC = () => {
         [],
     );
 
-    const handleRenameSession = useCallback(
-        async (sessionUuid: string, title: string) => {
-            if (!chatKey) return;
+    const queueSessionTitleUpdate = useCallback(
+        async (sessionUuid: string, update: () => Promise<void>) => {
+            const previous =
+                sessionTitleUpdateQueueRef.current.get(sessionUuid) ??
+                Promise.resolve();
+            const task = previous.catch(() => undefined).then(update);
+            const queueEntry = task.then(
+                () => undefined,
+                () => undefined,
+            );
+            sessionTitleUpdateQueueRef.current.set(sessionUuid, queueEntry);
+
             try {
-                const safeTitle = sessionTitleFromText(title, "New chat");
-                await updateSessionTitle(sessionUuid, safeTitle, chatKey);
-                updateSessionTitleInState(sessionUuid, safeTitle);
-            } catch (error) {
-                onGenericError(error);
+                await task;
+            } finally {
+                if (
+                    sessionTitleUpdateQueueRef.current.get(sessionUuid) ===
+                    queueEntry
+                ) {
+                    sessionTitleUpdateQueueRef.current.delete(sessionUuid);
+                }
             }
         },
-        [chatKey, onGenericError, updateSessionTitleInState],
+        [],
+    );
+
+    const handleRenameSession = useCallback(
+        async (sessionUuid: string, title: string) => {
+            if (!chatKey) return false;
+            try {
+                const safeTitle = sessionTitleFromText(title, "New chat");
+                const currentSession = sessions.find(
+                    (session) => session.sessionUuid === sessionUuid,
+                );
+                if (currentSession?.title === safeTitle) return true;
+
+                manuallyRenamedSessionIdsRef.current.add(sessionUuid);
+                await queueSessionTitleUpdate(sessionUuid, async () => {
+                    await updateSessionTitle(sessionUuid, safeTitle, chatKey);
+                    updateSessionTitleInState(sessionUuid, safeTitle);
+                });
+                return true;
+            } catch (error) {
+                manuallyRenamedSessionIdsRef.current.delete(sessionUuid);
+                onGenericError(error);
+                return false;
+            }
+        },
+        [
+            chatKey,
+            onGenericError,
+            queueSessionTitleUpdate,
+            sessions,
+            updateSessionTitleInState,
+        ],
     );
 
     const maybeGenerateSessionTitle = useCallback(
@@ -1913,8 +1958,24 @@ const Page: React.FC = () => {
                     ? sessionTitleFromText(summarySeed, fallbackTitle)
                     : fallbackTitle;
 
-                await updateSessionTitle(sessionUuid, title, chatKey);
-                updateSessionTitleInState(sessionUuid, title);
+                await queueSessionTitleUpdate(sessionUuid, async () => {
+                    if (manuallyRenamedSessionIdsRef.current.has(sessionUuid)) {
+                        return;
+                    }
+
+                    const latestSession = (await listSessions(chatKey)).find(
+                        (session) => session.sessionUuid === sessionUuid,
+                    );
+                    if (
+                        manuallyRenamedSessionIdsRef.current.has(sessionUuid) ||
+                        latestSession?.title.toLowerCase() !== "new chat"
+                    ) {
+                        return;
+                    }
+
+                    await updateSessionTitle(sessionUuid, title, chatKey);
+                    updateSessionTitleInState(sessionUuid, title);
+                });
             } catch (error) {
                 log.error("Failed to generate session title", error);
             } finally {
@@ -1924,6 +1985,7 @@ const Page: React.FC = () => {
         [
             chatKey,
             generateSessionSummary,
+            queueSessionTitleUpdate,
             trimToWords,
             updateSessionTitleInState,
         ],


### PR DESCRIPTION
## Description
Implemented the rename feature as discussed in #11819. The edit icon is displayed when hovering over or focusing a chat row.

## Tests
<img width="1234" height="898" alt="Screencast_20260805_233410" src="https://github.com/user-attachments/assets/19411f51-75e5-4d48-a885-dc7c064a2091" />
