### PR TITLE
[server][web][mobile] Increase limit for internal users

### DIFF
--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -51,6 +51,7 @@ class FileUploader {
   static const kMaximumConcurrentUploads = 4;
   static const kMaximumConcurrentVideoUploads = 2;
   static const kMaxFileSize10Gib = 10737418240;
+  static const kMaxFileSize20Gib = 21474836480;
   static const kBlockedUploadsPollFrequency = Duration(seconds: 2);
   static const _longRunningUploadThreshold = Duration(minutes: 50);
   static const k20MBStorageBuffer = 20 * 1024 * 1024;
@@ -904,13 +905,16 @@ class FileUploader {
         throw StorageLimitExceededError();
       }
       final estimatedEncryptedSize = CryptoUtil.estimateEncryptedSize(fileSize);
-      if (estimatedEncryptedSize > kMaxFileSize10Gib) {
+      final maxFileSize = flagService.flags.internalUser
+          ? kMaxFileSize20Gib
+          : kMaxFileSize10Gib;
+      if (estimatedEncryptedSize > maxFileSize) {
         _logger.warning(
-          'Encrypted file size exceeds 10GiB sourceSize $fileSize '
+          'Encrypted file size exceeds $maxFileSize sourceSize $fileSize '
           'estimatedEncryptedSize $estimatedEncryptedSize',
         );
         throw InvalidFileError(
-          'encrypted file size above 10GiB',
+          'encrypted file size above $maxFileSize',
           InvalidReason.tooLargeFile,
         );
       }

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -327,6 +327,7 @@ func main() {
 		ObjectCleanupRepo:     objectCleanupRepo,
 		TrashRepository:       trashRepo,
 		UserRepo:              userRepo,
+		RemoteStoreRepo:       remoteStoreRepository,
 		UsageCtrl:             usageController,
 		AccessCtrl:            accessCtrl,
 		CollectionRepo:        collectionRepo,

--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/ente/museum/ente"
 	"github.com/ente/museum/pkg/repo"
+	"github.com/ente/museum/pkg/repo/remotestore"
 	enteArray "github.com/ente/museum/pkg/utils/array"
 	"github.com/ente/museum/pkg/utils/s3config"
 	"github.com/ente/museum/pkg/utils/time"
@@ -45,6 +46,7 @@ type FileController struct {
 	ObjectCleanupRepo     *repo.ObjectCleanupRepository
 	TrashRepository       *repo.TrashRepository
 	UserRepo              *repo.UserRepository
+	RemoteStoreRepo       *remotestore.Repository
 	UsageCtrl             *UsageController
 	CollectionRepo        *repo.CollectionRepository
 	TaskLockingRepo       *repo.TaskLockRepository
@@ -67,6 +69,9 @@ const StorageOverflowAboveSubscriptionLimit = int64(1024 * 1024 * 50)
 // MaxFileSize is the maximum file size a user can upload
 const MaxFileSize = int64(1024 * 1024 * 1024 * 10)
 
+// InternalUserMaxFileSize is the maximum file size an internal user can upload
+const InternalUserMaxFileSize = int64(1024 * 1024 * 1024 * 20)
+
 // MaxUploadURLsLimit indicates the max number of upload urls which can be request in one go
 const MaxUploadURLsLimit = 50
 
@@ -78,6 +83,26 @@ const (
 const (
 	DeletedObjectQueueLock = "deleted_objects_queue_lock"
 )
+
+func (c *FileController) isFileSizeAllowed(ctx context.Context, userID int64, fileSize int64, app ente.App) (bool, error) {
+	if fileSize <= MaxFileSize {
+		return true, nil
+	}
+	if fileSize > InternalUserMaxFileSize {
+		return false, nil
+	}
+	if app != ente.Photos {
+		return false, nil
+	}
+	value, err := c.RemoteStoreRepo.GetValue(ctx, userID, string(ente.IsInternalUser))
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, stacktrace.Propagate(err, "failed to get internal user flag")
+	}
+	return value == "true", nil
+}
 
 func (c *FileController) validateFileCreateOrUpdateReq(userID int64, file ente.File, app ente.App) error {
 	objectPathPrefix := strconv.FormatInt(userID, 10) + "/"
@@ -161,7 +186,11 @@ func (c *FileController) Create(ctx *gin.Context, userID int64, file ente.File, 
 	}
 	fileSize := fileResult.size
 	thumbnailSize := thumbResult.size
-	if fileSize > MaxFileSize {
+	isFileSizeAllowed, err := c.isFileSizeAllowed(ctx, userID, fileSize, app)
+	if err != nil {
+		return file, stacktrace.Propagate(err, "")
+	}
+	if !isFileSizeAllowed {
 		return file, stacktrace.Propagate(ente.ErrFileTooLarge, "")
 	}
 
@@ -264,7 +293,11 @@ func (c *FileController) Update(ctx context.Context, userID int64, file ente.Fil
 	if err != nil {
 		return response, stacktrace.Propagate(err, "")
 	}
-	if fileSize > MaxFileSize {
+	isFileSizeAllowed, err := c.isFileSizeAllowed(ctx, userID, fileSize, app)
+	if err != nil {
+		return response, stacktrace.Propagate(err, "")
+	}
+	if !isFileSizeAllowed {
 		return response, stacktrace.Propagate(ente.ErrFileTooLarge, "")
 	}
 	if file.File.Size != 0 && file.File.Size != fileSize {
@@ -362,7 +395,11 @@ func (c *FileController) GetUploadURLWithMetadata(ctx context.Context, userID in
 	if req.ContentLength <= 0 {
 		return ente.UploadURL{}, stacktrace.Propagate(ente.ErrBadRequest, "contentLength must be greater than 0")
 	}
-	if req.ContentLength > MaxFileSize {
+	isFileSizeAllowed, err := c.isFileSizeAllowed(ctx, userID, req.ContentLength, app)
+	if err != nil {
+		return ente.UploadURL{}, stacktrace.Propagate(err, "")
+	}
+	if !isFileSizeAllowed {
 		return ente.UploadURL{}, stacktrace.Propagate(ente.ErrBadRequest, "contentLength exceeds max file size %d", MaxFileSize)
 	}
 	checksum, err := normalizeMD5String(req.ContentMD5)
@@ -1177,7 +1214,11 @@ func (c *FileController) GetMultipartUploadURLWithMetadata(ctx context.Context, 
 	if req.ContentLength <= 0 {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "contentLength must be greater than 0")
 	}
-	if req.ContentLength > MaxFileSize {
+	isFileSizeAllowed, err := c.isFileSizeAllowed(ctx, userID, req.ContentLength, app)
+	if err != nil {
+		return ente.MultipartUploadURLs{}, stacktrace.Propagate(err, "")
+	}
+	if !isFileSizeAllowed {
 		return ente.MultipartUploadURLs{}, stacktrace.Propagate(ente.ErrBadRequest, "contentLength exceeds max file size %d", MaxFileSize)
 	}
 	if req.PartMD5s != nil && len(req.PartMD5s) == 0 {

--- a/web/apps/photos/src/services/upload-manager.ts
+++ b/web/apps/photos/src/services/upload-manager.ts
@@ -541,6 +541,7 @@ class UploadManager {
             deferMultipartChecksums:
                 settings.deferredMultipartChecksumsEnabled &&
                 (settings.isInternalUser || isDevBuild),
+            isInternalUser: settings.isInternalUser,
             skipDuplicateAddToUploadCollection:
                 options?.skipDuplicateAddToUploadCollection,
             includePartnerSharedFiles: options?.includePartnerSharedFiles,

--- a/web/packages/gallery/services/upload/upload-service.ts
+++ b/web/packages/gallery/services/upload/upload-service.ts
@@ -473,6 +473,7 @@ const fileTooLargeErrorMessage = "File too large";
 interface UploadContext {
     isCFUploadProxyDisabled: boolean;
     deferMultipartChecksums: boolean;
+    isInternalUser: boolean;
     skipDuplicateAddToUploadCollection?: boolean;
     includePartnerSharedFiles?: boolean;
     publicAlbumsCredentials?: PublicAlbumsCredentials;
@@ -525,7 +526,8 @@ export const upload = async (
 
         if (fileSize === 0) return { type: "zeroSize" };
 
-        const maxFileSize = 10 * 1024 * 1024 * 1024;
+        const maxFileSize =
+            (uploadContext.isInternalUser ? 20 : 10) * 1024 * 1024 * 1024;
         if (fileSize >= maxFileSize) return { type: "tooLarge" };
 
         abortIfCancelled();


### PR DESCRIPTION
- Allow Photos users with `internalUser=true` to upload objects up to 20 GiB; non-internal users and non-Photos apps remain capped at 10 GiB. The server only reads the remote flag for Photos requests between those limits.
- Enforce the limit when issuing upload URLs and again on file create/update, and mirror the internal-user preflight limit in the signed-in web and mobile Photos clients.

Validation: server lint and full Go tests with local PostgreSQL; complete web and mobile lint/test workflows; `cargo test --locked --features museum,ente-photos/ml-assets`.