### PR TITLE
[rust][image] TIFF decode code cleanup

### DIFF
--- a/rust/crates/image/src/decode.rs
+++ b/rust/crates/image/src/decode.rs
@@ -171,34 +171,15 @@ fn should_attempt_tiff_fallback(format: Option<ImageFormat>) -> bool {
 fn decode_with_tiff_crate(image_path: &str) -> ImageResult<DecodedDynamicImage> {
     let file = File::open(image_path)
         .map_err(|e| ImageError::Decode(format!("failed to open TIFF file '{image_path}': {e}")))?;
-    let mut decoder = TiffDecoder::new(BufReader::new(file))
-        .map_err(|e| ImageError::Decode(format!("failed to initialize TIFF decoder: {e}")))?;
-    let (width, height) = decoder
-        .dimensions()
-        .map_err(|e| ImageError::Decode(format!("failed to read TIFF dimensions: {e}")))?;
-    let color_type = decoder
-        .colortype()
-        .map_err(|e| ImageError::Decode(format!("failed to read TIFF color type: {e}")))?;
-    let icc_profile = decoder.get_tag_u8_vec(TiffTag::IccProfile).ok();
-    let orientation = decoder
-        .find_tag_unsigned::<u16>(TiffTag::Orientation)
-        .ok()
-        .flatten()
-        .and_then(|value| u8::try_from(value).ok())
-        .and_then(Orientation::from_exif);
-    let decoded = decoder
-        .read_image()
-        .map_err(|e| ImageError::Decode(format!("failed to decode TIFF image data: {e}")))?;
-
-    Ok(DecodedDynamicImage {
-        image: dynamic_image_from_tiff(image_path, width, height, color_type, decoded)?,
-        icc_profile,
-        orientation,
-    })
+    decode_tiff(BufReader::new(file), image_path)
 }
 
 fn decode_tiff_from_bytes(image_bytes: &[u8]) -> ImageResult<DecodedDynamicImage> {
-    let mut decoder = TiffDecoder::new(Cursor::new(image_bytes))
+    decode_tiff(Cursor::new(image_bytes), "<bytes>")
+}
+
+fn decode_tiff<R: Read + Seek>(reader: R, source: &str) -> ImageResult<DecodedDynamicImage> {
+    let mut decoder = TiffDecoder::new(reader)
         .map_err(|e| ImageError::Decode(format!("failed to initialize TIFF decoder: {e}")))?;
     let (width, height) = decoder
         .dimensions()
@@ -218,14 +199,14 @@ fn decode_tiff_from_bytes(image_bytes: &[u8]) -> ImageResult<DecodedDynamicImage
         .map_err(|e| ImageError::Decode(format!("failed to decode TIFF image data: {e}")))?;
 
     Ok(DecodedDynamicImage {
-        image: dynamic_image_from_tiff("<bytes>", width, height, color_type, decoded)?,
+        image: dynamic_image_from_tiff(source, width, height, color_type, decoded)?,
         icc_profile,
         orientation,
     })
 }
 
 fn dynamic_image_from_tiff(
-    image_path: &str,
+    source: &str,
     width: u32,
     height: u32,
     color_type: TiffColorType,
@@ -234,60 +215,59 @@ fn dynamic_image_from_tiff(
     match (color_type, decoded) {
         (TiffColorType::Gray(8), TiffDecodingResult::U8(data)) => {
             let image = image::GrayImage::from_raw(width, height, data)
-                .ok_or_else(|| tiff_buffer_mismatch_error(image_path, width, height, "Gray(8)"))?;
+                .ok_or_else(|| tiff_buffer_mismatch_error(source, width, height, "Gray(8)"))?;
             Ok(DynamicImage::ImageLuma8(image))
         }
         (TiffColorType::GrayA(8), TiffDecodingResult::U8(data)) => {
             let image = image::GrayAlphaImage::from_raw(width, height, data)
-                .ok_or_else(|| tiff_buffer_mismatch_error(image_path, width, height, "GrayA(8)"))?;
+                .ok_or_else(|| tiff_buffer_mismatch_error(source, width, height, "GrayA(8)"))?;
             Ok(DynamicImage::ImageLumaA8(image))
         }
         (TiffColorType::RGB(8), TiffDecodingResult::U8(data)) => {
             let image = image::RgbImage::from_raw(width, height, data)
-                .ok_or_else(|| tiff_buffer_mismatch_error(image_path, width, height, "RGB(8)"))?;
+                .ok_or_else(|| tiff_buffer_mismatch_error(source, width, height, "RGB(8)"))?;
             Ok(DynamicImage::ImageRgb8(image))
         }
         (TiffColorType::RGBA(8), TiffDecodingResult::U8(data)) => {
             let image = image::RgbaImage::from_raw(width, height, data)
-                .ok_or_else(|| tiff_buffer_mismatch_error(image_path, width, height, "RGBA(8)"))?;
+                .ok_or_else(|| tiff_buffer_mismatch_error(source, width, height, "RGBA(8)"))?;
             Ok(DynamicImage::ImageRgba8(image))
         }
         (TiffColorType::Gray(16), TiffDecodingResult::U16(data)) => {
             let image = image::ImageBuffer::from_raw(width, height, data)
-                .ok_or_else(|| tiff_buffer_mismatch_error(image_path, width, height, "Gray(16)"))?;
+                .ok_or_else(|| tiff_buffer_mismatch_error(source, width, height, "Gray(16)"))?;
             Ok(DynamicImage::ImageLuma16(image))
         }
         (TiffColorType::GrayA(16), TiffDecodingResult::U16(data)) => {
-            let image = image::ImageBuffer::from_raw(width, height, data).ok_or_else(|| {
-                tiff_buffer_mismatch_error(image_path, width, height, "GrayA(16)")
-            })?;
+            let image = image::ImageBuffer::from_raw(width, height, data)
+                .ok_or_else(|| tiff_buffer_mismatch_error(source, width, height, "GrayA(16)"))?;
             Ok(DynamicImage::ImageLumaA16(image))
         }
         (TiffColorType::RGB(16), TiffDecodingResult::U16(data)) => {
             let image = image::ImageBuffer::from_raw(width, height, data)
-                .ok_or_else(|| tiff_buffer_mismatch_error(image_path, width, height, "RGB(16)"))?;
+                .ok_or_else(|| tiff_buffer_mismatch_error(source, width, height, "RGB(16)"))?;
             Ok(DynamicImage::ImageRgb16(image))
         }
         (TiffColorType::RGBA(16), TiffDecodingResult::U16(data)) => {
             let image = image::ImageBuffer::from_raw(width, height, data)
-                .ok_or_else(|| tiff_buffer_mismatch_error(image_path, width, height, "RGBA(16)"))?;
+                .ok_or_else(|| tiff_buffer_mismatch_error(source, width, height, "RGBA(16)"))?;
             Ok(DynamicImage::ImageRgba16(image))
         }
         (observed_color_type, observed_result_type) => Err(ImageError::Decode(format!(
-            "unsupported TIFF pixel format for '{image_path}': color_type={observed_color_type:?}, sample_type={}",
+            "unsupported TIFF pixel format for '{source}': color_type={observed_color_type:?}, sample_type={}",
             tiff_result_type_name(&observed_result_type)
         ))),
     }
 }
 
 fn tiff_buffer_mismatch_error(
-    image_path: &str,
+    source: &str,
     width: u32,
     height: u32,
     color_type: &str,
 ) -> ImageError {
     ImageError::Decode(format!(
-        "decoded TIFF buffer length does not match dimensions for '{image_path}': {width}x{height}, color_type={color_type}"
+        "decoded TIFF buffer length does not match dimensions for '{source}': {width}x{height}, color_type={color_type}"
     ))
 }
 


### PR DESCRIPTION
## Problem

The path-based and byte-based TIFF fallbacks duplicated the full decoder pipeline: initialization, dimensions and color type reads, ICC and orientation extraction, image decoding, and conversion to a dynamic image. That duplication made future TIFF maintenance easier to apply inconsistently.

## Why this cleanup

This was the clearest low-risk readability improvement in the requested scope. It is local to decoder plumbing, has no open-PR overlap, and offers useful deduplication without touching Smart Memories selection logic, ML runtime state, or numerical processing.

## Approach

- Introduce one reader-based `decode_tiff` helper for the shared pipeline.
- Keep the path wrapper responsible for opening and buffering the file.
- Keep the byte wrapper responsible for constructing its in-memory cursor.
- Rename internal diagnostic parameters from path to source so they accurately cover both inputs.

## Behavior preservation

Both entry points retain their original concrete readers (`BufReader<File>` and `Cursor<&[u8]>`), decode order, metadata handling, orientation handling, pixel conversion, source labels, and error messages. No public API, serialization, persistence, concurrency, ordering, error semantics, or numerical behavior changes.

## Scope

- `rust/crates/image/src/decode.rs`

## Verification

- `cargo fmt --package ente-image -- --check`
- `cargo clippy -p ente-image --all-targets -- -D warnings`
- `cargo test -p ente-image` (32 tests passed)
- `git diff --check`