### PR TITLE
[web] Defer multipart checksums for bounded-memory uploads

### DIFF
--- a/server/ente/file.go
+++ b/server/ente/file.go
@@ -178,7 +178,7 @@ type MultipartUploadURLs struct {
 type MultipartUploadURLRequest struct {
 	ContentLength int64    `json:"contentLength" binding:"required"`
 	PartLength    int64    `json:"partLength" binding:"required"`
-	PartMD5s      []string `json:"partMd5s" binding:"required"`
+	PartMD5s      []string `json:"partMd5s"`
 }
 
 type ObjectType string

--- a/server/ente/remotestore.go
+++ b/server/ente/remotestore.go
@@ -61,6 +61,8 @@ const (
 	// only when those clients no longer need to be isolated from a new flag.
 	// CastSessionsV2 gates cast sessions v2 support.
 	CastSessionsV2 int64 = 1 << 5
+	// DeferredMultipartChecksums gates multipart URLs without precomputed checksums.
+	DeferredMultipartChecksums int64 = 1 << 6
 )
 
 type FlagKey string

--- a/server/pkg/api/public_collection.go
+++ b/server/pkg/api/public_collection.go
@@ -163,6 +163,11 @@ func (h *PublicCollectionHandler) GetMultipartUploadURLV2(c *gin.Context) {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
 	}
+	// TODO: Remove once deferred multipart checksums are enabled for public uploads.
+	if len(req.PartMD5s) == 0 {
+		handler.Error(c, ente.ErrBadRequest)
+		return
+	}
 	collection, err := h.Controller.GetPublicCollection(c, true)
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -1172,7 +1172,7 @@ func (c *FileController) GetMultipartUploadURLs(ctx context.Context, userID int6
 	return multipartUploadURLs, nil
 }
 
-// GetMultipartUploadURLWithMetadata enforces content length & per-part checksum requirements
+// GetMultipartUploadURLWithMetadata enforces content length and optional per-part checksums.
 func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, userID int64, req ente.MultipartUploadURLRequest, app ente.App) (ente.MultipartUploadURLs, error) {
 	if req.ContentLength <= 0 {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "contentLength must be greater than 0")
@@ -1180,7 +1180,7 @@ func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, 
 	if req.ContentLength > MaxFileSize {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "contentLength exceeds max file size %d", MaxFileSize)
 	}
-	if len(req.PartMD5s) == 0 {
+	if req.PartMD5s != nil && len(req.PartMD5s) == 0 {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "partMd5s must not be empty")
 	}
 	if err := validateMultipartPartLength(req.ContentLength, req.PartLength); err != nil {
@@ -1190,16 +1190,19 @@ func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, 
 	if partCount > maxMultipartPartCount {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "multipart upload cannot exceed %d parts", maxMultipartPartCount)
 	}
-	if len(req.PartMD5s) != partCount {
-		return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "partMd5s size (%d) does not match computed part count (%d)", len(req.PartMD5s), partCount)
-	}
-	normalizedChecksums := make([]string, partCount)
-	for i, checksum := range req.PartMD5s {
-		normalized, err := normalizeMD5String(checksum)
-		if err != nil {
-			return ente.MultipartUploadURLs{}, err
+	var normalizedChecksums []string
+	if req.PartMD5s != nil {
+		if len(req.PartMD5s) != partCount {
+			return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "partMd5s size (%d) does not match computed part count (%d)", len(req.PartMD5s), partCount)
 		}
-		normalizedChecksums[i] = normalized
+		normalizedChecksums = make([]string, partCount)
+		for i, checksum := range req.PartMD5s {
+			normalized, err := normalizeMD5String(checksum)
+			if err != nil {
+				return ente.MultipartUploadURLs{}, err
+			}
+			normalizedChecksums[i] = normalized
+		}
 	}
 	partLengths := computePartLengths(req.ContentLength, req.PartLength, partCount)
 	if err := c.UsageCtrl.CanUploadFile(ctx, userID, nil, app); err != nil {
@@ -1224,9 +1227,11 @@ func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, 
 	for i := 0; i < partCount; i++ {
 		partNumber := int64(i + 1)
 		length := partLengths[i]
-		lengthCopy := length
-		checksumCopy := normalizedChecksums[i]
-		url, err := c.getPartURL(*s3Client, objectKey, partNumber, r.UploadId, &lengthCopy, &checksumCopy)
+		var checksum *string
+		if normalizedChecksums != nil {
+			checksum = &normalizedChecksums[i]
+		}
+		url, err := c.getPartURL(*s3Client, objectKey, partNumber, r.UploadId, &length, checksum)
 		if err != nil {
 			return multipartUploadURLs, stacktrace.Propagate(err, "")
 		}

--- a/server/pkg/controller/remotestore/controller.go
+++ b/server/pkg/controller/remotestore/controller.go
@@ -110,7 +110,7 @@ func (c *Controller) GetFeatureFlags(ctx *gin.Context) (*ente.FeatureFlagRespons
 		// Changing it to false will hide the option and disable multi part upload for everyone
 		// except internal user.rt
 		EnableMobMultiPart: true,
-		ServerApiFlag:      ente.UploadV2 | ente.Comments | ente.BackupOptions | ente.CastSessionsV2,
+		ServerApiFlag:      ente.UploadV2 | ente.Comments | ente.BackupOptions | ente.CastSessionsV2 | ente.DeferredMultipartChecksums,
 		CastUrl:            viper.GetString("apps.cast"),
 		EmbedUrl:           viper.GetString("apps.embed-albums"),
 		CustomDomainCNAME:  viper.GetString("apps.custom-domain.cname"),

--- a/web/apps/photos/src/services/upload-manager.ts
+++ b/web/apps/photos/src/services/upload-manager.ts
@@ -4,6 +4,7 @@ import { ensureLocalUser } from "ente-accounts/services/user";
 import { isDesktop } from "ente-base/app";
 import { createComlinkCryptoWorker } from "ente-base/crypto";
 import type { CryptoWorker } from "ente-base/crypto/worker";
+import { isDevBuild } from "ente-base/env";
 import { lowercaseExtension, nameAndExtension } from "ente-base/file-name";
 import log from "ente-base/log";
 import { ComlinkWorker } from "ente-base/worker/comlink-worker";
@@ -45,6 +46,7 @@ import { FileType } from "ente-media/file-type";
 import { potentialFileTypeFromExtension } from "ente-media/live-photo";
 import { computeNormalCollectionFilesFromSaved } from "ente-new/photos/services/file";
 import { indexNewUpload } from "ente-new/photos/services/ml";
+import { settingsSnapshot } from "ente-new/photos/services/settings";
 import { wait } from "ente-utils/promise";
 import watcher from "./watch";
 
@@ -533,8 +535,12 @@ class UploadManager {
         options?: UploadItemsOptions,
     ) {
         const uiService = this.uiService;
+        const settings = settingsSnapshot();
         const uploadContext = {
             isCFUploadProxyDisabled: shouldDisableCFUploadProxy(),
+            deferMultipartChecksums:
+                settings.deferredMultipartChecksumsEnabled &&
+                (settings.isInternalUser || isDevBuild),
             skipDuplicateAddToUploadCollection:
                 options?.skipDuplicateAddToUploadCollection,
             includePartnerSharedFiles: options?.includePartnerSharedFiles,

--- a/web/packages/base/crypto/types.ts
+++ b/web/packages/base/crypto/types.ts
@@ -4,6 +4,8 @@ export type SodiumStateAddress = StateAddress;
 
 // Existing encrypted files depend on this chunk boundary.
 export const streamEncryptionChunkSize = 4 * 1024 * 1024;
+// libsodium secretstream adds this many bytes per encrypted chunk.
+export const streamEncryptionChunkOverhead = 17;
 
 export const deriveKeyInsufficientMemoryErrorMessage =
     "Failed to derive key (insufficient memory)";

--- a/web/packages/gallery/services/upload/remote.ts
+++ b/web/packages/gallery/services/upload/remote.ts
@@ -79,7 +79,7 @@ export const fetchMultipartUploadURLsWithMetadata = async ({
 }: {
     contentLength: number;
     partLength: number;
-    partMd5s: string[];
+    partMd5s?: string[];
 }) => {
     const headers = new Headers(await authenticatedRequestHeaders());
     headers.set("Content-Type", "application/json");

--- a/web/packages/gallery/services/upload/upload-service.ts
+++ b/web/packages/gallery/services/upload/upload-service.ts
@@ -2,7 +2,10 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import type { BytesOrB64 } from "ente-base/crypto/types";
-import { streamEncryptionChunkSize } from "ente-base/crypto/types";
+import {
+    streamEncryptionChunkOverhead,
+    streamEncryptionChunkSize,
+} from "ente-base/crypto/types";
 import type { CryptoWorker } from "ente-base/crypto/worker";
 import { ensureElectron } from "ente-base/electron";
 import { basename, nameAndExtension } from "ente-base/file-name";
@@ -233,6 +236,21 @@ class UploadService {
             throw translateURLFetchErrorIfNeeded(e);
         });
     }
+
+    async fetchMultipartUploadURLsWithoutChecksums(
+        contentLength: number,
+        partLength: number,
+    ) {
+        if (this.publicAlbumsCredentials) {
+            throw new Error("Public uploads require part checksums");
+        }
+        return fetchMultipartUploadURLsWithMetadata({
+            contentLength,
+            partLength,
+        }).catch((e: unknown) => {
+            throw translateURLFetchErrorIfNeeded(e);
+        });
+    }
 }
 
 const uploadService = new UploadService();
@@ -273,6 +291,7 @@ interface FileWithMetadata extends Omit<ThumbnailedFile, "hasStaticThumbnail"> {
 interface EncryptedFileStream {
     stream: ReadableStream<Uint8Array<ArrayBuffer>>;
     chunkCount: number;
+    encryptedSize: number;
 }
 
 interface EncryptedFilePieces {
@@ -453,6 +472,7 @@ const fileTooLargeErrorMessage = "File too large";
 
 interface UploadContext {
     isCFUploadProxyDisabled: boolean;
+    deferMultipartChecksums: boolean;
     skipDuplicateAddToUploadCollection?: boolean;
     includePartnerSharedFiles?: boolean;
     publicAlbumsCredentials?: PublicAlbumsCredentials;
@@ -1215,7 +1235,7 @@ const encryptBytesWithOptionalVerification = async (
 };
 
 const encryptFileStream = async (
-    { stream, chunkCount }: FileStream,
+    { stream, chunkCount, fileSize }: FileStream,
     fileKey: BytesOrB64,
     worker: CryptoWorker,
     shouldVerify: boolean,
@@ -1274,7 +1294,12 @@ const encryptFileStream = async (
     });
     return {
         decryptionHeader,
-        encryptedData: { stream: encryptedFileStream, chunkCount },
+        encryptedData: {
+            stream: encryptedFileStream,
+            chunkCount,
+            encryptedSize:
+                fileSize + chunkCount * streamEncryptionChunkOverhead,
+        },
     };
 };
 
@@ -1428,6 +1453,9 @@ const uploadStreamUsingMultipart = async (
         uploadContext;
     const shouldSendPartChecksums =
         checksumEnabled || !!uploadContext.publicAlbumsCredentials;
+    const deferPartChecksums =
+        uploadContext.deferMultipartChecksums &&
+        !uploadContext.publicAlbumsCredentials;
 
     const { stream } = dataStream;
     const streamReader = stream.getReader();
@@ -1436,7 +1464,7 @@ const uploadStreamUsingMultipart = async (
         dataStream.chunkCount / multipartChunksPerPart,
     );
 
-    if (shouldSendPartChecksums) {
+    if (shouldSendPartChecksums && !deferPartChecksums) {
         const parts: Uint8Array<ArrayBuffer>[] = [];
         const partMd5s: string[] = [];
         let fileSize = 0;
@@ -1518,8 +1546,20 @@ const uploadStreamUsingMultipart = async (
         return { objectKey: multipartUploadURLs.objectKey, fileSize };
     }
 
-    const multipartUploadURLs =
-        await uploadService.fetchMultipartUploadURLs(uploadPartCount);
+    const partLength = Math.min(
+        dataStream.encryptedSize,
+        multipartChunksPerPart *
+            (streamEncryptionChunkSize + streamEncryptionChunkOverhead),
+    );
+    const multipartUploadURLs = deferPartChecksums
+        ? await uploadService.fetchMultipartUploadURLsWithoutChecksums(
+              dataStream.encryptedSize,
+              partLength,
+          )
+        : await uploadService.fetchMultipartUploadURLs(uploadPartCount);
+    if (multipartUploadURLs.partURLs.length != uploadPartCount) {
+        throw new Error("Unexpected multipart upload URL count");
+    }
 
     const percentPerPart = maxPercent / uploadPartCount;
     let fileSize = 0;
@@ -1533,14 +1573,20 @@ const uploadStreamUsingMultipart = async (
         const partNumber = index + 1;
         const partData = await nextMultipartUploadPart(streamReader);
         fileSize += partData.length;
+        const checksum = deferPartChecksums
+            ? computeMd5Base64(partData)
+            : undefined;
 
         const eTag = !isCFUploadProxyDisabled
             ? await putFilePartViaWorker(
                   partUploadURL,
                   partData,
                   requestRetrier,
+                  { contentMd5: checksum },
               )
-            : await putFilePart(partUploadURL, partData, requestRetrier);
+            : await putFilePart(partUploadURL, partData, requestRetrier, {
+                  contentMd5: checksum,
+              });
         if (!eTag) throw new Error(eTagMissingErrorMessage);
 
         updateUploadProgress(fileLocalID, percentPerPart * partNumber);

--- a/web/packages/new/photos/services/settings.ts
+++ b/web/packages/new/photos/services/settings.ts
@@ -13,6 +13,7 @@ import {
 
 export interface Settings {
     isInternalUser: boolean;
+    deferredMultipartChecksumsEnabled: boolean;
     mapEnabled: boolean;
     cfUploadProxyDisabled: boolean;
     castURL: string;
@@ -23,6 +24,7 @@ export interface Settings {
 
 const createDefaultSettings = (): Settings => ({
     isInternalUser: false,
+    deferredMultipartChecksumsEnabled: false,
     mapEnabled: false,
     cfUploadProxyDisabled: false,
     castURL: "https://cast.ente.com",
@@ -85,10 +87,15 @@ const FeatureFlags = z.object({
 
 type FeatureFlags = z.infer<typeof FeatureFlags>;
 
+const deferredMultipartChecksumsFlag = 1 << 6;
+
 const syncSettingsSnapshotWithLocalStorage = () => {
     const flags = savedRemoteFeatureFlags();
     const settings = createDefaultSettings();
     settings.isInternalUser = flags?.internalUser || false;
+    settings.deferredMultipartChecksumsEnabled = !!(
+        (flags?.serverApiFlag ?? 0) & deferredMultipartChecksumsFlag
+    );
     settings.mapEnabled = flags?.mapEnabled || false;
     settings.cfUploadProxyDisabled = savedCFProxyDisabled();
     if (flags?.castUrl) settings.castURL = flags.castUrl;


### PR DESCRIPTION
- Allow Museum to issue length-bound multipart URLs without requiring checksums upfront.
- On web, compute and send each part checksum immediately before upload when the server advertises support and the user is internal or the build is development. Existing public web behavior is unchanged.

Validation: web audit, WASM builds, lint and tests; server lint and full tests with local Postgres.