### PR TITLE
[web] Fix Legacy Kit PDF recovery sheet parsing

### DIFF
--- a/web/apps/legacy/next.config.js
+++ b/web/apps/legacy/next.config.js
@@ -1,6 +1,56 @@
+const crypto = require("crypto");
+const fs = require("fs");
+
 const baseConfig = require("ente-base/next.config.base.js");
+const pdfWorkerPath =
+    require.resolve("pdfjs-dist/legacy/build/pdf.worker.min.mjs");
+const pdfWorkerSource = fs.readFileSync(pdfWorkerPath);
+const pdfWorkerHash = crypto
+    .createHash("sha256")
+    .update(pdfWorkerSource)
+    .digest("hex")
+    .slice(0, 8);
+const pdfWorkerAssetName = `static/media/pdf.worker.min.${pdfWorkerHash}.mjs`;
+
+class EmitPDFWorkerPlugin {
+    apply(compiler) {
+        compiler.hooks.thisCompilation.tap(
+            "EmitPDFWorkerPlugin",
+            (compilation) => {
+                compilation.hooks.processAssets.tap(
+                    {
+                        name: "EmitPDFWorkerPlugin",
+                        stage: compiler.webpack.Compilation
+                            .PROCESS_ASSETS_STAGE_ADDITIONAL,
+                    },
+                    () => {
+                        compilation.emitAsset(
+                            pdfWorkerAssetName,
+                            new compiler.webpack.sources.RawSource(
+                                pdfWorkerSource,
+                            ),
+                        );
+                    },
+                );
+            },
+        );
+    }
+}
 
 module.exports = {
     ...baseConfig,
+    env: {
+        ...(baseConfig.env ?? {}),
+        pdfWorkerSrc: `/_next/${pdfWorkerAssetName}`,
+    },
     transpilePackages: [...(baseConfig.transpilePackages ?? []), "pdfjs-dist"],
+    webpack: (config, options) => {
+        const configured = baseConfig.webpack
+            ? baseConfig.webpack(config, options)
+            : config;
+        if (!options.isServer) {
+            configured.plugins.push(new EmitPDFWorkerPlugin());
+        }
+        return configured;
+    },
 };

--- a/web/apps/legacy/package.json
+++ b/web/apps/legacy/package.json
@@ -7,7 +7,7 @@
         "ente-accounts-rs": "*",
         "ente-base": "*",
         "ente-wasm": "*",
-        "pdfjs-dist": "5.7.284",
+        "pdfjs-dist": "6.2.108",
         "qr": "0.6.0",
         "zod": "4.4.3"
     },

--- a/web/apps/legacy/src/features/legacy-kit/pdf-payload.ts
+++ b/web/apps/legacy/src/features/legacy-kit/pdf-payload.ts
@@ -1,0 +1,121 @@
+const legacyKitShareMetadataPrefix = "ente-legacy-kit-share-v1:";
+const legacyKitBundleMetadataPrefix = "ente-legacy-kit-shares-v1:";
+const maxVisiblePDFShareCodeChars = 512;
+
+export const findLegacyKitJSONObject = (value: string) => {
+    const start = value.indexOf('{"pv"');
+    if (start < 0) return undefined;
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let index = start; index < value.length; index++) {
+        const char = value[index];
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (char === "\\") {
+            escaped = true;
+            continue;
+        }
+        if (char === '"') {
+            inString = !inString;
+            continue;
+        }
+        if (inString) continue;
+        if (char === "{") {
+            depth += 1;
+        } else if (char === "}") {
+            depth -= 1;
+            if (depth === 0) return value.slice(start, index + 1);
+        }
+    }
+
+    return undefined;
+};
+
+const markerPayload = (value: string, marker: string) => {
+    const markerStart = value.indexOf(marker);
+    if (markerStart < 0) return undefined;
+
+    const payloadStart = markerStart + marker.length;
+    return /^[A-Za-z0-9_-]+/.exec(value.slice(payloadStart))?.[0];
+};
+
+const decodeBase64URLUTF8 = (value: string) => {
+    const base64 = value
+        .replaceAll("-", "+")
+        .replaceAll("_", "/")
+        .padEnd(Math.ceil(value.length / 4) * 4, "=");
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+        bytes[index] = binary.charCodeAt(index);
+    }
+    return new TextDecoder().decode(bytes);
+};
+
+export const legacyKitCodeFromPDFMetadata = (bytes: Uint8Array) => {
+    const pdfText = new TextDecoder("latin1").decode(bytes);
+    const sharePayload = markerPayload(pdfText, legacyKitShareMetadataPrefix);
+    if (sharePayload) return decodeBase64URLUTF8(sharePayload);
+
+    const bundlePayload = markerPayload(pdfText, legacyKitBundleMetadataPrefix);
+    if (!bundlePayload) return undefined;
+
+    const payloads: unknown = JSON.parse(decodeBase64URLUTF8(bundlePayload));
+    if (!Array.isArray(payloads)) {
+        throw new Error("Legacy Kit PDF metadata is invalid.");
+    }
+    if (payloads.length === 1 && typeof payloads[0] === "string") {
+        return payloads[0];
+    }
+    throw new Error("Choose individual Legacy Kit sheet PDFs.");
+};
+
+export const legacyKitCodeFromVisiblePDFText = (text: string) => {
+    const encodedJSONPrefix = "eyJwdiI";
+    const isEncodedChunk = (value: string) => /^[A-Za-z0-9_-]+$/.test(value);
+    const decodeCandidate = (encoded: string) => {
+        try {
+            const code = decodeBase64URLUTF8(encoded);
+            return findLegacyKitJSONObject(code) === code ? code : undefined;
+        } catch {
+            return undefined;
+        }
+    };
+
+    let encoded = "";
+    for (const line of text.split(/\r?\n/)) {
+        const chunk = line.trim();
+        if (encoded) {
+            if (
+                isEncodedChunk(chunk) &&
+                encoded.length + chunk.length <= maxVisiblePDFShareCodeChars
+            ) {
+                encoded += chunk;
+                const code = decodeCandidate(encoded);
+                if (code) return code;
+                continue;
+            }
+            encoded = "";
+        }
+
+        const start = chunk.indexOf(encodedJSONPrefix);
+        if (start < 0) continue;
+
+        const candidate = chunk.slice(start);
+        if (
+            candidate.length <= maxVisiblePDFShareCodeChars &&
+            isEncodedChunk(candidate)
+        ) {
+            encoded = candidate;
+            const code = decodeCandidate(encoded);
+            if (code) return code;
+        }
+    }
+
+    return undefined;
+};

--- a/web/apps/legacy/src/features/legacy-kit/scan.ts
+++ b/web/apps/legacy/src/features/legacy-kit/scan.ts
@@ -1,9 +1,13 @@
 import type { PDFDocumentProxy, PDFPageProxy } from "pdfjs-dist";
 
+import {
+    findLegacyKitJSONObject,
+    legacyKitCodeFromPDFMetadata,
+    legacyKitCodeFromVisiblePDFText,
+} from "./pdf-payload";
+
 type DecodeQR = (typeof import("qr/decode.js"))["default"];
 
-const legacyKitShareMetadataPrefix = "ente-legacy-kit-share-v1:";
-const legacyKitBundleMetadataPrefix = "ente-legacy-kit-shares-v1:";
 const maxTextFileBytes = 64 * 1024;
 const maxPDFFileBytes = 32 * 1024 * 1024;
 const maxImageFileBytes = 32 * 1024 * 1024;
@@ -38,6 +42,7 @@ interface DrawableImage {
 }
 
 let decodeQrPromise: Promise<DecodeQR> | undefined;
+let pdfJSPromise: Promise<typeof import("pdfjs-dist")> | undefined;
 
 export class LegacyKitQRDecodeError extends Error {}
 
@@ -48,6 +53,14 @@ const loadDecodeQr = () =>
             decodeQrPromise = undefined;
             throw error;
         }));
+
+const loadPDFJS = () =>
+    (pdfJSPromise ??= import("pdfjs-dist/legacy/build/pdf.mjs").then(
+        (pdfjs) => {
+            pdfjs.GlobalWorkerOptions.workerSrc = process.env.pdfWorkerSrc!;
+            return pdfjs;
+        },
+    ));
 
 const isPDF = (file: File) =>
     file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
@@ -335,86 +348,6 @@ const imageDimensionsFromFile = async (file: File) => {
     return dimensions;
 };
 
-const findJsonObject = (value: string) => {
-    const start = value.indexOf('{"pv"');
-    if (start < 0) return undefined;
-
-    let depth = 0;
-    let inString = false;
-    let escaped = false;
-
-    for (let index = start; index < value.length; index++) {
-        const char = value[index];
-        if (escaped) {
-            escaped = false;
-            continue;
-        }
-        if (char === "\\") {
-            escaped = true;
-            continue;
-        }
-        if (char === '"') {
-            inString = !inString;
-            continue;
-        }
-        if (inString) {
-            continue;
-        }
-        if (char === "{") {
-            depth += 1;
-        } else if (char === "}") {
-            depth -= 1;
-            if (depth === 0) {
-                return value.slice(start, index + 1);
-            }
-        }
-    }
-
-    return undefined;
-};
-
-const markerPayload = (value: string, marker: string) => {
-    const markerStart = value.indexOf(marker);
-    if (markerStart < 0) return undefined;
-
-    const payloadStart = markerStart + marker.length;
-    const payload = /^[A-Za-z0-9_-]+/.exec(value.slice(payloadStart))?.[0];
-    return payload || undefined;
-};
-
-const decodeBase64URLUTF8 = (value: string) => {
-    const base64 = value
-        .replaceAll("-", "+")
-        .replaceAll("_", "/")
-        .padEnd(Math.ceil(value.length / 4) * 4, "=");
-    const binary = atob(base64);
-    const bytes = new Uint8Array(binary.length);
-    for (let index = 0; index < binary.length; index++) {
-        bytes[index] = binary.charCodeAt(index);
-    }
-    return new TextDecoder().decode(bytes);
-};
-
-const codeFromPDFMetadata = (bytes: Uint8Array) => {
-    const pdfText = new TextDecoder("latin1").decode(bytes);
-    const sharePayload = markerPayload(pdfText, legacyKitShareMetadataPrefix);
-    if (sharePayload) {
-        return decodeBase64URLUTF8(sharePayload);
-    }
-
-    const bundlePayload = markerPayload(pdfText, legacyKitBundleMetadataPrefix);
-    if (!bundlePayload) return undefined;
-
-    const payloads: unknown = JSON.parse(decodeBase64URLUTF8(bundlePayload));
-    if (!Array.isArray(payloads)) {
-        throw new Error("Legacy Kit PDF metadata is invalid.");
-    }
-    if (payloads.length === 1 && typeof payloads[0] === "string") {
-        return payloads[0];
-    }
-    throw new Error("Choose individual Legacy Kit sheet PDFs.");
-};
-
 const loadImageFromFile = (file: File) =>
     new Promise<DrawableImage>((resolve, reject) => {
         const objectURL = URL.createObjectURL(file);
@@ -588,7 +521,11 @@ const textFromPDF = async (pdf: PDFDocumentProxy) => {
                 "Could not read that PDF page.",
             );
             const pageText = textContent.items
-                .map((item) => ("str" in item ? item.str : ""))
+                .map((item) =>
+                    "str" in item
+                        ? `${item.str}${item.hasEOL ? "\n" : ""}`
+                        : "",
+                )
                 .join("")
                 .slice(0, maxPDFTextChars - charCount);
             chunks.push(pageText);
@@ -657,8 +594,7 @@ const renderPDFPage = async (page: PDFPageProxy) => {
 };
 
 const decodeQrFromPDFBytes = async (bytes: Uint8Array) => {
-    const pdfjs =
-        (await import("pdfjs-dist/legacy/webpack.mjs")) as unknown as typeof import("pdfjs-dist");
+    const pdfjs = await loadPDFJS();
     const loadingTask = pdfjs.getDocument({
         data: bytes.slice(),
         disableFontFace: true,
@@ -678,7 +614,10 @@ const decodeQrFromPDFBytes = async (bytes: Uint8Array) => {
     try {
         let textCode: string | undefined;
         try {
-            textCode = findJsonObject(await textFromPDF(pdf));
+            const text = await textFromPDF(pdf);
+            const jsonCode = findLegacyKitJSONObject(text);
+            if (jsonCode) return jsonCode;
+            textCode = legacyKitCodeFromVisiblePDFText(text);
         } catch {
             // Text extraction is a fast path; scanned PDFs should still use QR rendering.
         }
@@ -698,7 +637,7 @@ const decodeQrFromPDFBytes = async (bytes: Uint8Array) => {
             }
         }
     } finally {
-        await pdf.destroy();
+        await loadingTask.destroy();
     }
 
     throw new LegacyKitQRDecodeError(
@@ -709,7 +648,7 @@ const decodeQrFromPDFBytes = async (bytes: Uint8Array) => {
 const decodeQrFromPDF = async (file: File) => {
     assertFileSize(file, maxPDFFileBytes);
     const bytes = new Uint8Array(await file.arrayBuffer());
-    const metadataCode = codeFromPDFMetadata(bytes);
+    const metadataCode = legacyKitCodeFromPDFMetadata(bytes);
     if (metadataCode) return metadataCode;
     return decodeQrFromPDFBytes(bytes);
 };
@@ -719,7 +658,7 @@ export const readLegacyKitCodeFromFile = async (file: File) => {
     if (isPlainText(file)) {
         assertFileSize(file, maxTextFileBytes);
         const value = await file.text();
-        return findJsonObject(value) ?? value.trim();
+        return findLegacyKitJSONObject(value) ?? value.trim();
     }
     assertFileSize(file, maxImageFileBytes);
     return decodeQrImage(await imageDataFromFile(file));

--- a/web/apps/legacy/src/types/pdfjs.d.ts
+++ b/web/apps/legacy/src/types/pdfjs.d.ts
@@ -1,3 +1,0 @@
-declare module "pdfjs-dist/legacy/webpack.mjs" {
-    export * from "pdfjs-dist/legacy/build/pdf.mjs";
-}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -212,7 +212,7 @@
                 "ente-accounts-rs": "*",
                 "ente-base": "*",
                 "ente-wasm": "*",
-                "pdfjs-dist": "5.7.284",
+                "pdfjs-dist": "6.2.108",
                 "qr": "0.6.0",
                 "zod": "4.4.3"
             },
@@ -2179,9 +2179,9 @@
             }
         },
         "node_modules/@napi-rs/canvas": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
-            "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.3.tgz",
+            "integrity": "sha512-OlI657a5XXvKGFX7kNeIzJ8rO7IXt87Mqu2H8rXE46viAuOfum/JA7ysX7+eBhxNKznT+RCZh418mndlcFX3+w==",
             "license": "MIT",
             "optional": true,
             "workspaces": [
@@ -2195,23 +2195,23 @@
                 "url": "https://github.com/sponsors/Brooooooklyn"
             },
             "optionalDependencies": {
-                "@napi-rs/canvas-android-arm64": "0.1.100",
-                "@napi-rs/canvas-darwin-arm64": "0.1.100",
-                "@napi-rs/canvas-darwin-x64": "0.1.100",
-                "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
-                "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
-                "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
-                "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
-                "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
-                "@napi-rs/canvas-linux-x64-musl": "0.1.100",
-                "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
-                "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+                "@napi-rs/canvas-android-arm64": "1.0.3",
+                "@napi-rs/canvas-darwin-arm64": "1.0.3",
+                "@napi-rs/canvas-darwin-x64": "1.0.3",
+                "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.3",
+                "@napi-rs/canvas-linux-arm64-gnu": "1.0.3",
+                "@napi-rs/canvas-linux-arm64-musl": "1.0.3",
+                "@napi-rs/canvas-linux-riscv64-gnu": "1.0.3",
+                "@napi-rs/canvas-linux-x64-gnu": "1.0.3",
+                "@napi-rs/canvas-linux-x64-musl": "1.0.3",
+                "@napi-rs/canvas-win32-arm64-msvc": "1.0.3",
+                "@napi-rs/canvas-win32-x64-msvc": "1.0.3"
             }
         },
         "node_modules/@napi-rs/canvas-android-arm64": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
-            "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.3.tgz",
+            "integrity": "sha512-7kSCdUhoXiO+AaIMXdBGdtp6EctZNkmF62Rea/BmVQlwKaM3bBhOzyGUzxyxz9dv5vdBfpyAaxhSRSJF4kqK4A==",
             "cpu": [
                 "arm64"
             ],
@@ -2229,9 +2229,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-darwin-arm64": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
-            "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.3.tgz",
+            "integrity": "sha512-ds14V1BPagLszQyaDTeggny5fNeTCqsUQ5QhFj9VDxSEfzrVxXtdbR0LoFyKa0Siaaw8KvqSk4t7k/WoZJwvbg==",
             "cpu": [
                 "arm64"
             ],
@@ -2249,9 +2249,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-darwin-x64": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
-            "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.3.tgz",
+            "integrity": "sha512-qof3LRAAycmkV2I1izZo9RoSHF8kCQr5O05sFwv0jK8rSdYV6KHVwimo6Qb7RxZj40WHKbLHm5JDaUF0o5XUAA==",
             "cpu": [
                 "x64"
             ],
@@ -2269,9 +2269,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
-            "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.3.tgz",
+            "integrity": "sha512-FU2kKZLmolHA9+KcUA+l1+xH3WTLUUTQDU/kLv9SEUr2TrRPu94aytOeizFJDHPs/QBcw4QL1mCQhetQXYBbag==",
             "cpu": [
                 "arm"
             ],
@@ -2289,11 +2289,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
-            "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.3.tgz",
+            "integrity": "sha512-GVSjntxKeA+/y/ZKf1F+cmUw1WeIkE5aMRPqnZUlBTBvBcrvgWccJAWuYCKPX4QJQwZILIIwhgdAbl51yj6fpA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2309,11 +2312,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
-            "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.3.tgz",
+            "integrity": "sha512-J51oK/axyZ13kxycumSMfLiDZMdWdOVvqDFI28BpuViZHE3A0bQfr8B5vg8YnPEnqLD3BSn1hkdlh2buspEcNQ==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2329,11 +2335,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
-            "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.3.tgz",
+            "integrity": "sha512-CtQgQjoVTX67jS9XuCTtJ40Sl7wRLMguoFnnGnfDmCWf7kzKFZVwj5ynqUOIGKFMSB61ZCuQlwPvVNxYTTseaw==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2349,11 +2358,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
-            "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.3.tgz",
+            "integrity": "sha512-jtfzAHFp+FRaR7zGT4jyCe6wUgAG/dVb5A4Apd8FY9jKarntDfUAlJXscugiH7ZF5kKnu7/lHFk9LaDPcrGEVQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2369,11 +2381,14 @@
             }
         },
         "node_modules/@napi-rs/canvas-linux-x64-musl": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
-            "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.3.tgz",
+            "integrity": "sha512-xTzaUCKUHTY4bCGadeeRZggbRVbGUT1petg7Z8r9AJR2+D9Bqu6nQAgqBGC6D47tA70LjaaaLTrJ7wNY1T74dg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -2389,9 +2404,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
-            "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.3.tgz",
+            "integrity": "sha512-ktVLuBkI6QVOm5BwO/WbdGwxgeetAMJa7TTmR8qBarXF0OU2NKjvjUtPJAl2y8t+zBRczJl/1VOl9gua6WcK2g==",
             "cpu": [
                 "arm64"
             ],
@@ -2409,9 +2424,9 @@
             }
         },
         "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-            "version": "0.1.100",
-            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
-            "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.3.tgz",
+            "integrity": "sha512-SGhlQ8bDjL1Cz2KnsKMasr/5sTcwG/SZkB6WCJxLsmSm/3aS2C+3p39bA7iZ2/94+NkVDySZfbiGoaSZSFHYxA==",
             "cpu": [
                 "x64"
             ],
@@ -8698,15 +8713,15 @@
             "link": true
         },
         "node_modules/pdfjs-dist": {
-            "version": "5.7.284",
-            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
-            "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+            "version": "6.2.108",
+            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz",
+            "integrity": "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=22.13.0 || >=24"
             },
             "optionalDependencies": {
-                "@napi-rs/canvas": "^0.1.100"
+                "@napi-rs/canvas": "^1.0.0"
             }
         },
         "node_modules/photos": {


### PR DESCRIPTION
## Summary

- preserve recovery from legacy PDFs that contain the existing `/Keywords` payload
- support metadata-free recovery sheets by extracting and decoding the printed recovery key
- render PDF pages and decode their QR code when text recovery is unavailable
- serve an untouched, version-matched PDF.js worker and update PDF.js to 6.2.108 https://github.com/ente/ente/pull/12019

## Root cause

New recovery sheets no longer embed the Legacy Kit payload in PDF metadata. The existing fallback depended on `pdfjs-dist/legacy/webpack.mjs`, whose worker is transformed by Next/Webpack and fails when loaded independently in the browser. As a result, PDF loading never completes and QR decoding is never reached.

## Impact

Both older metadata-based recovery sheets and newer metadata-free sheets are supported. Image uploads, pasted recovery codes, and existing recovery validation remain unchanged.

## Validation

- `npm run lint`
- `npm run build:legacy`
- localhost browser validation with an old metadata PDF, a printed-key-only PDF, and a QR-only PDF
