### PR TITLE
[mobile][photos] Handle non-JSON API errors

### DIFF
--- a/mobile/apps/photos/lib/core/network/api_response.dart
+++ b/mobile/apps/photos/lib/core/network/api_response.dart
@@ -27,6 +27,7 @@ class ApiResponseInterceptor extends Interceptor {
     final unexpected = UnexpectedApiResponseException(
       error.requestOptions,
       response,
+      error.type,
     );
     handler.reject(unexpected);
   }
@@ -50,6 +51,7 @@ class UnexpectedApiResponseException extends DioException
   UnexpectedApiResponseException(
     RequestOptions request,
     Response<dynamic>? originalResponse,
+    DioExceptionType originalType,
   ) : details = _details(originalResponse),
       super(
         requestOptions: _safeRequest(request),
@@ -60,7 +62,7 @@ class UnexpectedApiResponseException extends DioException
                 statusCode: originalResponse.statusCode,
                 data: _details(originalResponse),
               ),
-        type: DioExceptionType.badResponse,
+        type: originalType,
         message: "The API returned an unexpected response",
       );
 
@@ -79,7 +81,6 @@ Map<String, Object> _details(Response<dynamic>? response) {
     "content_type": ?response?.headers.value(Headers.contentTypeHeader),
     "server": ?response?.headers.value("server"),
     "cf_ray": ?response?.headers.value("cf-ray"),
-    "retry_after": ?response?.headers.value("retry-after"),
     if (body is String) "body_length": utf8.encode(body).length,
   });
 }
@@ -91,5 +92,6 @@ RequestOptions _safeRequest(RequestOptions request) {
   return RequestOptions(
     method: request.method,
     path: segments.isEmpty ? "/" : "/${segments.first}",
+    headers: {"x-request-id": ?request.headers["x-request-id"]},
   );
 }

--- a/mobile/apps/photos/lib/core/network/api_response.dart
+++ b/mobile/apps/photos/lib/core/network/api_response.dart
@@ -1,0 +1,95 @@
+import "dart:convert";
+
+import "package:dio/dio.dart";
+import "package:photos/core/exceptions.dart";
+
+class ApiResponseInterceptor extends Interceptor {
+  ApiResponseInterceptor(String endpoint) : _endpoint = Uri.parse(endpoint);
+
+  final Uri _endpoint;
+
+  @override
+  void onError(DioException error, ErrorInterceptorHandler handler) {
+    if (!_isApiRequest(error.requestOptions)) {
+      handler.next(error);
+      return;
+    }
+
+    final response = error.response;
+    final isInvalidJSON = response == null && error.error is FormatException;
+    final hasNonJSONBody =
+        response != null && response.data is! Map && response.data is! List;
+    if (!isInvalidJSON && !hasNonJSONBody) {
+      handler.next(error);
+      return;
+    }
+
+    final unexpected = UnexpectedApiResponseException(
+      error.requestOptions,
+      response,
+    );
+    handler.reject(unexpected);
+  }
+
+  bool _isApiRequest(RequestOptions request) {
+    final uri = request.uri;
+    if (uri.scheme != _endpoint.scheme ||
+        uri.host != _endpoint.host ||
+        uri.port != _endpoint.port) {
+      return false;
+    }
+    final basePath = _endpoint.path.replaceFirst(RegExp(r"/$"), "");
+    return basePath.isEmpty ||
+        uri.path == basePath ||
+        uri.path.startsWith("$basePath/");
+  }
+}
+
+class UnexpectedApiResponseException extends DioException
+    implements LocallyHandledError {
+  UnexpectedApiResponseException(
+    RequestOptions request,
+    Response<dynamic>? originalResponse,
+  ) : details = _details(originalResponse),
+      super(
+        requestOptions: _safeRequest(request),
+        response: originalResponse == null
+            ? null
+            : Response<dynamic>(
+                requestOptions: _safeRequest(request),
+                statusCode: originalResponse.statusCode,
+                data: _details(originalResponse),
+              ),
+        type: DioExceptionType.badResponse,
+        message: "The API returned an unexpected response",
+      );
+
+  final Map<String, Object> details;
+
+  @override
+  String toString() => "UnexpectedApiResponseException: $details";
+}
+
+Map<String, Object> _details(Response<dynamic>? response) {
+  final body = response?.data;
+  return Map.unmodifiable({
+    "unexpected_response": true,
+    if (response == null) "reason": "invalid_json",
+    "status_code": ?response?.statusCode,
+    "content_type": ?response?.headers.value(Headers.contentTypeHeader),
+    "server": ?response?.headers.value("server"),
+    "cf_ray": ?response?.headers.value("cf-ray"),
+    "retry_after": ?response?.headers.value("retry-after"),
+    if (body is String) "body_length": utf8.encode(body).length,
+  });
+}
+
+RequestOptions _safeRequest(RequestOptions request) {
+  final segments = request.uri.pathSegments.where(
+    (segment) => segment.isNotEmpty,
+  );
+  return RequestOptions(
+    method: request.method,
+    path: segments.isEmpty ? "/" : "/${segments.first}",
+  );
+}

--- a/mobile/apps/photos/lib/core/network/network.dart
+++ b/mobile/apps/photos/lib/core/network/network.dart
@@ -9,9 +9,9 @@ import 'package:logging/logging.dart';
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import "package:photos/core/event_bus.dart";
+import "package:photos/core/network/api_response.dart";
 import "package:photos/core/network/endpoint_config.dart";
 import 'package:photos/core/network/ente_interceptor.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 import "package:shared_preferences/shared_preferences.dart";
 import "package:ua_client_hints/ua_client_hints.dart";
 
@@ -42,7 +42,6 @@ class NetworkClient {
     );
     _enteDio.httpClientAdapter = _newAdaptiveHttpClientAdapter(_connectTimeout);
 
-    _dio.interceptors.add(_StringResponseBreadcrumbInterceptor());
     _setupInterceptors(endpoint);
 
     if (_endpointUpdatedSubscription != null) {
@@ -57,9 +56,11 @@ class NetworkClient {
   }
 
   void _setupInterceptors(String endpoint) {
+    _dio.interceptors.clear();
+    _dio.interceptors.add(ApiResponseInterceptor(endpoint));
     _enteDio.interceptors.clear();
     _enteDio.interceptors.add(EnteRequestInterceptor(endpoint));
-    _enteDio.interceptors.add(_StringResponseBreadcrumbInterceptor());
+    _enteDio.interceptors.add(ApiResponseInterceptor(endpoint));
   }
 
   BaseOptions _newBaseOptions(
@@ -118,51 +119,6 @@ class NetworkClient {
   Dio get downloadDio => _downloadDio;
 
   Dio get enteDio => _enteDio;
-}
-
-class _StringResponseBreadcrumbInterceptor extends Interceptor {
-  @override
-  void onResponse(Response response, ResponseInterceptorHandler handler) {
-    _addBreadcrumb(response);
-    handler.next(response);
-  }
-
-  @override
-  void onError(DioException err, ErrorInterceptorHandler handler) {
-    final response = err.response;
-    if (response != null) {
-      _addBreadcrumb(response);
-    }
-    handler.next(err);
-  }
-
-  void _addBreadcrumb(Response response) {
-    final responseData = response.data;
-    if (responseData is! String || responseData.isEmpty) {
-      return;
-    }
-
-    final uri = response.requestOptions.uri;
-    unawaited(
-      Sentry.addBreadcrumb(
-        Breadcrumb(
-          category: "http",
-          type: "http",
-          message: "String API response",
-          data: {
-            "method": response.requestOptions.method,
-            "host": uri.host,
-            "status_code": response.statusCode,
-            "content_type": response.headers.value(Headers.contentTypeHeader),
-            "server_header": response.headers.value(HttpHeaders.serverHeader),
-            "cf_ray": response.headers.value("cf-ray"),
-            "cf_cache_status": response.headers.value("cf-cache-status"),
-            "body_length": responseData.length,
-          },
-        ),
-      ),
-    );
-  }
 }
 
 class _HttpSchemeFallbackAdapter implements HttpClientAdapter {


### PR DESCRIPTION
Convert non-JSON API failures into a sanitized local-only error and remove the Sentry breadcrumb path.