### PR TITLE
[mobile][photos] Fix Smart Memories date boundaries

### DIFF
--- a/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
@@ -108,6 +108,7 @@ class TimeMemoriesCalculator {
           .toList();
 
       if (significantDays.length >= 3) {
+        final titleDate = DateTime(significantDays.first, month, day);
         final allPhotos = yearGroups.values.expand((x) => x).toList();
         final photoSelection = await SmartMemoriesService._bestSelection(
           allPhotos,
@@ -122,7 +123,7 @@ class TimeMemoriesCalculator {
         historicalMemoryResult.add(
           TimeMemory(
             photoSelection,
-            day: showDate,
+            day: titleDate,
             showDate.subtract(kMemoriesMargin).microsecondsSinceEpoch,
             showDate.add(kDayItself).microsecondsSinceEpoch,
           ),
@@ -322,9 +323,13 @@ class TimeMemoriesCalculator {
   }
 
   static DateTime _nextOccurrence(DateTime currentTime, int month, int day) {
-    DateTime occurrenceIn(int year) => currentTime.isUtc
-        ? DateTime.utc(year, month, day)
-        : DateTime(year, month, day);
+    DateTime occurrenceIn(int year) {
+      final lastDayOfMonth = DateTime.utc(year, month + 1, 0).day;
+      final occurrenceDay = min(day, lastDayOfMonth);
+      return currentTime.isUtc
+          ? DateTime.utc(year, month, occurrenceDay)
+          : DateTime(year, month, occurrenceDay);
+    }
 
     var occurrence = occurrenceIn(currentTime.year);
     if (_calendarDayDifference(currentTime, occurrence) < 0) {

--- a/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
@@ -69,7 +69,6 @@ class TimeMemoriesCalculator {
       clipPositiveTextVector: clipPositiveTextVector,
     );
 
-    final currentDayMonth = currentTime.month * 100 + currentTime.day;
     final currentWeek = getWeekNumber(currentTime);
     final currentMonth = currentTime.month;
     final currentYear = currentTime.year;
@@ -96,8 +95,11 @@ class TimeMemoriesCalculator {
     }
 
     for (final dayMonth in dayMonthYearGroups.keys) {
-      final dayDiff = dayMonth - currentDayMonth;
-      if (dayDiff < 0 || dayDiff > kMemoriesUpdateFrequency.inDays) continue;
+      final month = dayMonth ~/ 100;
+      final day = dayMonth % 100;
+      final showDate = _nextOccurrence(currentTime, month, day);
+      final dayDiff = _calendarDayDifference(currentTime, showDate);
+      if (dayDiff > kMemoriesUpdateFrequency.inDays) continue;
 
       final yearGroups = dayMonthYearGroups[dayMonth]!;
       final significantDays = yearGroups.entries
@@ -106,11 +108,6 @@ class TimeMemoriesCalculator {
           .toList();
 
       if (significantDays.length >= 3) {
-        final date = DateTime(
-          currentTime.year,
-          dayMonth ~/ 100,
-          dayMonth % 100,
-        );
         final allPhotos = yearGroups.values.expand((x) => x).toList();
         final photoSelection = await SmartMemoriesService._bestSelection(
           allPhotos,
@@ -125,19 +122,14 @@ class TimeMemoriesCalculator {
         historicalMemoryResult.add(
           TimeMemory(
             photoSelection,
-            day: date,
-            date.subtract(kMemoriesMargin).microsecondsSinceEpoch,
-            date.add(kDayItself).microsecondsSinceEpoch,
+            day: showDate,
+            showDate.subtract(kMemoriesMargin).microsecondsSinceEpoch,
+            showDate.add(kDayItself).microsecondsSinceEpoch,
           ),
         );
       } else {
         for (final year in significantDays) {
-          final date = DateTime(year, dayMonth ~/ 100, dayMonth % 100);
-          final showDate = DateTime(
-            currentYear,
-            dayMonth ~/ 100,
-            dayMonth % 100,
-          );
+          final date = DateTime(year, month, day);
           final files = yearGroups[year]!;
           final photoSelection = await SmartMemoriesService._bestSelection(
             files,
@@ -152,7 +144,7 @@ class TimeMemoriesCalculator {
             TimeMemory(
               photoSelection,
               day: date,
-              yearsAgo: currentTime.year - date.year,
+              yearsAgo: showDate.year - date.year,
               showDate.subtract(kMemoriesMargin).microsecondsSinceEpoch,
               showDate.add(kDayItself).microsecondsSinceEpoch,
             ),
@@ -327,6 +319,24 @@ class TimeMemoriesCalculator {
     );
 
     return [...recentMemoryResult, ...historicalMemoryResult];
+  }
+
+  static DateTime _nextOccurrence(DateTime currentTime, int month, int day) {
+    DateTime occurrenceIn(int year) => currentTime.isUtc
+        ? DateTime.utc(year, month, day)
+        : DateTime(year, month, day);
+
+    var occurrence = occurrenceIn(currentTime.year);
+    if (_calendarDayDifference(currentTime, occurrence) < 0) {
+      occurrence = occurrenceIn(currentTime.year + 1);
+    }
+    return occurrence;
+  }
+
+  static int _calendarDayDifference(DateTime start, DateTime end) {
+    final startDate = DateTime.utc(start.year, start.month, start.day);
+    final endDate = DateTime.utc(end.year, end.month, end.day);
+    return endDate.difference(startDate).inDays;
   }
 
   static Future<void> _maybeAddRecentTimeMemory(

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -139,69 +139,6 @@ void main() {
     );
 
     test(
-      "TimeMemoriesCalculator includes upcoming days across month boundaries",
-      () async {
-        final currentTime = DateTime.utc(2026, 8, 29);
-        final historicalFile = _file(
-          id: 1,
-          createdAt: DateTime.utc(2024, 9, 1, 12),
-        );
-
-        final memories = await TimeMemoriesCalculator.computeTimeMemories(
-          [historicalFile],
-          currentTime,
-          isLocalGalleryMode: false,
-          mlEnabled: false,
-          seenTimes: const <int, int>{},
-          fileIdToFaces: const <int, List<FaceWithoutEmbedding>>{},
-          faceIDsToPersonID: const <String, String>{},
-          fileIDToImageEmbedding: const <int, EmbeddingVector>{},
-          clipPositiveTextVector: _positiveTextVector,
-        );
-
-        final dayMemory = memories.singleWhere(
-          (memory) => memory.kind == TimeMemoryKind.day,
-        );
-        expect(dayMemory.memories.single.file.uploadedFileID, 1);
-        expect(dayMemory.day!.year, 2024);
-        expect(dayMemory.day!.month, 9);
-        expect(dayMemory.day!.day, 1);
-      },
-    );
-
-    test(
-      "TimeMemoriesCalculator includes upcoming days across year boundaries",
-      () async {
-        final currentTime = DateTime.utc(2026, 12, 30);
-        final historicalFile = _file(
-          id: 1,
-          createdAt: DateTime.utc(2024, 1, 1, 12),
-        );
-
-        final memories = await TimeMemoriesCalculator.computeTimeMemories(
-          [historicalFile],
-          currentTime,
-          isLocalGalleryMode: false,
-          mlEnabled: false,
-          seenTimes: const <int, int>{},
-          fileIdToFaces: const <int, List<FaceWithoutEmbedding>>{},
-          faceIDsToPersonID: const <String, String>{},
-          fileIDToImageEmbedding: const <int, EmbeddingVector>{},
-          clipPositiveTextVector: _positiveTextVector,
-        );
-
-        final dayMemory = memories.singleWhere(
-          (memory) => memory.kind == TimeMemoryKind.day,
-        );
-        expect(dayMemory.yearsAgo, 3);
-        expect(
-          dayMemory.firstDateToShow,
-          DateTime.utc(2026, 12, 31).microsecondsSinceEpoch,
-        );
-      },
-    );
-
-    test(
       "ClipMemoriesCalculator surfaces a memory from the full source set",
       () async {
         final currentTime = DateTime.utc(2026, 4, 10);

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -139,6 +139,69 @@ void main() {
     );
 
     test(
+      "TimeMemoriesCalculator includes upcoming days across month boundaries",
+      () async {
+        final currentTime = DateTime.utc(2026, 8, 29);
+        final historicalFile = _file(
+          id: 1,
+          createdAt: DateTime.utc(2024, 9, 1, 12),
+        );
+
+        final memories = await TimeMemoriesCalculator.computeTimeMemories(
+          [historicalFile],
+          currentTime,
+          isLocalGalleryMode: false,
+          mlEnabled: false,
+          seenTimes: const <int, int>{},
+          fileIdToFaces: const <int, List<FaceWithoutEmbedding>>{},
+          faceIDsToPersonID: const <String, String>{},
+          fileIDToImageEmbedding: const <int, EmbeddingVector>{},
+          clipPositiveTextVector: _positiveTextVector,
+        );
+
+        final dayMemory = memories.singleWhere(
+          (memory) => memory.kind == TimeMemoryKind.day,
+        );
+        expect(dayMemory.memories.single.file.uploadedFileID, 1);
+        expect(dayMemory.day!.year, 2024);
+        expect(dayMemory.day!.month, 9);
+        expect(dayMemory.day!.day, 1);
+      },
+    );
+
+    test(
+      "TimeMemoriesCalculator includes upcoming days across year boundaries",
+      () async {
+        final currentTime = DateTime.utc(2026, 12, 30);
+        final historicalFile = _file(
+          id: 1,
+          createdAt: DateTime.utc(2024, 1, 1, 12),
+        );
+
+        final memories = await TimeMemoriesCalculator.computeTimeMemories(
+          [historicalFile],
+          currentTime,
+          isLocalGalleryMode: false,
+          mlEnabled: false,
+          seenTimes: const <int, int>{},
+          fileIdToFaces: const <int, List<FaceWithoutEmbedding>>{},
+          faceIDsToPersonID: const <String, String>{},
+          fileIDToImageEmbedding: const <int, EmbeddingVector>{},
+          clipPositiveTextVector: _positiveTextVector,
+        );
+
+        final dayMemory = memories.singleWhere(
+          (memory) => memory.kind == TimeMemoryKind.day,
+        );
+        expect(dayMemory.yearsAgo, 3);
+        expect(
+          dayMemory.firstDateToShow,
+          DateTime.utc(2026, 12, 31).microsecondsSinceEpoch,
+        );
+      },
+    );
+
+    test(
       "ClipMemoriesCalculator surfaces a memory from the full source set",
       () async {
         final currentTime = DateTime.utc(2026, 4, 10);


### PR DESCRIPTION
## Bug
Historical Smart Memories compared MMDD integers to decide whether an anniversary fell within the upcoming computation window. Dates just across a month boundary were treated as dozens of days away, and dates across the year boundary were always skipped.

## Root cause
Calendar dates were encoded as month * 100 + day and subtracted instead of comparing actual dates.

## Fix
Resolve each anniversary to its next calendar occurrence, compare calendar-day distances, and use that occurrence for the display window and years-ago value.

## Verification
- flutter test test/services/memories/smart_memories_source_selection_test.dart
- flutter analyze lib/services/smart_memories_time_calculator.dart test/services/memories/smart_memories_source_selection_test.dart
- dart format on both touched files