### PR TITLE
[mobile][photos] native handling for network disconnections in payment webview

### DIFF
--- a/mobile/apps/photos/changes/payment-webview-network-error.md
+++ b/mobile/apps/photos/changes/payment-webview-network-error.md
@@ -1,0 +1,1 @@
+- Native handling of network disconnections in payment webview. (@r4khul)

--- a/mobile/apps/photos/lib/ui/payment/payment_web_page.dart
+++ b/mobile/apps/photos/lib/ui/payment/payment_web_page.dart
@@ -96,8 +96,17 @@ class _PaymentWebPageState extends State<PaymentWebPage> {
                 onLoadStart: (controller, navigationAction) async {
                   _logger.info("onLoadStart $navigationAction");
                 },
-                onReceivedError: (controller, navigationAction, code) async {
-                  _logger.severe("onLoadError $navigationAction $code");
+                onReceivedError: (controller, navigationAction, error) async {
+                  _logger.severe("onLoadError $navigationAction $error");
+                  if (navigationAction.isForMainFrame == true &&
+                      error.type != WebResourceErrorType.CANCELLED) {
+                    if (!mounted) return;
+                    Navigator.of(context).pop(false);
+                    await showGenericErrorDialog(
+                      context: context,
+                      error: error,
+                    );
+                  }
                 },
                 onReceivedHttpError:
                     (controller, navigationAction, code) async {

--- a/mobile/apps/photos/lib/ui/payment/payment_web_page.dart
+++ b/mobile/apps/photos/lib/ui/payment/payment_web_page.dart
@@ -101,9 +101,11 @@ class _PaymentWebPageState extends State<PaymentWebPage> {
                   if (navigationAction.isForMainFrame == true &&
                       error.type != WebResourceErrorType.CANCELLED) {
                     if (!mounted) return;
-                    Navigator.of(context).pop(false);
+                    final navigator = Navigator.of(context);
+                    navigator.pop(false);
+                    if (!navigator.mounted) return;
                     await showGenericErrorDialog(
-                      context: context,
+                      context: navigator.context,
                       error: error,
                     );
                   }

--- a/mobile/apps/photos/lib/ui/payment/payment_web_page.dart
+++ b/mobile/apps/photos/lib/ui/payment/payment_web_page.dart
@@ -98,8 +98,17 @@ class _PaymentWebPageState extends State<PaymentWebPage> {
                 },
                 onReceivedError: (controller, navigationAction, error) async {
                   _logger.severe("onLoadError $navigationAction $error");
+                  final networkErrorTypes = {
+                    WebResourceErrorType.HOST_LOOKUP,
+                    WebResourceErrorType.NOT_CONNECTED_TO_INTERNET,
+                    WebResourceErrorType.NETWORK_CONNECTION_LOST,
+                    WebResourceErrorType.TIMEOUT,
+                    WebResourceErrorType.CANNOT_CONNECT_TO_HOST,
+                    WebResourceErrorType.SERVER_UNREACHABLE,
+                  };
+                  final isNetworkError = networkErrorTypes.contains(error.type);
                   if (navigationAction.isForMainFrame == true &&
-                      error.type != WebResourceErrorType.CANCELLED) {
+                      isNetworkError) {
                     if (!mounted) return;
                     final navigator = Navigator.of(context);
                     navigator.pop(false);

--- a/mobile/apps/photos/lib/utils/dialog_util.dart
+++ b/mobile/apps/photos/lib/utils/dialog_util.dart
@@ -4,6 +4,7 @@ import "package:ente_strings/ente_strings.dart";
 import "package:flutter/foundation.dart";
 import 'package:flutter/material.dart';
 import "package:flutter/services.dart";
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:photos/models/button_result.dart';
 import 'package:photos/models/typedefs.dart';
 import "package:photos/module/download/manager.dart";
@@ -125,6 +126,18 @@ String parseErrorForUI(
       }
     }
   }
+
+  if (error is WebResourceError) {
+    if (error.type == WebResourceErrorType.HOST_LOOKUP ||
+        error.type == WebResourceErrorType.NOT_CONNECTED_TO_INTERNET ||
+        error.type == WebResourceErrorType.TIMEOUT) {
+      return context.strings.networkHostLookUpErr;
+    } else if (error.type == WebResourceErrorType.CANNOT_CONNECT_TO_HOST ||
+        error.type == WebResourceErrorType.SERVER_UNREACHABLE) {
+      return context.strings.networkConnectionRefusedErr;
+    }
+  }
+
   // return generic error if the user is not internal and the error is not in debug mode
   if (!(flagService.internalUser && kDebugMode)) {
     return genericError;

--- a/mobile/apps/photos/lib/utils/dialog_util.dart
+++ b/mobile/apps/photos/lib/utils/dialog_util.dart
@@ -130,6 +130,7 @@ String parseErrorForUI(
   if (error is WebResourceError) {
     if (error.type == WebResourceErrorType.HOST_LOOKUP ||
         error.type == WebResourceErrorType.NOT_CONNECTED_TO_INTERNET ||
+        error.type == WebResourceErrorType.NETWORK_CONNECTION_LOST ||
         error.type == WebResourceErrorType.TIMEOUT) {
       return context.strings.networkHostLookUpErr;
     } else if (error.type == WebResourceErrorType.CANNOT_CONNECT_TO_HOST ||


### PR DESCRIPTION
## Description
The payment webview displayed a broken web page and leaked the full URL when the network disconnected.

This fix applies the existing network error handling pattern used in Manage Subscriptions. The `dialog_util` now parses webview errors to present the standard network error dialog instead of the broken page. All remaining logic remains unchanged.

### Visuals

**Before:**


https://github.com/user-attachments/assets/ed44ea63-0b5e-4d9a-8db3-b053d0f43e7d


**After:**


https://github.com/user-attachments/assets/e84c8601-a6d0-4381-b3d3-eca2079c0bda


## Tests

Tested & verified on physical devices - realme C67 5G & realme Pad 2.