### PR TITLE
[mobile][photos] Fix hero animation glitch when exiting the full-screen viewer

### DIFF
--- a/mobile/apps/photos/changes/file-viewer-ui-updates.md
+++ b/mobile/apps/photos/changes/file-viewer-ui-updates.md
@@ -1,1 +1,2 @@
 - UI updates for the memories and gallery file viewers.
+- Fixed hero animation bug where multiple photos animated when closing. (@r4khul)

--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -488,13 +488,18 @@ class _BodyState extends State<_Body> {
                     .startTextSelectionAt(file, details.globalPosition)
               : null,
         );
-        return GestureDetector(
+        final page = GestureDetector(
           onTap: () {
             file.fileType != FileType.video
                 ? InheritedDetailPageState.of(context).toggleFullScreenByUser()
                 : null;
           },
           child: fileContent,
+        );
+        return ValueListenableBuilder(
+          valueListenable: _selectedIndexNotifier,
+          builder: (context, selectedIndex, _) =>
+              HeroMode(enabled: index == selectedIndex, child: page),
         );
       },
       onPageChanged: (index) {


### PR DESCRIPTION
## Description

Fixed a glitch in the full-screen photo viewer where swiping through photos and popping back quickly to the gallery made multiple images fly across the screen at once.

Root cause: PageView keeps neighboring pages cached, and every page registers a Hero whose tag also exists on the gallery grid. On pop, Flutter started a flight animation for every cached page. 

Now each page's Hero is gated behind `HeroMode(enabled: index == selectedIndex)`, so only the currently visible page participates in the transition.

### Visuals

**Before:**



https://github.com/user-attachments/assets/93b6e047-7fce-4646-9c63-5a442247f983






**After:**

https://github.com/user-attachments/assets/bda096ac-797c-4224-8f66-6078de63e9c1


Note: This glitch at times looks harsh rather than smooth (like in the video), especially when scrolling through a gallery and trying to immediately open a image, swiping to the adjacent image and exiting back.


## Tests
Tested & verified on physical devices - realme C67 5G & realme Pad 2.