### PR TITLE
[rust][photos] Reduce bulk vector search memory

### DIFF
--- a/rust/crates/photos/src/ml/vector_db.rs
+++ b/rust/crates/photos/src/ml/vector_db.rs
@@ -354,36 +354,22 @@ impl VectorDB {
         exact: bool,
     ) -> Result<BulkSearchByKeyMatch, String> {
         let dimensions = self.index.dimensions();
-        let mut embedding_data = vec![0.0f32; potential_keys.len() * dimensions];
-        let mut contained_keys = Vec::with_capacity(potential_keys.len());
-        let mut actual_query_count = 0;
+        let result_capacity = potential_keys.len().min(self.index.size());
+        let mut contained_keys = Vec::with_capacity(result_capacity);
+        let mut closeby_keys = Vec::with_capacity(result_capacity);
+        let mut distances = Vec::with_capacity(result_capacity);
+        let mut query = vec![0.0f32; dimensions];
 
         for key in potential_keys {
             if self.index.contains(*key) {
-                let start_idx = actual_query_count * dimensions;
-                let end_idx = start_idx + dimensions;
-                let embedding_slice = &mut embedding_data[start_idx..end_idx];
-
                 self.index
-                    .get(*key, embedding_slice)
+                    .get(*key, &mut query)
                     .map_err(|e| format!("Failed to get vector for key {key}: {e}"))?;
+                let (keys_result, distances_result) = self.search_vectors(&query, count, exact)?;
                 contained_keys.push(*key);
-                actual_query_count += 1;
+                closeby_keys.push(keys_result);
+                distances.push(distances_result);
             }
-        }
-        embedding_data.truncate(actual_query_count * dimensions);
-
-        let max_result_size = std::cmp::min(self.index.size(), count);
-        let mut closeby_keys = vec![Vec::with_capacity(max_result_size); actual_query_count];
-        let mut distances = vec![Vec::with_capacity(max_result_size); actual_query_count];
-
-        for i in 0..actual_query_count {
-            let start_idx = i * dimensions;
-            let end_idx = start_idx + dimensions;
-            let query_slice = &embedding_data[start_idx..end_idx];
-            let (keys_result, distances_result) = self.search_vectors(query_slice, count, exact)?;
-            closeby_keys[i] = keys_result;
-            distances[i] = distances_result;
         }
 
         Ok((contained_keys, closeby_keys, distances))
@@ -471,5 +457,31 @@ impl VectorDB {
             expansion_add,
             expansion_search,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VectorDB;
+
+    #[test]
+    fn bulk_search_keys_preserves_contained_key_order_and_result_alignment() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let index_path = temp_dir.path().join("vectors.usearch");
+        let mut db = VectorDB::new(index_path.to_str().unwrap(), 3).unwrap();
+        db.bulk_add_vectors(vec![2, 4], &[vec![1.0, 0.0, 0.0], vec![0.0, 1.0, 0.0]])
+            .unwrap();
+
+        let potential_keys = vec![9, 4, 2, 8];
+        let (contained_keys, matched_keys, distances) =
+            db.bulk_search_keys(&potential_keys, 2, true).unwrap();
+
+        assert_eq!(contained_keys, vec![4, 2]);
+        assert_eq!(matched_keys.len(), contained_keys.len());
+        assert_eq!(distances.len(), contained_keys.len());
+        assert_eq!(matched_keys[0].first(), Some(&4));
+        assert_eq!(matched_keys[1].first(), Some(&2));
+        assert_eq!(distances[0].first(), Some(&0.0));
+        assert_eq!(distances[1].first(), Some(&0.0));
     }
 }


### PR DESCRIPTION
## Opportunity

Similar Images passes every eligible indexed photo ID to VectorDB.bulk_search_keys. The Rust implementation allocated a contiguous scratch buffer sized as potential keys times embedding dimensions before running the searches, even though only one query vector is needed at a time.

## Evidence of value

CLIP image embeddings are 512-dimensional, so the removed scratch buffer consumed 2,048 bytes per potential key: 195.3 MiB for a 100,000-photo library.

A temporary 5,000-key, 512-dimension probe isolated this buffer using the same test binary. Peak RSS fell from 43,728,896 bytes to 33,357,824 bytes, a 10,371,072-byte reduction that matches the removed allocation. Wall time was effectively unchanged (4.46 s before, 4.42 s after), so this PR makes no latency claim.

## Implementation

Reuse one embedding-sized query buffer, search each contained key immediately, and append its keys and distances to the aligned result vectors. A focused test covers missing-key filtering, contained-key order, self matches, and result alignment.

## Risk

Low. The public API and output shape are unchanged, and the method still performs the same contains, get, and search operations in input order. The change only shortens the lifetime and count of query-vector storage.

## Verification

- cargo fmt --all -- --check
- cargo test -p ente-photos --features usearch ml::vector_db::tests::bulk_search_keys_preserves_contained_key_order_and_result_alignment
- cargo clippy -p ente-photos --features usearch --tests -- -D warnings