### PR TITLE
[mobile][photos] Fix cross-year On This Day scheduling

### DIFF
--- a/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
@@ -532,7 +532,7 @@ class TimeMemoriesCalculator {
       } else if (almostYearEnd) {
         final altDiff = fileDate
             .copyWith(year: currentYear + 1)
-            .difference(currentTime);
+            .difference(startPoint);
         if (!altDiff.isNegative && altDiff < diffThreshold) {
           daysToMemories
               .putIfAbsent(altDiff.inDays, () => [])

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -197,29 +197,4 @@ void main() {
       },
     );
   });
-
-  group("On This Day dates", () {
-    test("On This Day keeps cross-year dates aligned after midnight", () async {
-      final currentTime = DateTime(2026, 12, 30, 12);
-      final files = <EnteFile>[
-        for (int i = 0; i < 3; i++)
-          _file(id: i + 1, createdAt: DateTime(2024, 1, 1, 9 + i)),
-        for (int i = 0; i < 2; i++)
-          _file(id: i + 4, createdAt: DateTime(2025, 1, 1, 9 + i)),
-      ];
-
-      final memories = await TimeMemoriesCalculator.computeOnThisDayMemories(
-        files,
-        currentTime,
-        seenTimes: const <int, int>{},
-        collectionIDsToExclude: const <int>{},
-      );
-
-      expect(memories, hasLength(1));
-      expect(
-        DateTime.fromMicrosecondsSinceEpoch(memories.single.firstDateToShow),
-        DateTime(2027),
-      );
-    });
-  });
 }

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -197,4 +197,29 @@ void main() {
       },
     );
   });
+
+  group("On This Day dates", () {
+    test("On This Day keeps cross-year dates aligned after midnight", () async {
+      final currentTime = DateTime(2026, 12, 30, 12);
+      final files = <EnteFile>[
+        for (int i = 0; i < 3; i++)
+          _file(id: i + 1, createdAt: DateTime(2024, 1, 1, 9 + i)),
+        for (int i = 0; i < 2; i++)
+          _file(id: i + 4, createdAt: DateTime(2025, 1, 1, 9 + i)),
+      ];
+
+      final memories = await TimeMemoriesCalculator.computeOnThisDayMemories(
+        files,
+        currentTime,
+        seenTimes: const <int, int>{},
+        collectionIDsToExclude: const <int>{},
+      );
+
+      expect(memories, hasLength(1));
+      expect(
+        DateTime.fromMicrosecondsSinceEpoch(memories.single.firstDateToShow),
+        DateTime(2027),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Bug

Near year end, the On This Day cross-year branch measured its day offset from the current clock time, then applied the truncated day count to midnight. A computation after midnight could therefore schedule January memories one calendar day early.

## Root cause

The cross-year offset used `currentTime` while the regular branch and display-date construction use the midnight `startPoint`.

## Fix

Measure the cross-year offset from the same midnight start point.

## Verification

- `flutter test test/services/memories/smart_memories_source_selection_test.dart`
- `flutter analyze --no-pub lib/services/smart_memories_time_calculator.dart`
- `dart format --output=none --set-exit-if-changed lib/services/smart_memories_time_calculator.dart test/services/memories/smart_memories_source_selection_test.dart`
- `git diff --check`
