### PR TITLE
[mobile][locker] show cached item count in drawer when offline

### DIFF
--- a/mobile/apps/locker/changes/drawer-offline-cached-count.md
+++ b/mobile/apps/locker/changes/drawer-offline-cached-count.md
@@ -1,0 +1,1 @@
+- Show last cached count of items stored when offline instead of a spinner. (@r4khul)

--- a/mobile/apps/locker/lib/ui/components/usage_card_widget.dart
+++ b/mobile/apps/locker/lib/ui/components/usage_card_widget.dart
@@ -15,8 +15,7 @@ class UsageCardWidget extends StatelessWidget {
     final colors = context.componentColors;
     final inheritedDetails = InheritedUserDetails.of(context);
     final userDetails = inheritedDetails?.userDetails;
-    final isCached = inheritedDetails?.isCached ?? false;
-    final isLoading = userDetails is! UserDetails || isCached;
+    final isLoading = userDetails is! UserDetails;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(20),


### PR DESCRIPTION
### Description
When the drawer is opened while offline, the "Items stored" card spins forever. 
The network refresh never completes, and the card treated the last-cached file count as "loading" instead of showing it.

**Fix:** show the spinner only when there's no cached data at all, so the last-known count is displayed while offline.
- usage_card_widget.dart: drop the || isCached loading condition
- Matches the existing behavior in the photos app's storage card

### Before: Spinner instead of cached data

https://github.com/user-attachments/assets/be502792-92bf-4b99-a7c1-9cdbad6e5ac1

### After: Available cached data shown

<img width="368" height="136" alt="image" src="https://github.com/user-attachments/assets/e4366b4b-a35f-4207-b35c-6dcb2e3fa734" />

### Tests
Verified with physical device - realme c67 5g & realme pad 2.