### PR TITLE
Update self-hosting setup command to use bash

### DIFF
--- a/docs/docs/self-hosting/index.md
+++ b/docs/docs/self-hosting/index.md
@@ -23,7 +23,7 @@ For a quick preview, make sure your system meets the requirements mentioned belo
 Run this command on your terminal to setup Ente.
 
 ```sh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/ente/ente/main/server/quickstart.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ente/ente/main/server/quickstart.sh)"
 ```
 
 This creates a directory `my-ente` in the current working directory, prompts to start the cluster with needed containers after pulling the images required to run Ente.


### PR DESCRIPTION
## Description
Changed the command from 'sh' to 'bash' to fix https://github.com/ente/ente/issues/7701

More specifically, this fixes the sh: 230: [[: not found that i also had when trying to install ente on ubuntu 24.04 (Focal)

