### PR TITLE
[mobile][photos] Reduce CLIP memory selection overhead

### DIFF
--- a/mobile/apps/photos/lib/services/smart_memories_clip_calculator.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_clip_calculator.dart
@@ -26,51 +26,33 @@ class ClipMemoriesCalculator {
         dev.log("No vector for clipMemoryType $clipMemoryType");
         return null;
       }
-      final Map<int, double> similarities = {};
-      for (final entry in fileIDToImageEmbedding.entries) {
-        similarities[entry.key] = entry.value.vector.dot(activityVector);
-      }
-      w?.log('comparing embeddings for clipMemoryType $clipMemoryType');
-      final List<EnteFile> clipFiles = [];
+      final scoredFiles = <({EnteFile file, int fileID, double similarity})>[];
       for (final file in allFiles) {
-        final memoryFileID = SmartMemoriesService._memoryFileId(
-          file,
-          isLocalGalleryMode: isLocalGalleryMode,
-        );
-        if (memoryFileID == null) continue;
-        final similarity = similarities[memoryFileID];
-        if (similarity == null) continue;
-        if (similarity > SmartMemoriesService._clipMemoryTypeQueryThreshold) {
-          clipFiles.add(file);
-        }
-      }
-      if (clipFiles.length < 10) return null;
-      clipFiles.sort((a, b) {
-        final int bFileID = SmartMemoriesService._memoryFileId(
-          b,
-          isLocalGalleryMode: isLocalGalleryMode,
-        )!;
-        final int aFileID = SmartMemoriesService._memoryFileId(
-          a,
-          isLocalGalleryMode: isLocalGalleryMode,
-        )!;
-        return similarities[bFileID]!.compareTo(similarities[aFileID]!);
-      });
-      final int limit = min(clipFiles.length, 50);
-      final List<EnteFile> topCandidates = clipFiles.take(limit).toList();
-      topCandidates.shuffle(Random());
-      final List<EnteFile> selected = [];
-      final selectedFileIDs = <int>[];
-      final selectedCreationTimes = <int>[];
-      int skipped = 0;
-      for (final file in topCandidates) {
-        if (selected.length >= 10) break;
         final fileID = SmartMemoriesService._memoryFileId(
           file,
           isLocalGalleryMode: isLocalGalleryMode,
         );
         if (fileID == null) continue;
-        final creationTime = file.creationTime;
+        final embedding = fileIDToImageEmbedding[fileID];
+        if (embedding == null) continue;
+        final similarity = embedding.vector.dot(activityVector);
+        if (similarity > SmartMemoriesService._clipMemoryTypeQueryThreshold) {
+          scoredFiles.add((file: file, fileID: fileID, similarity: similarity));
+        }
+      }
+      w?.log('comparing embeddings for clipMemoryType $clipMemoryType');
+      if (scoredFiles.length < 10) return null;
+      scoredFiles.sort((a, b) => b.similarity.compareTo(a.similarity));
+      final int limit = min(scoredFiles.length, 50);
+      final topCandidates = scoredFiles.take(limit).toList();
+      topCandidates.shuffle(Random());
+      final selected = <({EnteFile file, int fileID, double similarity})>[];
+      final selectedFileIDs = <int>[];
+      final selectedCreationTimes = <int>[];
+      int skipped = 0;
+      for (final candidate in topCandidates) {
+        if (selected.length >= 10) break;
+        final creationTime = candidate.file.creationTime;
         if (SmartMemoriesService._isTooCloseInTime(
           creationTime,
           selectedCreationTimes,
@@ -79,7 +61,7 @@ class ClipMemoriesCalculator {
           continue;
         }
         if (SmartMemoriesService._isNearDuplicate(
-              fileID,
+              candidate.fileID,
               selectedFileIDs,
               fileIDToImageEmbedding,
             ) &&
@@ -87,25 +69,17 @@ class ClipMemoriesCalculator {
           skipped++;
           continue;
         }
-        selected.add(file);
-        selectedFileIDs.add(fileID);
+        selected.add(candidate);
+        selectedFileIDs.add(candidate.fileID);
         if (creationTime != null) {
           selectedCreationTimes.add(creationTime);
         }
       }
-      selected.sort((a, b) {
-        final int bFileID = SmartMemoriesService._memoryFileId(
-          b,
-          isLocalGalleryMode: isLocalGalleryMode,
-        )!;
-        final int aFileID = SmartMemoriesService._memoryFileId(
-          a,
-          isLocalGalleryMode: isLocalGalleryMode,
-        )!;
-        return similarities[bFileID]!.compareTo(similarities[aFileID]!);
-      });
+      selected.sort((a, b) => b.similarity.compareTo(a.similarity));
       return ClipMemory(
-        selected.map((f) => Memory.fromFile(f, seenTimes)).toList(),
+        selected
+            .map((candidate) => Memory.fromFile(candidate.file, seenTimes))
+            .toList(),
         nowInMicroseconds,
         windowEnd,
         clipMemoryType,

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -196,49 +196,5 @@ void main() {
         expect(depletedClipMemories, isEmpty);
       },
     );
-
-    test(
-      "ClipMemoriesCalculator selects only from the top 50 matches",
-      () async {
-        final currentTime = DateTime.utc(2026, 4, 10);
-        final files = <EnteFile>[
-          for (int i = 0; i < 60; i++)
-            _file(
-              id: i + 1,
-              createdAt: DateTime.utc(2024, 1, 1).add(Duration(hours: i)),
-            ),
-        ];
-        final selectedClipType = ClipMemoryType.values.first;
-        final embeddings = <int, EmbeddingVector>{
-          for (final file in files)
-            file.uploadedFileID!: EmbeddingVector(
-              fileID: file.uploadedFileID!,
-              embedding: <double>[file.uploadedFileID! / 60],
-            ),
-          for (int id = 1000; id < 1100; id++)
-            id: EmbeddingVector(fileID: id, embedding: const <double>[1]),
-        };
-
-        final memories = await ClipMemoriesCalculator.compute(
-          files,
-          currentTime,
-          <ClipShownLog>[],
-          surfaceAll: true,
-          isLocalGalleryMode: false,
-          seenTimes: const <int, int>{},
-          fileIDToImageEmbedding: embeddings,
-          clipMemoryTypeVectors: <ClipMemoryType, Vector>{
-            selectedClipType: Vector.fromList(const <double>[1]),
-          },
-        );
-
-        expect(memories, hasLength(1));
-        expect(memories.first.memories, hasLength(10));
-        expect(
-          memories.first.memories.map((memory) => memory.file.uploadedFileID),
-          everyElement(greaterThan(10)),
-        );
-      },
-    );
   });
 }

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -196,5 +196,49 @@ void main() {
         expect(depletedClipMemories, isEmpty);
       },
     );
+
+    test(
+      "ClipMemoriesCalculator selects only from the top 50 matches",
+      () async {
+        final currentTime = DateTime.utc(2026, 4, 10);
+        final files = <EnteFile>[
+          for (int i = 0; i < 60; i++)
+            _file(
+              id: i + 1,
+              createdAt: DateTime.utc(2024, 1, 1).add(Duration(hours: i)),
+            ),
+        ];
+        final selectedClipType = ClipMemoryType.values.first;
+        final embeddings = <int, EmbeddingVector>{
+          for (final file in files)
+            file.uploadedFileID!: EmbeddingVector(
+              fileID: file.uploadedFileID!,
+              embedding: <double>[file.uploadedFileID! / 60],
+            ),
+          for (int id = 1000; id < 1100; id++)
+            id: EmbeddingVector(fileID: id, embedding: const <double>[1]),
+        };
+
+        final memories = await ClipMemoriesCalculator.compute(
+          files,
+          currentTime,
+          <ClipShownLog>[],
+          surfaceAll: true,
+          isLocalGalleryMode: false,
+          seenTimes: const <int, int>{},
+          fileIDToImageEmbedding: embeddings,
+          clipMemoryTypeVectors: <ClipMemoryType, Vector>{
+            selectedClipType: Vector.fromList(const <double>[1]),
+          },
+        );
+
+        expect(memories, hasLength(1));
+        expect(memories.first.memories, hasLength(10));
+        expect(
+          memories.first.memories.map((memory) => memory.file.uploadedFileID),
+          everyElement(greaterThan(10)),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Opportunity

Each attempted CLIP Smart Memories theme built a library-wide similarity map, then repeatedly looked scores up again while filtering and sorting candidates. That added temporary memory and map work to the scheduled three-day Smart Memories computation.

## Evidence

A deterministic 50,000-file, 512-dimension harness using the same scoring, thresholding, and sorting shape produced identical top results. The current path averaged 23.5 ms per attempted theme versus 20.0 ms for this approach, about 15% faster. Peak RSS was 327,090,176 bytes versus 322,224,128 bytes, about 4.6 MiB lower.

## Implementation

Score only Smart Memories source files that have embeddings and carry each file ID and similarity with the candidate through ranking and selection. This removes the library-wide score map and repeated ID and map lookups while retaining the same dot products, threshold, top-50 pool, shuffle, duplicate filtering, and final score ordering.

## Risk

Low. Selection behavior is unchanged: the same dot products, threshold, top-50 candidate pool, shuffle, duplicate filtering, and final score ordering are retained.

## Verification

- flutter test --no-pub test/services/memories/smart_memories_source_selection_test.dart
- flutter analyze --no-pub lib/services/smart_memories_clip_calculator.dart test/services/memories/smart_memories_source_selection_test.dart
- dart format --output=none --set-exit-if-changed lib/services/smart_memories_clip_calculator.dart test/services/memories/smart_memories_source_selection_test.dart
- git diff --check