### PR TITLE
[mobile] Remove the whole-file upload timeout

### DIFF
--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -52,7 +52,7 @@ class FileUploader {
   static const kMaximumConcurrentVideoUploads = 2;
   static const kMaxFileSize10Gib = 10737418240;
   static const kBlockedUploadsPollFrequency = Duration(seconds: 2);
-  static const kFileUploadTimeout = Duration(minutes: 50);
+  static const _longRunningUploadThreshold = Duration(minutes: 50);
   static const k20MBStorageBuffer = 20 * 1024 * 1024;
   static const _lastStaleFileCleanupTime = "lastStaleFileCleanupTime";
 
@@ -258,15 +258,15 @@ class FileUploader {
   }) async {
     final file = item.file;
     final collectionID = item.collectionID;
+    final stopwatch = Stopwatch()..start();
     try {
-      final uploadedFile = await _tryToUpload(file, collectionID, forcedUpload)
-          .timeout(
-            kFileUploadTimeout,
-            onTimeout: () {
-              final message = "Upload timed out for file " + file.toString();
-              throw TimeoutException(message);
-            },
-          );
+      final uploadedFile = await _tryToUpload(file, collectionID, forcedUpload);
+      stopwatch.stop();
+      if (stopwatch.elapsed >= _longRunningUploadThreshold) {
+        _logger.info(
+          "Long-running upload completed in ${stopwatch.elapsed} for ${file.tag}",
+        );
+      }
       _queue.complete(item, uploadedFile);
       return uploadedFile;
     } catch (e) {


### PR DESCRIPTION
- Remove the 50-minute deadline around the full Photos upload pipeline. It does not cancel the underlying future, and Sentry shows it firing for ordinary images and videos, mostly while iOS is inactive or paused, including repeated timeouts for the same file.
- Log successful uploads that finish after the former threshold. Multipart resume and Locker behavior are unchanged.
- A genuinely hung operation can retain its queue slot until process restart; previously it kept running invisibly while the queue started more work.

Validation: full mobile lint workflow (pubspec/ARB/icon checks, FRB codegen, Rust clippy, Dart format, Flutter analyze, and all workspace Flutter tests).