### PR TITLE
[mobile][photos] Dismiss progress dialogs after widget disposal

### DIFF
--- a/mobile/apps/photos/lib/ui/account/login_pwd_verification_page.dart
+++ b/mobile/apps/photos/lib/ui/account/login_pwd_verification_page.dart
@@ -162,7 +162,10 @@ class _LoginPasswordVerificationPageState
     );
     await dialog.show();
     try {
-      if (!context.mounted) return;
+      if (!context.mounted) {
+        await dialog.hide();
+        return;
+      }
       await UserService.instance.verifyEmailViaPassword(
         context,
         widget.srpAttributes,

--- a/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
@@ -682,7 +682,10 @@ class FileAppBarState extends State<FileAppBar> {
       isDismissible: true,
     );
     await dialog.show();
-    if (!mounted) return;
+    if (!mounted) {
+      await dialog.hide();
+      return;
+    }
     final Collection? sharedLinkCollection = await CollectionActions(
       CollectionsService.instance,
     ).createSharedCollectionLink(context, [file]);
@@ -714,7 +717,10 @@ class FileAppBarState extends State<FileAppBar> {
       final m = MediaExtension();
       final bool result = await m.setAs("file://${fileToSave.path}", "image/*");
       if (result == false) {
-        if (!mounted) return;
+        if (!mounted) {
+          await dialog.hide();
+          return;
+        }
         showShortToast(context, context.strings.somethingWentWrong);
       }
       await dialog.hide();

--- a/mobile/apps/photos/lib/ui/viewer/gallery/shared_public_collection_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/shared_public_collection_page.dart
@@ -84,7 +84,10 @@ class _SharedPublicCollectionPageState
       );
       await dialog.show();
       try {
-        if (!mounted) return;
+        if (!mounted) {
+          await dialog.hide();
+          return;
+        }
         await RemoteSyncService.instance.joinAndSyncCollection(
           context,
           widget.c.collection.id,
@@ -231,7 +234,10 @@ class _SharedPublicCollectionPageState
       );
       await dialog.show();
       try {
-        if (!mounted) return;
+        if (!mounted) {
+          await dialog.hide();
+          return;
+        }
         await RemoteSyncService.instance.joinAndSyncCollection(
           context,
           widget.c.collection.id,


### PR DESCRIPTION
Dismiss progress dialogs before lifecycle guards return, preventing stale overlays in login, link creation, Set as, and public-album join flows.

Validation: mobile-lint workflow checks.