### PR TITLE
[mob][locker] Migrate remaining legacy sharing components

### DIFF
--- a/mobile/apps/locker/lib/ui/components/delete_confirmation_sheet.dart
+++ b/mobile/apps/locker/lib/ui/components/delete_confirmation_sheet.dart
@@ -1,17 +1,11 @@
 import "package:ente_components/ente_components.dart";
 import "package:ente_strings/ente_strings.dart";
-import "package:ente_ui/components/buttons/button_widget.dart";
-import "package:ente_ui/components/buttons/models/button_result.dart";
 import "package:flutter/material.dart";
 
 class DeleteConfirmationResult {
-  final ButtonResult buttonResult;
   final bool deleteFromAllCollections;
 
-  DeleteConfirmationResult({
-    required this.buttonResult,
-    required this.deleteFromAllCollections,
-  });
+  DeleteConfirmationResult({required this.deleteFromAllCollections});
 }
 
 Future<DeleteConfirmationResult?> showDeleteConfirmationSheet(
@@ -103,7 +97,6 @@ class _DeleteConfirmationSheetState extends State<DeleteConfirmationSheet> {
           onTap: () {
             Navigator.of(context).pop(
               DeleteConfirmationResult(
-                buttonResult: ButtonResult(ButtonAction.first),
                 deleteFromAllCollections: _deleteFromAllCollections,
               ),
             );

--- a/mobile/apps/locker/lib/ui/components/share_link_sheet.dart
+++ b/mobile/apps/locker/lib/ui/components/share_link_sheet.dart
@@ -1,7 +1,5 @@
 import "package:ente_components/ente_components.dart";
 import "package:ente_strings/ente_strings.dart";
-import "package:ente_ui/components/buttons/button_widget.dart";
-import "package:ente_ui/components/buttons/models/button_result.dart";
 import "package:ente_ui/utils/dialog_util.dart";
 import "package:ente_ui/utils/toast_util.dart";
 import "package:ente_utils/share_utils.dart";
@@ -131,7 +129,7 @@ class _ShareLinkSheetState extends State<ShareLinkSheet> {
   Future<void> _deleteShareLink(BuildContext context) async {
     final l10n = context.strings;
 
-    final result = await showBottomSheetComponent<ButtonResult>(
+    final confirmed = await showBottomSheetComponent<bool>(
       context: context,
       builder: (_) => BottomSheetComponent(
         title: l10n.deleteLinkQuestion,
@@ -141,14 +139,13 @@ class _ShareLinkSheetState extends State<ShareLinkSheet> {
           ButtonComponent(
             label: l10n.delete,
             variant: ButtonComponentVariant.critical,
-            onTap: () =>
-                Navigator.of(context).pop(ButtonResult(ButtonAction.first)),
+            onTap: () => Navigator.of(context).pop(true),
           ),
         ],
       ),
     );
 
-    if (result?.action == ButtonAction.first && context.mounted) {
+    if (confirmed == true && context.mounted) {
       final dialog = createProgressDialog(
         context,
         l10n.deletingShareLink,

--- a/mobile/apps/locker/lib/ui/pages/trash_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/trash_page.dart
@@ -3,7 +3,6 @@ import "dart:async";
 import 'package:ente_components/ente_components.dart';
 import "package:ente_events/event_bus.dart";
 import 'package:ente_strings/ente_strings.dart';
-import 'package:ente_ui/components/buttons/button_widget.dart';
 import 'package:ente_ui/utils/dialog_util.dart';
 import 'package:ente_ui/utils/toast_util.dart';
 import 'package:flutter/material.dart';
@@ -72,7 +71,7 @@ class _TrashPageState extends State<TrashPage> {
       illustration: LockerBottomSheetIllustration.collectionDelete,
     );
 
-    if (result?.buttonResult.action == ButtonAction.first) {
+    if (result != null) {
       await _performEmptyTrash();
     }
   }

--- a/mobile/apps/locker/lib/ui/sharing/add_email_bottom_sheet.dart
+++ b/mobile/apps/locker/lib/ui/sharing/add_email_bottom_sheet.dart
@@ -7,9 +7,6 @@ import "package:ente_sharing/models/user.dart";
 import "package:ente_sharing/user_avator_widget.dart";
 import "package:ente_sharing/verify_identity_dialog.dart";
 import "package:ente_strings/ente_strings.dart";
-import "package:ente_ui/components/captioned_text_widget_v2.dart";
-import "package:ente_ui/components/divider_widget.dart";
-import "package:ente_ui/components/menu_item_widget_v2.dart";
 import "package:flutter/material.dart";
 import "package:intl/intl.dart";
 import "package:locker/services/collections/collections_service.dart";
@@ -161,55 +158,44 @@ class _AddEmailSheetState extends State<AddEmailSheet> {
                   constraints: const BoxConstraints(
                     maxHeight: maxVisibleHeight,
                   ),
-                  child: ListView.builder(
+                  child: ListView(
                     controller: _scrollController,
                     shrinkWrap: true,
                     padding: EdgeInsets.zero,
-                    itemCount: filteredUsers.length,
-                    itemBuilder: (context, index) {
-                      final user = filteredUsers[index];
-                      final isFirst = index == 0;
-                      final isLast = index == filteredUsers.length - 1;
-                      return Column(
-                        children: [
-                          if (!isFirst)
-                            DividerWidget(
-                              dividerType: DividerType.menu,
-                              bgColor: colors.fillLight,
-                            ),
-                          MenuItemWidgetV2(
-                            captionedTextWidget: CaptionedTextWidgetV2(
-                              title: user.resolvedDisplayName,
-                            ),
-                            leadingIconSize: 24.0,
-                            leadingIconWidget: UserAvatarWidget(
-                              user,
-                              type: AvatarType.mini,
-                              config: Configuration.instance,
-                            ),
-                            menuItemColor: colors.fillLight,
-                            surfaceExecutionStates: false,
-                            onTap: () async {
-                              _textFieldFocusNode.unfocus();
-                              _textController.text = user.email;
-                              _email = user.email;
-                              _emailIsValid = true;
-                              setState(() {});
-                            },
-                            onLongPress: () {
-                              showVerifyIdentitySheet(
-                                context,
-                                self: false,
-                                config: Configuration.instance,
-                                email: user.email,
-                              );
-                            },
-                            isTopBorderRadiusRemoved: !isFirst,
-                            isBottomBorderRadiusRemoved: !isLast,
-                          ),
-                        ],
-                      );
-                    },
+                    children: [
+                      MenuGroupComponent(
+                        backgroundColor: colors.fillLight,
+                        showDividers: true,
+                        dividerPadding: const EdgeInsets.only(left: 48),
+                        items: filteredUsers
+                            .map(
+                              (user) => MenuComponent(
+                                title: user.resolvedDisplayName,
+                                leading: UserAvatarWidget(
+                                  user,
+                                  type: AvatarType.mini,
+                                  config: Configuration.instance,
+                                ),
+                                onTap: () async {
+                                  _textFieldFocusNode.unfocus();
+                                  _textController.text = user.email;
+                                  _email = user.email;
+                                  _emailIsValid = true;
+                                  setState(() {});
+                                },
+                                onLongPress: () {
+                                  showVerifyIdentitySheet(
+                                    context,
+                                    self: false,
+                                    config: Configuration.instance,
+                                    email: user.email,
+                                  );
+                                },
+                              ),
+                            )
+                            .toList(),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/mobile/apps/locker/lib/ui/sharing/share_collection_bottom_sheet.dart
+++ b/mobile/apps/locker/lib/ui/sharing/share_collection_bottom_sheet.dart
@@ -3,9 +3,6 @@ import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_sharing/models/user.dart";
 import "package:ente_sharing/user_avator_widget.dart";
 import "package:ente_strings/ente_strings.dart";
-import "package:ente_ui/components/captioned_text_widget_v2.dart";
-import "package:ente_ui/components/divider_widget.dart";
-import "package:ente_ui/components/menu_item_widget_v2.dart";
 import "package:ente_utils/share_utils.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
@@ -117,48 +114,34 @@ class _ShareCollectionSheetState extends State<ShareCollectionSheet> {
             borderRadius: BorderRadius.circular(20),
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxHeight: maxVisibleHeight),
-              child: ListView.builder(
+              child: ListView(
                 controller: _scrollController,
                 shrinkWrap: true,
                 padding: EdgeInsets.zero,
-                itemCount: allUsers.length,
-                itemBuilder: (context, index) {
-                  final user = allUsers[index];
-                  final isFirst = index == 0;
-                  final isLast = index == allUsers.length - 1;
-                  final role = CollectionParticipantRoleExtn.fromString(
-                    user.role,
-                  );
-
-                  return Column(
-                    children: [
-                      if (!isFirst)
-                        DividerWidget(
-                          dividerType: DividerType.menu,
-                          bgColor: colors.fillLight,
-                        ),
-                      MenuItemWidgetV2(
-                        captionedTextWidget: CaptionedTextWidgetV2(
-                          title: user.email,
-                        ),
-                        leadingIconSize: 24,
-                        leadingIconWidget: UserAvatarWidget(
+                children: [
+                  MenuGroupComponent(
+                    backgroundColor: colors.fillLight,
+                    showDividers: true,
+                    dividerPadding: const EdgeInsets.only(left: 48),
+                    items: allUsers.map((user) {
+                      final role = CollectionParticipantRoleExtn.fromString(
+                        user.role,
+                      );
+                      return MenuComponent(
+                        title: user.email,
+                        leading: UserAvatarWidget(
                           user,
                           currentUserID: currentUserId,
                           config: Configuration.instance,
                           type: AvatarType.mini,
                         ),
-                        menuItemColor: colors.fillLight,
-                        trailingWidget: _isOwner
+                        trailing: _isOwner
                             ? _buildRolePopupMenu(user)
                             : _buildRoleIcon(role),
-                        surfaceExecutionStates: false,
-                        isTopBorderRadiusRemoved: !isFirst,
-                        isBottomBorderRadiusRemoved: !isLast,
-                      ),
-                    ],
-                  );
-                },
+                      );
+                    }).toList(),
+                  ),
+                ],
               ),
             ),
           ),

--- a/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
+++ b/mobile/apps/locker/lib/ui/viewer/actions/file_selection_overlay_bar.dart
@@ -2,7 +2,6 @@ import 'package:ente_components/ente_components.dart';
 import "package:ente_events/event_bus.dart";
 import "package:ente_icons/ente_icons.dart";
 import "package:ente_strings/ente_strings.dart";
-import "package:ente_ui/components/buttons/button_widget.dart";
 import "package:ente_ui/utils/dialog_util.dart";
 import "package:ente_ui/utils/toast_util.dart";
 import "package:flutter/material.dart";
@@ -768,7 +767,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       illustration: LockerBottomSheetIllustration.fileDelete,
     );
 
-    if (confirmation?.buttonResult.action != ButtonAction.first) {
+    if (confirmation == null) {
       return;
     }
 
@@ -921,7 +920,7 @@ class _FileSelectionOverlayBarState extends State<FileSelectionOverlayBar> {
       illustration: LockerBottomSheetIllustration.collectionDelete,
     );
 
-    if (confirmation?.buttonResult.action != ButtonAction.first) {
+    if (confirmation == null) {
       return;
     }
 

--- a/mobile/apps/locker/lib/utils/collection_actions.dart
+++ b/mobile/apps/locker/lib/utils/collection_actions.dart
@@ -6,7 +6,6 @@ import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_sharing/components/invite_dialog.dart";
 import "package:ente_sharing/models/user.dart";
 import 'package:ente_strings/ente_strings.dart';
-import "package:ente_ui/components/buttons/button_widget.dart";
 import "package:ente_ui/components/progress_dialog.dart";
 import 'package:ente_ui/utils/dialog_util.dart';
 import "package:ente_ui/utils/toast_util.dart";
@@ -133,7 +132,7 @@ class CollectionActions {
       showDeleteFromAllCollectionsOption: true,
     );
 
-    if (dialogChoice?.buttonResult.action != ButtonAction.first) return;
+    if (dialogChoice == null) return;
 
     ProgressDialog? progressDialog;
     if (context.mounted) {
@@ -142,7 +141,7 @@ class CollectionActions {
     }
 
     bool isFavoriteCollection = false;
-    final bool keepFiles = !(dialogChoice?.deleteFromAllCollections ?? false);
+    final bool keepFiles = !dialogChoice.deleteFromAllCollections;
     final List<Collection> emptyCollections = [];
     final List<Collection> nonEmptyCollections = [];
     final List<dynamic> errors = [];
@@ -286,7 +285,7 @@ class CollectionActions {
       showDeleteFromAllCollectionsOption: true,
     );
 
-    if (result?.buttonResult.action != ButtonAction.first) {
+    if (result == null) {
       return;
     }
 
@@ -302,7 +301,7 @@ class CollectionActions {
       await CollectionService.instance.trashCollection(
         context.mounted ? context : null,
         collection,
-        keepFiles: !(result?.deleteFromAllCollections ?? false),
+        keepFiles: !result.deleteFromAllCollections,
       );
 
       await progressDialog?.hide();

--- a/mobile/apps/locker/lib/utils/file_actions.dart
+++ b/mobile/apps/locker/lib/utils/file_actions.dart
@@ -1,5 +1,4 @@
 import "package:ente_strings/ente_strings.dart";
-import "package:ente_ui/components/buttons/button_widget.dart";
 import "package:ente_ui/utils/dialog_util.dart";
 import "package:ente_ui/utils/toast_util.dart";
 import "package:flutter/material.dart";
@@ -294,7 +293,7 @@ class FileActions {
       illustration: LockerBottomSheetIllustration.fileDelete,
     );
 
-    if (confirmation?.buttonResult.action != ButtonAction.first) {
+    if (confirmation == null) {
       return;
     }
 
@@ -349,7 +348,7 @@ class FileActions {
       illustration: LockerBottomSheetIllustration.fileDelete,
     );
 
-    if (confirmation?.buttonResult.action != ButtonAction.first) {
+    if (confirmation == null) {
       return;
     }
 


### PR DESCRIPTION
Migrates Locker’s remaining legacy button-result and sharing-menu components to Locker-owned results and current `ente_components` menu patterns without changing delete or sharing behavior.

## Before / After

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/a4cc3c06-a8e3-4030-937f-88f80bb5b560" width="300" height="650" alt="Share collection before"></td>
<td><img src="https://github.com/user-attachments/assets/9420d9ca-fd6f-43e4-8232-5bf960089d5f" width="300" height="650" alt="Share collection after"></td>
</tr>
</table>

## Add email

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/8d63916d-dd69-406e-ad49-9bee4c830514" width="300" height="650" alt="Add email before"></td>
<td><img src="https://github.com/user-attachments/assets/90d755e6-a528-4834-9269-944f7fb56625" width="300" height="650" alt="Add email after"></td>
</tr>
</table>

## Validation

- `dart format` on all 8 changed Dart files
- `git diff --check` and recursive legacy usage/import searches
- `flutter analyze --no-pub` from `mobile/apps/locker`
- `flutter analyze --no-pub` from `mobile`
- iPhone 17 / iOS 26.4 simulator build and before/after comparison
- Empty-trash confirmation cancellation verified without deleting trash items

Populated sharing rows were unavailable on the test account, so avatar/role/remove/long-press/scrollbar contracts were verified through static review.
