### PR TITLE
[mobile][photos] Isolate social state across account sessions

### DIFF
--- a/mobile/apps/photos/lib/models/social/comment_draft_store.dart
+++ b/mobile/apps/photos/lib/models/social/comment_draft_store.dart
@@ -1,0 +1,65 @@
+import "package:photos/core/event_bus.dart";
+import "package:photos/events/user_logged_out_event.dart";
+import "package:photos/models/social/comment.dart";
+
+typedef CommentDraftFileKey = ({int fileID, int userID});
+typedef CommentDraftKey = ({int collectionID, int fileID, int userID});
+
+class CommentDraft {
+  const CommentDraft({required this.text, required this.replyingTo});
+
+  final String text;
+  final Comment? replyingTo;
+}
+
+class CommentDraftStore {
+  CommentDraftStore._() {
+    Bus.instance.on<UserLoggedOutEvent>().listen((_) => clear());
+  }
+
+  static final instance = CommentDraftStore._();
+
+  final Map<CommentDraftKey, CommentDraft> _drafts = {};
+  final Map<CommentDraftFileKey, int> _lastSelectedCollectionIDs = {};
+
+  CommentDraft? draftFor(CommentDraftKey key) => _drafts[key];
+
+  int? lastSelectedCollectionID(CommentDraftFileKey key) =>
+      _lastSelectedCollectionIDs[key];
+
+  void save(CommentDraftKey key, CommentDraft draft) {
+    _lastSelectedCollectionIDs[_fileKey(key)] = key.collectionID;
+    _drafts[key] = draft;
+  }
+
+  void remove(CommentDraftKey key) {
+    _drafts.remove(key);
+    final fileKey = _fileKey(key);
+    if (_lastSelectedCollectionIDs[fileKey] != key.collectionID) {
+      return;
+    }
+    final nextCollectionID = _firstDraftCollectionID(fileKey);
+    if (nextCollectionID == null) {
+      _lastSelectedCollectionIDs.remove(fileKey);
+    } else {
+      _lastSelectedCollectionIDs[fileKey] = nextCollectionID;
+    }
+  }
+
+  void clear() {
+    _drafts.clear();
+    _lastSelectedCollectionIDs.clear();
+  }
+
+  CommentDraftFileKey _fileKey(CommentDraftKey key) =>
+      (userID: key.userID, fileID: key.fileID);
+
+  int? _firstDraftCollectionID(CommentDraftFileKey fileKey) {
+    for (final key in _drafts.keys) {
+      if (key.userID == fileKey.userID && key.fileID == fileKey.fileID) {
+        return key.collectionID;
+      }
+    }
+    return null;
+  }
+}

--- a/mobile/apps/photos/lib/models/social/feed_data_provider.dart
+++ b/mobile/apps/photos/lib/models/social/feed_data_provider.dart
@@ -1,14 +1,17 @@
 import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/configuration.dart";
+import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/db/social_db.dart";
+import "package:photos/events/user_logged_out_event.dart";
 import "package:photos/models/collection/collection.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/social/comment.dart";
 import "package:photos/models/social/feed_item.dart";
+import "package:photos/models/social/feed_items_cache.dart";
 import "package:photos/models/social/reaction.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/collections_service.dart";
@@ -20,7 +23,10 @@ import "package:photos/services/social_sync_service.dart";
 /// Aggregates social activity (comments, reactions) into feed items
 /// for display in the activity feed.
 class FeedDataProvider {
-  FeedDataProvider._();
+  FeedDataProvider._() {
+    Bus.instance.on<UserLoggedOutEvent>().listen((_) => _cache.clear());
+  }
+
   static final instance = FeedDataProvider._();
 
   final _logger = Logger('FeedDataProvider');
@@ -31,12 +37,7 @@ class FeedDataProvider {
   static const _kSharedPhotoFetchMaxRows =
       _kSharedPhotoFetchPageSize * _kSharedPhotoFetchMaxPages;
   static const _kSharedCollectionPreviewFileLimit = 30;
-  static const _kFeedItemsCacheTtlMs = 3000;
-  Future<List<FeedItem>>? _inFlightFeedItemsFuture;
-  String? _inFlightFeedItemsKey;
-  List<FeedItem>? _lastFeedItems;
-  String? _lastFeedItemsKey;
-  int? _lastFeedItemsAtMs;
+  final _cache = FeedItemsCache(ttl: const Duration(seconds: 3));
 
   /// Gets feed items aggregated from local database.
   ///
@@ -48,55 +49,38 @@ class FeedDataProvider {
     bool includeSharedPhotos = true,
     bool verifyFileExistence = true,
   }) async {
-    final requestKey = '$limit|$includeSharedPhotos|$verifyFileExistence';
-    final nowMs = DateTime.now().millisecondsSinceEpoch;
-
-    if (_inFlightFeedItemsFuture != null &&
-        _inFlightFeedItemsKey == requestKey) {
-      return _inFlightFeedItemsFuture!;
-    }
-
-    final lastAtMs = _lastFeedItemsAtMs;
-    if (_lastFeedItems != null &&
-        _lastFeedItemsKey == requestKey &&
-        lastAtMs != null &&
-        (nowMs - lastAtMs) <= _kFeedItemsCacheTtlMs) {
-      return List<FeedItem>.from(_lastFeedItems!);
-    }
-
-    final future = _computeFeedItems(
-      limit: limit,
-      includeSharedPhotos: includeSharedPhotos,
-      verifyFileExistence: verifyFileExistence,
-    );
-    _inFlightFeedItemsFuture = future;
-    _inFlightFeedItemsKey = requestKey;
-
-    try {
-      final items = await future;
-      _lastFeedItems = List<FeedItem>.from(items);
-      _lastFeedItemsKey = requestKey;
-      _lastFeedItemsAtMs = DateTime.now().millisecondsSinceEpoch;
-      return items;
-    } finally {
-      if (identical(_inFlightFeedItemsFuture, future)) {
-        _inFlightFeedItemsFuture = null;
-        _inFlightFeedItemsKey = null;
-      }
-    }
-  }
-
-  Future<List<FeedItem>> _computeFeedItems({
-    required int limit,
-    required bool includeSharedPhotos,
-    required bool verifyFileExistence,
-  }) async {
     final userID = Configuration.instance.getUserID();
     if (userID == null) {
       _logger.warning('No user ID found, returning empty feed');
       return [];
     }
+    final requestKey = (
+      userID: userID,
+      limit: limit,
+      includeSharedPhotos: includeSharedPhotos,
+      verifyFileExistence: verifyFileExistence,
+    );
+    final items = await _cache.getOrCompute(
+      requestKey,
+      () => _computeFeedItems(
+        userID: userID,
+        limit: limit,
+        includeSharedPhotos: includeSharedPhotos,
+        verifyFileExistence: verifyFileExistence,
+      ),
+    );
+    if (Configuration.instance.getUserID() != userID) {
+      return [];
+    }
+    return items;
+  }
 
+  Future<List<FeedItem>> _computeFeedItems({
+    required int userID,
+    required int limit,
+    required bool includeSharedPhotos,
+    required bool verifyFileExistence,
+  }) async {
     final feedItems = <FeedItem>[];
 
     // Fetch all activity types in parallel

--- a/mobile/apps/photos/lib/models/social/feed_items_cache.dart
+++ b/mobile/apps/photos/lib/models/social/feed_items_cache.dart
@@ -1,0 +1,68 @@
+import "package:photos/models/social/feed_item.dart";
+
+typedef FeedItemsCacheKey = ({
+  int userID,
+  int limit,
+  bool includeSharedPhotos,
+  bool verifyFileExistence,
+});
+
+class FeedItemsCache {
+  FeedItemsCache({required this.ttl});
+
+  final Duration ttl;
+
+  Future<List<FeedItem>>? _inFlightFuture;
+  FeedItemsCacheKey? _inFlightKey;
+  List<FeedItem>? _lastItems;
+  FeedItemsCacheKey? _lastKey;
+  int? _lastItemsAtMs;
+  int _generation = 0;
+
+  Future<List<FeedItem>> getOrCompute(
+    FeedItemsCacheKey key,
+    Future<List<FeedItem>> Function() compute,
+  ) async {
+    if (_inFlightFuture != null && _inFlightKey == key) {
+      return _inFlightFuture!;
+    }
+
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final lastItemsAtMs = _lastItemsAtMs;
+    if (_lastItems != null &&
+        _lastKey == key &&
+        lastItemsAtMs != null &&
+        nowMs - lastItemsAtMs <= ttl.inMilliseconds) {
+      return List<FeedItem>.from(_lastItems!);
+    }
+
+    final generation = _generation;
+    final future = compute();
+    _inFlightFuture = future;
+    _inFlightKey = key;
+
+    try {
+      final items = await future;
+      if (generation == _generation) {
+        _lastItems = List<FeedItem>.from(items);
+        _lastKey = key;
+        _lastItemsAtMs = DateTime.now().millisecondsSinceEpoch;
+      }
+      return items;
+    } finally {
+      if (identical(_inFlightFuture, future)) {
+        _inFlightFuture = null;
+        _inFlightKey = null;
+      }
+    }
+  }
+
+  void clear() {
+    _generation++;
+    _inFlightFuture = null;
+    _inFlightKey = null;
+    _lastItems = null;
+    _lastKey = null;
+    _lastItemsAtMs = null;
+  }
+}

--- a/mobile/apps/photos/lib/ui/social/comments_screen.dart
+++ b/mobile/apps/photos/lib/ui/social/comments_screen.dart
@@ -10,6 +10,7 @@ import "package:photos/models/api/collection/user.dart";
 import "package:photos/models/collection/collection.dart";
 import "package:photos/models/social/comment.dart";
 import "package:photos/models/social/comment_author_utils.dart";
+import "package:photos/models/social/comment_draft_store.dart";
 import "package:photos/models/social/reaction.dart";
 import "package:photos/models/social/social_data_provider.dart";
 import "package:photos/services/collections_service.dart";
@@ -23,18 +24,7 @@ import "package:photos/ui/social/widgets/collection_selector_widget.dart";
 import "package:photos/ui/social/widgets/comment_bubble_widget.dart";
 import "package:photos/ui/social/widgets/comment_input_widget.dart";
 
-typedef _CommentDraftFileKey = ({int fileID, int userID});
-typedef _CommentDraftKey = ({int collectionID, int fileID, int userID});
-
-final Map<_CommentDraftKey, _CommentDraft> _commentDrafts = {};
-final Map<_CommentDraftFileKey, int> _lastSelectedDraftCollectionIDs = {};
-
-class _CommentDraft {
-  final String text;
-  final Comment? replyingTo;
-
-  const _CommentDraft({required this.text, required this.replyingTo});
-}
+final _commentDraftStore = CommentDraftStore.instance;
 
 /// Shows the file comments bottom sheet
 Future<void> showFileCommentsBottomSheet(
@@ -196,7 +186,9 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
     _currentUserID = Configuration.instance.getUserID()!;
     _selectedCollectionID = resolveInitialCommentsCollectionID(
       requestedCollectionID: widget.collectionID,
-      draftCollectionID: _lastSelectedDraftCollectionIDs[_draftFileKey],
+      draftCollectionID: _commentDraftStore.lastSelectedCollectionID(
+        _draftFileKey,
+      ),
       preferDraftCollection: widget.preferDraftCollection,
       hasHighlightedComment: widget.highlightCommentID != null,
     );
@@ -262,8 +254,8 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
         return;
       }
 
-      final savedSelectedCollectionID =
-          _lastSelectedDraftCollectionIDs[_draftFileKey];
+      final savedSelectedCollectionID = _commentDraftStore
+          .lastSelectedCollectionID(_draftFileKey);
       final nextSelectedCollectionID =
           _shouldPreferDraftCollection &&
               savedSelectedCollectionID != null &&
@@ -685,26 +677,26 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
         .collection;
   }
 
-  _CommentDraftFileKey get _draftFileKey =>
+  CommentDraftFileKey get _draftFileKey =>
       (userID: _currentUserID, fileID: widget.fileID);
 
   bool get _shouldPreferDraftCollection =>
       widget.preferDraftCollection && widget.highlightCommentID == null;
 
-  _CommentDraftKey get _draftKey => (
+  CommentDraftKey get _draftKey => (
     userID: _currentUserID,
     fileID: widget.fileID,
     collectionID: _selectedCollectionID,
   );
 
-  _CommentDraftKey _draftKeyForCollection(int collectionID) => (
+  CommentDraftKey _draftKeyForCollection(int collectionID) => (
     userID: _currentUserID,
     fileID: widget.fileID,
     collectionID: collectionID,
   );
 
   void _restoreDraftForSelectedCollection() {
-    final draft = _commentDrafts[_draftKey];
+    final draft = _commentDraftStore.draftFor(_draftKey);
     final text = draft?.text ?? '';
     _replyingTo = draft?.replyingTo;
     _textController.value = TextEditingValue(
@@ -718,10 +710,9 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
       _removeDraftForCollection(_selectedCollectionID);
       return;
     }
-    _lastSelectedDraftCollectionIDs[_draftFileKey] = _selectedCollectionID;
-    _commentDrafts[_draftKey] = _CommentDraft(
-      text: _textController.text,
-      replyingTo: _replyingTo,
+    _commentDraftStore.save(
+      _draftKey,
+      CommentDraft(text: _textController.text, replyingTo: _replyingTo),
     );
   }
 
@@ -730,24 +721,7 @@ class _FileCommentsBottomSheetState extends State<FileCommentsBottomSheet> {
   }
 
   void _removeDraftForCollection(int collectionID) {
-    _commentDrafts.remove(_draftKeyForCollection(collectionID));
-    if (_lastSelectedDraftCollectionIDs[_draftFileKey] == collectionID) {
-      final nextCollectionID = _firstDraftCollectionIDForFile();
-      if (nextCollectionID == null) {
-        _lastSelectedDraftCollectionIDs.remove(_draftFileKey);
-      } else {
-        _lastSelectedDraftCollectionIDs[_draftFileKey] = nextCollectionID;
-      }
-    }
-  }
-
-  int? _firstDraftCollectionIDForFile() {
-    for (final key in _commentDrafts.keys) {
-      if (key.userID == _currentUserID && key.fileID == widget.fileID) {
-        return key.collectionID;
-      }
-    }
-    return null;
+    _commentDraftStore.remove(_draftKeyForCollection(collectionID));
   }
 
   Widget _buildHeader(BuildContext context) {


### PR DESCRIPTION
Prevent feed items and comment drafts from carrying across account sessions.

Validation: mobile format/analyze checks and the full Photos test suite.