### PR TITLE
[mob][packages] Migrate Accounts buttons to ButtonComponent

### DIFF
--- a/mobile/packages/accounts/lib/pages/change_email_dialog.dart
+++ b/mobile/packages/accounts/lib/pages/change_email_dialog.dart
@@ -1,9 +1,9 @@
 import 'package:ente_accounts/ente_accounts.dart';
+import 'package:ente_components/ente_components.dart';
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import 'package:ente_strings/ente_strings.dart';
 import 'package:ente_ui/components/alert_bottom_sheet.dart';
 import 'package:ente_ui/components/base_bottom_sheet.dart';
-import 'package:ente_ui/components/buttons/gradient_button.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:flutter/material.dart';
 
@@ -80,9 +80,10 @@ class _ChangeEmailDialogState extends State<ChangeEmailDialog> {
             onFieldSubmitted: (_) => _handleSubmit(),
           ),
           const SizedBox(height: 24),
-          GradientButton(
-            text: context.strings.verify,
+          ButtonComponent(
+            label: context.strings.verify,
             onTap: _emailIsValid ? _handleSubmit : null,
+            shouldSurfaceExecutionStates: false,
           ),
         ],
       ),

--- a/mobile/packages/accounts/lib/pages/login_pwd_verification_page.dart
+++ b/mobile/packages/accounts/lib/pages/login_pwd_verification_page.dart
@@ -1,11 +1,11 @@
 import "package:dio/dio.dart";
 import "package:ente_accounts/ente_accounts.dart";
+import "package:ente_components/ente_components.dart";
 import "package:ente_configuration/base_configuration.dart";
 import "package:ente_crypto_api/ente_crypto_api.dart";
 import "package:ente_strings/ente_strings.dart";
 import "package:ente_ui/components/alert_bottom_sheet.dart";
 import "package:ente_ui/components/buttons/dynamic_fab.dart";
-import "package:ente_ui/components/buttons/gradient_button.dart";
 import "package:ente_ui/theme/ente_theme.dart";
 import "package:ente_ui/utils/dialog_util.dart";
 import "package:ente_utils/email_util.dart";
@@ -173,11 +173,12 @@ class _LoginPasswordVerificationPageState
           message: context.strings.recreatePasswordBody,
           assetPath: 'assets/warning-grey.png',
           buttons: [
-            GradientButton(
-              text: context.strings.useRecoveryKey,
+            ButtonComponent(
+              label: context.strings.useRecoveryKey,
               onTap: () {
                 Navigator.of(context).pop(true);
               },
+              shouldSurfaceExecutionStates: false,
             ),
           ],
         );
@@ -213,11 +214,12 @@ class _LoginPasswordVerificationPageState
       message: message,
       assetPath: 'assets/warning-grey.png',
       buttons: [
-        GradientButton(
-          text: context.strings.contactSupport,
+        ButtonComponent(
+          label: context.strings.contactSupport,
           onTap: () {
             Navigator.of(context).pop(true);
           },
+          shouldSurfaceExecutionStates: false,
         ),
       ],
     );

--- a/mobile/packages/accounts/lib/pages/passkey_page.dart
+++ b/mobile/packages/accounts/lib/pages/passkey_page.dart
@@ -1,13 +1,14 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:app_links/app_links.dart';
 import 'package:ente_accounts/ente_accounts.dart';
 import 'package:ente_accounts/models/errors.dart';
+import 'package:ente_components/ente_components.dart';
 import 'package:ente_configuration/base_configuration.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:ente_strings/ente_strings.dart';
 import 'package:ente_ui/components/alert_bottom_sheet.dart';
-import 'package:ente_ui/components/buttons/gradient_button.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
 import 'package:ente_ui/utils/toast_util.dart';
@@ -207,14 +208,15 @@ class _PasskeyPageState extends State<PasskeyPage> {
               style: textTheme.body.copyWith(color: colorScheme.textMuted),
             ),
             const SizedBox(height: 24),
-            GradientButton(
-              text: context.strings.tryAgain,
-              onTap: () => launchPasskey(),
+            ButtonComponent(
+              label: context.strings.tryAgain,
+              onTap: () => unawaited(launchPasskey()),
+              shouldSurfaceExecutionStates: false,
             ),
             const SizedBox(height: 16),
-            GradientButton(
-              text: context.strings.checkStatus,
-              buttonType: GradientButtonType.secondary,
+            ButtonComponent(
+              label: context.strings.checkStatus,
+              variant: ButtonComponentVariant.secondary,
               onTap: () async {
                 try {
                   await checkStatus();
@@ -225,6 +227,7 @@ class _PasskeyPageState extends State<PasskeyPage> {
                   }
                 }
               },
+              shouldSurfaceExecutionStates: false,
             ),
             const SizedBox(height: 16),
             Row(

--- a/mobile/packages/accounts/lib/pages/password_entry_page.dart
+++ b/mobile/packages/accounts/lib/pages/password_entry_page.dart
@@ -1,11 +1,11 @@
 import 'package:ente_accounts/ente_accounts.dart';
+import 'package:ente_components/ente_components.dart';
 import 'package:ente_configuration/base_configuration.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:ente_strings/ente_strings.dart';
 import "package:ente_ui/components/alert_bottom_sheet.dart";
 import "package:ente_ui/components/base_bottom_sheet.dart";
 import 'package:ente_ui/components/buttons/dynamic_fab.dart';
-import "package:ente_ui/components/buttons/gradient_button.dart";
 import 'package:ente_ui/pages/base_home_page.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
@@ -485,12 +485,13 @@ class _PasswordEntryPageState extends State<PasswordEntryPage> {
                 style: textTheme.body.copyWith(color: colorScheme.textMuted),
               ),
               const SizedBox(height: 20),
-              GradientButton(
-                text: context.strings.doNotSignOut,
+              ButtonComponent(
+                label: context.strings.doNotSignOut,
                 onTap: () {
                   logOutFromOther = false;
                   Navigator.of(bottomSheetContext).pop();
                 },
+                shouldSurfaceExecutionStates: false,
               ),
               const SizedBox(height: 20),
               GestureDetector(

--- a/mobile/packages/accounts/lib/pages/password_reentry_page.dart
+++ b/mobile/packages/accounts/lib/pages/password_reentry_page.dart
@@ -3,12 +3,12 @@ import 'dart:typed_data';
 
 import 'package:ente_accounts/ente_accounts.dart';
 import 'package:ente_accounts/models/errors.dart';
+import 'package:ente_components/ente_components.dart';
 import 'package:ente_configuration/base_configuration.dart';
 import 'package:ente_crypto_api/ente_crypto_api.dart';
 import 'package:ente_strings/ente_strings.dart';
 import "package:ente_ui/components/alert_bottom_sheet.dart";
 import 'package:ente_ui/components/buttons/dynamic_fab.dart';
-import "package:ente_ui/components/buttons/gradient_button.dart";
 import 'package:ente_ui/pages/base_home_page.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
@@ -130,11 +130,12 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
         message: context.strings.recreatePasswordBody,
         assetPath: 'assets/warning-grey.png',
         buttons: [
-          GradientButton(
-            text: context.strings.useRecoveryKey,
+          ButtonComponent(
+            label: context.strings.useRecoveryKey,
             onTap: () {
               Navigator.of(context).pop(true);
             },
+            shouldSurfaceExecutionStates: false,
           ),
         ],
       );
@@ -162,11 +163,12 @@ class _PasswordReentryPageState extends State<PasswordReentryPage> {
         message: context.strings.pleaseTryAgain,
         assetPath: 'assets/warning-grey.png',
         buttons: [
-          GradientButton(
-            text: context.strings.contactSupport,
+          ButtonComponent(
+            label: context.strings.contactSupport,
             onTap: () {
               Navigator.of(context).pop(true);
             },
+            shouldSurfaceExecutionStates: false,
           ),
         ],
       );

--- a/mobile/packages/accounts/lib/pages/recovery_key_page.dart
+++ b/mobile/packages/accounts/lib/pages/recovery_key_page.dart
@@ -3,11 +3,11 @@ import 'dart:io' as io;
 
 import 'package:bip39/bip39.dart' as bip39;
 import 'package:dots_indicator/dots_indicator.dart';
+import 'package:ente_components/ente_components.dart';
 import 'package:ente_configuration/base_configuration.dart';
 import 'package:ente_configuration/constants.dart';
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import 'package:ente_strings/ente_strings.dart';
-import 'package:ente_ui/components/buttons/gradient_button.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:ente_ui/utils/toast_util.dart';
 import 'package:ente_utils/ente_utils.dart';
@@ -240,7 +240,7 @@ class _RecoveryKeyPageState extends State<RecoveryKeyPage> {
     }
 
     childrens.add(
-      GradientButton(
+      ButtonComponent(
         onTap: () async {
           await showShareSheet(
             context,
@@ -253,7 +253,8 @@ class _RecoveryKeyPageState extends State<RecoveryKeyPage> {
             },
           );
         },
-        text: context.strings.saveKey,
+        label: context.strings.saveKey,
+        shouldSurfaceExecutionStates: false,
       ),
     );
 

--- a/mobile/packages/accounts/lib/pages/recovery_page.dart
+++ b/mobile/packages/accounts/lib/pages/recovery_page.dart
@@ -1,9 +1,9 @@
 import 'package:ente_accounts/ente_accounts.dart';
+import 'package:ente_components/ente_components.dart';
 import 'package:ente_configuration/base_configuration.dart';
 import 'package:ente_strings/ente_strings.dart';
 import "package:ente_ui/components/alert_bottom_sheet.dart";
 import 'package:ente_ui/components/buttons/dynamic_fab.dart';
-import "package:ente_ui/components/buttons/gradient_button.dart";
 import 'package:ente_ui/pages/base_home_page.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
@@ -176,14 +176,15 @@ class _RecoveryPageState extends State<RecoveryPage> {
                                   context.strings.noRecoveryKeyNoDecryption,
                               assetPath: 'assets/warning-grey.png',
                               buttons: [
-                                GradientButton(
-                                  text: context.strings.contactSupport,
+                                ButtonComponent(
+                                  label: context.strings.contactSupport,
                                   onTap: () async {
                                     await sendEmail(
                                       context,
                                       to: "support@ente.com",
                                     );
                                   },
+                                  shouldSurfaceExecutionStates: false,
                                 ),
                               ],
                             );


### PR DESCRIPTION
Migrates every `GradientButton` usage in `mobile/packages/accounts` to `ButtonComponent` while preserving disabled state, execution behavior, callbacks, validation, spacing, and navigation.

- Keeps existing `ente_ui` toast, dialog, loading, progress, theme, and other components unchanged.
- Removes only obsolete `GradientButton` imports.
- Leaves Legacy, application packages, and `mobile/packages/ui` untouched.

Tested with:

- `flutter analyze --no-pub` in `mobile/packages/accounts`
- `flutter test --no-pub test/components/button_test.dart` in `mobile/packages/ente_components` (29 tests)
- Auth iOS build and launch on an iPhone 17 simulator

Claude and independent code review found no remaining actionable issues.
