### PR TITLE
Update custom ONNX Runtime build to 1.28.0-r3

### DIFF
--- a/desktop/scripts/ort.js
+++ b/desktop/scripts/ort.js
@@ -3,7 +3,7 @@ const fsp = require("node:fs/promises");
 const path = require("node:path");
 const { execFileSync } = require("node:child_process");
 
-const ortVersion = "1.28.0-r1";
+const ortVersion = "1.28.0-r3";
 
 // Our packaging enables CoreML on macOS and WebGPU elsewhere.
 const ortReleaseURL = `https://github.com/ente/ort-packaging/releases/download/ort-${ortVersion}`;
@@ -12,17 +12,17 @@ const ortReleaseURL = `https://github.com/ente/ort-packaging/releases/download/o
 // release's .sha256 sidecars.
 const ortAssetSHA256s = {
     "darwin-arm64":
-        "de08b6c23398f1d6639c66519b44b06f7cd0f7c44a5ad7bade3c4d8b049c5428",
+        "5f5bf25a65756c25ab13b331c90d5b4324e59bb669dfc1b3bf2d060a8760c0f3",
     "darwin-x64":
-        "eee287e7d221a9b17928ee8f368dfaccb1467fe58fbb54fa08cab0ae903ba057",
+        "8be0681d58f0398cf8fbc52cf5a10aa5ee0f7976c45dca81598dd562575a8cdc",
     "linux-arm64":
-        "90b9cf4501213e09f97804ac0d7d0cd80d7f5da2a5d5cc599606b11e3c35fc78",
+        "343572e7a09565d517bb2802fed5b27c8a950337dafa99a4d8bc4fe06acb5485",
     "linux-x64":
-        "2293762c2b665e55282b677de7f8e4ae106507a72c9985bdb930685c0d902fd5",
+        "8478974b222df6ce9069976a4bbf99a89f0604565c350bb9a40565a3ec43e05d",
     "win32-arm64":
-        "552950610a7be5348c0d5ba6ef3ee6c3010bbe374b57d0d37f14be0408d88dec",
+        "bb31227878d7684ff1ef80a90bea7e95d4868db91e4751dfa5af6ae9b3b6adcd",
     "win32-x64":
-        "10bdfec578e0ecc6064ea562a63e1165593cfbb2cec47250616aa64ef8456f5c",
+        "d6984f7fafd1d4cd7b3969654e919e148c0b697ffffa64d4f203549615d59877",
 };
 
 const ortAssetName = (platform, arch) => {

--- a/mobile/apps/photos/android/app/build.gradle
+++ b/mobile/apps/photos/android/app/build.gradle
@@ -199,7 +199,7 @@ dependencies {
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
     // Custom WebGPU/XNNPACK build required by Rust ML, which dynamically
     // loads libonnxruntime.so.
-    implementation 'io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.0-r1@aar'
+    implementation 'io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.0-r3@aar'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/mobile/apps/photos/android/gradle/verification-metadata.xml
+++ b/mobile/apps/photos/android/gradle/verification-metadata.xml
@@ -18,9 +18,9 @@
       </trusted-artifacts>
    </configuration>
    <components>
-      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.0-r1">
-         <artifact name="onnxruntime-webgpu-android-1.28.0-r1.aar">
-            <sha256 value="0311c4eed8527782ad5f89606c24d40e1ba614047597f5d08ac9d0b718daf106"/>
+      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.0-r3">
+         <artifact name="onnxruntime-webgpu-android-1.28.0-r3.aar">
+            <sha256 value="1d268652c6c8392581a06eef889a2823f88ce006633cd76106ca27aade27f193"/>
          </artifact>
       </component>
    </components>

--- a/mobile/apps/photos/ios/Podfile.lock
+++ b/mobile/apps/photos/ios/Podfile.lock
@@ -28,7 +28,7 @@ PODS:
     - Flutter
   - ente_screen_cover (0.0.1):
     - Flutter
-  - EnteOnnxRuntime (1.28.0-r1)
+  - EnteOnnxRuntime (1.28.0-r3)
   - ffmpeg_kit_custom (6.0.3)
   - ffmpeg_kit_flutter (6.0.3):
     - ffmpeg_kit_custom
@@ -481,7 +481,7 @@ SPEC CHECKSUMS:
   ente_qr: 86beaf5d2644705db9b565b32dd8b82c05fb36af
   ente_rust: d0197ebd5460e8f67576579452b073d698404abe
   ente_screen_cover: 6792566774f1c83939f9c1d03ed0a1f1ded45ae4
-  EnteOnnxRuntime: 2417796182a546cbd5e3261e21be269054af2043
+  EnteOnnxRuntime: c994300f7ef809dd318664cfd85868ca69b3cd1a
   ffmpeg_kit_custom: 682b4f2f1ff1f8abae5a92f6c3540f2441d5be99
   ffmpeg_kit_flutter: 915b345acc97d4142e8a9a8549d177ff10f043f5
   file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6

--- a/mobile/native/android/apps/ensu/gradle/verification-metadata.xml
+++ b/mobile/native/android/apps/ensu/gradle/verification-metadata.xml
@@ -18,9 +18,9 @@
       </trusted-artifacts>
    </configuration>
    <components>
-      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.0-r1">
-         <artifact name="onnxruntime-webgpu-android-1.28.0-r1.aar">
-            <sha256 value="0311c4eed8527782ad5f89606c24d40e1ba614047597f5d08ac9d0b718daf106"/>
+      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.0-r3">
+         <artifact name="onnxruntime-webgpu-android-1.28.0-r3.aar">
+            <sha256 value="1d268652c6c8392581a06eef889a2823f88ce006633cd76106ca27aade27f193"/>
          </artifact>
       </component>
    </components>

--- a/mobile/native/android/apps/ensu/rust/build.gradle.kts
+++ b/mobile/native/android/apps/ensu/rust/build.gradle.kts
@@ -135,5 +135,5 @@ dependencies {
     // Custom WebGPU/XNNPACK build; the Rust runtime dynamically loads its
     // libonnxruntime.so. Resolved from the Ivy repository declared in
     // settings.gradle.kts and SHA-256 pinned in gradle/verification-metadata.xml.
-    api("io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.0-r1@aar")
+    api("io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.0-r3@aar")
 }

--- a/mobile/native/apple/packages/EnteOnnxRuntime/EnteOnnxRuntime.podspec
+++ b/mobile/native/apple/packages/EnteOnnxRuntime/EnteOnnxRuntime.podspec
@@ -5,14 +5,14 @@
 # XCFramework's static archive for the active platform via ORT_LIB_PATH.
 Pod::Spec.new do |s|
   s.name     = 'EnteOnnxRuntime'
-  s.version  = '1.28.0-r1'
+  s.version  = '1.28.0-r3'
   s.summary  = "Ente's custom prebuilt ONNX Runtime static-library XCFramework for iOS."
   s.homepage = 'https://github.com/ente/ort-packaging'
   s.authors  = { 'Ente' => 'engineering@ente.io' }
   s.license  = { :type => 'MIT', :file => 'ONNXRUNTIME-LICENSE' }
   s.source   = {
-    :http   => 'https://github.com/ente/ort-packaging/releases/download/ort-1.28.0-r1/onnxruntime-coreml-ios-1.28.0-r1.zip',
-    :sha256 => 'a7115a93a403c037692149a0013d30ddb0e33fc6899bb596ba791d5d743fa657',
+    :http   => 'https://github.com/ente/ort-packaging/releases/download/ort-1.28.0-r3/onnxruntime-coreml-ios-1.28.0-r3.zip',
+    :sha256 => 'cb9d2ca4ad1b463c8396882d878787918343da087dfc150cc09f067d0ea92834',
   }
 
   s.platform = :ios, '15.1'

--- a/mobile/native/apple/packages/EnteOnnxRuntime/Package.swift
+++ b/mobile/native/apple/packages/EnteOnnxRuntime/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "onnxruntime",
-            url: "https://github.com/ente/ort-packaging/releases/download/ort-1.28.0-r1/onnxruntime-coreml-ios-1.28.0-r1.zip",
-            checksum: "a7115a93a403c037692149a0013d30ddb0e33fc6899bb596ba791d5d743fa657"
+            url: "https://github.com/ente/ort-packaging/releases/download/ort-1.28.0-r3/onnxruntime-coreml-ios-1.28.0-r3.zip",
+            checksum: "cb9d2ca4ad1b463c8396882d878787918343da087dfc150cc09f067d0ea92834"
         )
     ]
 )


### PR DESCRIPTION
## Summary

- Upgrade the custom ONNX Runtime build from 1.28.0-r1 to 1.28.0-r3 across desktop, Android, and Apple.
- Refresh archive, AAR, Swift package, and CocoaPods checksum pins.

## Validation

- Gradle dependency resolution for Photos and Ensu
- Node syntax and Prettier checks for the desktop packaging script
- XML validation for Gradle verification metadata
- git diff --check