### PR TITLE
[ensu] rename chats in desktop

### DIFF
--- a/desktop/changes/chat-rename.md
+++ b/desktop/changes/chat-rename.md
@@ -1,0 +1,1 @@
+- Added the ability to rename chats on desktop (@fosszil).

--- a/rust/crates/ensu/src/db/chat/mod.rs
+++ b/rust/crates/ensu/src/db/chat/mod.rs
@@ -103,10 +103,9 @@ impl<B: Backend> ChatDb<B> {
 
     pub fn update_session_title(&self, uuid: Uuid, title: &str) -> Result<()> {
         let affected = self.backend.execute(
-            "UPDATE sessions SET title = ?, updated_at = ? WHERE session_uuid = ?",
+            "UPDATE sessions SET title = ? WHERE session_uuid = ?",
             &[
                 Value::Blob(crypto::encrypt_string(title, &self.key)?),
-                Value::Integer(self.clock.now_us()),
                 Value::Text(uuid.to_string()),
             ],
         )?;
@@ -147,7 +146,7 @@ impl<B: Backend> ChatDb<B> {
              VALUES (?, ?, ?, ?)
              ON CONFLICT(session_uuid) DO UPDATE SET
                title = CASE
-                 WHEN excluded.updated_at >= sessions.updated_at THEN excluded.title
+                 WHEN excluded.updated_at > sessions.updated_at THEN excluded.title
                  ELSE sessions.title
                END,
                created_at = MIN(sessions.created_at, excluded.created_at),

--- a/web/apps/ensu/src/components/chat/ChatDialogs.tsx
+++ b/web/apps/ensu/src/components/chat/ChatDialogs.tsx
@@ -75,6 +75,11 @@ export interface ChatDialogsProps {
     openModelSettings: () => void;
     openSystemPromptSettings: () => void;
     isSmall: boolean;
+    renameSessionId: string | null;
+    renameSessionTitle: string;
+    setRenameSessionTitle: (title: string) => void;
+    handleCancelRenameSession: () => void;
+    handleConfirmRenameSession: () => void | Promise<void>;
     deleteSessionId: string | null;
     deleteSessionLabel: string;
     handleCancelDeleteSession: () => void;
@@ -122,6 +127,11 @@ export const ChatDialogs = memo(
         openModelSettings,
         openSystemPromptSettings,
         isSmall,
+        renameSessionId,
+        renameSessionTitle,
+        setRenameSessionTitle,
+        handleCancelRenameSession,
+        handleConfirmRenameSession,
         deleteSessionId,
         deleteSessionLabel,
         handleCancelDeleteSession,
@@ -623,6 +633,53 @@ export const ChatDialogs = memo(
                             onClick={() => setShowBackupComingSoon(false)}
                         >
                             Got it
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+
+                <Dialog
+                    open={Boolean(renameSessionId)}
+                    onClose={handleCancelRenameSession}
+                    fullScreen={isSmall}
+                    maxWidth="xs"
+                    fullWidth
+                    slotProps={{ paper: { sx: dialogPaperSx } }}
+                >
+                    <DialogTitle sx={dialogTitleSx}>Rename chat</DialogTitle>
+                    <DialogContent>
+                        <TextField
+                            value={renameSessionTitle}
+                            onChange={(event) =>
+                                setRenameSessionTitle(event.target.value)
+                            }
+                            autoFocus
+                            fullWidth
+                            label="Chat name"
+                            slotProps={{ htmlInput: { maxLength: 40 } }}
+                            onKeyDown={(event) => {
+                                if (
+                                    event.key === "Enter" &&
+                                    !event.nativeEvent.isComposing
+                                ) {
+                                    void handleConfirmRenameSession();
+                                }
+                            }}
+                        />
+                    </DialogContent>
+                    <DialogActions sx={{ px: 3, pb: 3 }}>
+                        <Button
+                            onClick={handleCancelRenameSession}
+                            color="secondary"
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="contained"
+                            color="accent"
+                            disabled={!renameSessionTitle.trim()}
+                            onClick={() => void handleConfirmRenameSession()}
+                        >
+                            Rename
                         </Button>
                     </DialogActions>
                 </Dialog>

--- a/web/apps/ensu/src/components/chat/ChatSidebar.tsx
+++ b/web/apps/ensu/src/components/chat/ChatSidebar.tsx
@@ -308,6 +308,11 @@ export const ChatSidebar = memo(
                                         "&.Mui-selected:hover": {
                                             backgroundColor: "fill.faintHover",
                                         },
+                                        "& .rename-chat-button": {
+                                            visibility: "hidden",
+                                        },
+                                        "&:hover .rename-chat-button, &:focus-within .rename-chat-button":
+                                            { visibility: "visible" },
                                     }}
                                 >
                                     <Stack
@@ -350,6 +355,7 @@ export const ChatSidebar = memo(
                                             </Typography>
                                         </Box>
                                         <IconButton
+                                            className="rename-chat-button"
                                             aria-label="Rename chat"
                                             sx={actionButtonSx}
                                             onClick={(event) => {

--- a/web/apps/ensu/src/components/chat/ChatSidebar.tsx
+++ b/web/apps/ensu/src/components/chat/ChatSidebar.tsx
@@ -4,6 +4,7 @@ import {
     ArrowRight01Icon,
     Cancel01Icon,
     Delete01Icon,
+    Edit01Icon,
     PlusSignIcon,
     Search01Icon,
 } from "@hugeicons/core-free-icons";
@@ -42,6 +43,7 @@ export interface ChatSidebarProps {
     groupedSessions: Array<[string, ChatSession[]]>;
     currentSessionId?: string;
     handleSelectSession: (sessionId: string) => void;
+    requestRenameSession: (session: ChatSession) => void;
     requestDeleteSession: (sessionId: string) => void;
     openSettingsModal: () => void;
 }
@@ -65,6 +67,7 @@ export const ChatSidebar = memo(
         groupedSessions,
         currentSessionId,
         handleSelectSession,
+        requestRenameSession,
         requestDeleteSession,
         openSettingsModal,
     }: ChatSidebarProps) => (
@@ -346,6 +349,19 @@ export const ChatSidebar = memo(
                                                     "Nothing here"}
                                             </Typography>
                                         </Box>
+                                        <IconButton
+                                            aria-label="Rename chat"
+                                            sx={actionButtonSx}
+                                            onClick={(event) => {
+                                                event.stopPropagation();
+                                                requestRenameSession(session);
+                                            }}
+                                        >
+                                            <HugeiconsIcon
+                                                icon={Edit01Icon}
+                                                {...actionIconProps}
+                                            />
+                                        </IconButton>
                                         <IconButton
                                             aria-label="Delete chat"
                                             sx={actionButtonSx}

--- a/web/apps/ensu/src/pages/chat.tsx
+++ b/web/apps/ensu/src/pages/chat.tsx
@@ -1912,7 +1912,25 @@ const Page: React.FC = () => {
                 );
                 if (!firstUser) return;
 
+                const currentTitle = sessions.find(
+                    (session) => session.sessionUuid === sessionUuid,
+                )?.title;
                 const userText = parseDocumentBlocks(firstUser.text).text;
+                const automaticFallbackTitles = [
+                    sessionTitleFromText(firstUser.text, "New chat"),
+                    sessionTitleFromText(
+                        userText || firstUser.text,
+                        "New chat",
+                    ),
+                ];
+                if (
+                    currentTitle &&
+                    currentTitle.toLowerCase() !== "new chat" &&
+                    !automaticFallbackTitles.includes(currentTitle)
+                ) {
+                    return;
+                }
+
                 const assistantText = stripHiddenPartsText(firstAssistant.text);
 
                 const fallbackSeed = trimToWords(userText, 7) || "New chat";
@@ -1938,7 +1956,13 @@ const Page: React.FC = () => {
                 sessionSummaryInFlightRef.current = false;
             }
         },
-        [chatKey, generateSessionSummary, persistSessionTitle, trimToWords],
+        [
+            chatKey,
+            generateSessionSummary,
+            persistSessionTitle,
+            sessions,
+            trimToWords,
+        ],
     );
 
     const preloadModelIfAvailable = useCallback(async () => {
@@ -2330,8 +2354,15 @@ const Page: React.FC = () => {
     const handleConfirmRenameSession = useCallback(async () => {
         if (!chatKey || !renameSessionId || !renameSessionTitle.trim()) return;
         if (pendingSessionRenamesRef.current.has(renameSessionId)) return;
-        pendingSessionRenamesRef.current.add(renameSessionId);
         const title = sessionTitleFromText(renameSessionTitle);
+        const currentTitle = sessions.find(
+            (session) => session.sessionUuid === renameSessionId,
+        )?.title;
+        if (!currentTitle || title === currentTitle) {
+            handleCancelRenameSession();
+            return;
+        }
+        pendingSessionRenamesRef.current.add(renameSessionId);
         const wasManuallyRenamed =
             manuallyRenamedSessionIdsRef.current.has(renameSessionId);
         manuallyRenamedSessionIdsRef.current.add(renameSessionId);
@@ -2353,6 +2384,7 @@ const Page: React.FC = () => {
         persistSessionTitle,
         renameSessionId,
         renameSessionTitle,
+        sessions,
     ]);
 
     const handleConfirmDeleteSession = useCallback(async () => {

--- a/web/apps/ensu/src/pages/chat.tsx
+++ b/web/apps/ensu/src/pages/chat.tsx
@@ -650,6 +650,8 @@ const Page: React.FC = () => {
     >("checking");
     const [modelGateError, setModelGateError] = useState<string | null>(null);
     const [isTauriRuntime, setIsTauriRuntime] = useState(false);
+    const [renameSessionId, setRenameSessionId] = useState<string | null>(null);
+    const [renameSessionTitle, setRenameSessionTitle] = useState("");
     const [deleteSessionId, setDeleteSessionId] = useState<string | null>(null);
 
     const allowMmproj = isTauriRuntime;
@@ -664,6 +666,9 @@ const Page: React.FC = () => {
         previousSelection?: string | null;
     } | null>(null);
     const sessionSummaryInFlightRef = useRef(false);
+    const manuallyRenamedSessionIdsRef = useRef(new Set<string>());
+    const pendingSessionRenamesRef = useRef(new Set<string>());
+    const sessionTitleUpdatesRef = useRef(new Map<string, Promise<void>>());
     const inputRef = useRef<HTMLTextAreaElement | null>(null);
     const attachmentPreviewUrlsRef = useRef<Record<string, string>>({});
     const pendingPreviewUrlsRef = useRef<Record<string, string>>({});
@@ -1853,6 +1858,30 @@ const Page: React.FC = () => {
         [],
     );
 
+    const persistSessionTitle = useCallback(
+        (sessionUuid: string, title: string, key: string) => {
+            const previous = sessionTitleUpdatesRef.current.get(sessionUuid);
+            const task = (previous?.catch(() => {}) ?? Promise.resolve()).then(
+                async () => {
+                    await updateSessionTitle(sessionUuid, title, key);
+                    updateSessionTitleInState(sessionUuid, title);
+                },
+            );
+            sessionTitleUpdatesRef.current.set(sessionUuid, task);
+            void task
+                .finally(() => {
+                    if (
+                        sessionTitleUpdatesRef.current.get(sessionUuid) === task
+                    ) {
+                        sessionTitleUpdatesRef.current.delete(sessionUuid);
+                    }
+                })
+                .catch(() => {});
+            return task;
+        },
+        [updateSessionTitleInState],
+    );
+
     const maybeGenerateSessionTitle = useCallback(
         async ({
             sessionUuid,
@@ -1899,20 +1928,17 @@ const Page: React.FC = () => {
                     ? sessionTitleFromText(summarySeed, fallbackTitle)
                     : fallbackTitle;
 
-                await updateSessionTitle(sessionUuid, title, chatKey);
-                updateSessionTitleInState(sessionUuid, title);
+                if (manuallyRenamedSessionIdsRef.current.has(sessionUuid)) {
+                    return;
+                }
+                await persistSessionTitle(sessionUuid, title, chatKey);
             } catch (error) {
                 log.error("Failed to generate session title", error);
             } finally {
                 sessionSummaryInFlightRef.current = false;
             }
         },
-        [
-            chatKey,
-            generateSessionSummary,
-            trimToWords,
-            updateSessionTitleInState,
-        ],
+        [chatKey, generateSessionSummary, persistSessionTitle, trimToWords],
     );
 
     const preloadModelIfAvailable = useCallback(async () => {
@@ -2236,6 +2262,7 @@ const Page: React.FC = () => {
 
     const removeSessionFromState = useCallback(
         (sessionId: string) => {
+            manuallyRenamedSessionIdsRef.current.delete(sessionId);
             setSessions((prev) =>
                 prev.filter((session) => session.sessionUuid !== sessionId),
             );
@@ -2288,6 +2315,45 @@ const Page: React.FC = () => {
     const requestDeleteSession = useCallback((sessionId: string) => {
         setDeleteSessionId(sessionId);
     }, []);
+
+    const requestRenameSession = useCallback((session: ChatSession) => {
+        if (pendingSessionRenamesRef.current.has(session.sessionUuid)) return;
+        setRenameSessionId(session.sessionUuid);
+        setRenameSessionTitle(session.title?.trim() || "New chat");
+    }, []);
+
+    const handleCancelRenameSession = useCallback(() => {
+        setRenameSessionId(null);
+        setRenameSessionTitle("");
+    }, []);
+
+    const handleConfirmRenameSession = useCallback(async () => {
+        if (!chatKey || !renameSessionId || !renameSessionTitle.trim()) return;
+        if (pendingSessionRenamesRef.current.has(renameSessionId)) return;
+        pendingSessionRenamesRef.current.add(renameSessionId);
+        const title = sessionTitleFromText(renameSessionTitle);
+        const wasManuallyRenamed =
+            manuallyRenamedSessionIdsRef.current.has(renameSessionId);
+        manuallyRenamedSessionIdsRef.current.add(renameSessionId);
+        handleCancelRenameSession();
+        try {
+            await persistSessionTitle(renameSessionId, title, chatKey);
+        } catch (error) {
+            if (!wasManuallyRenamed) {
+                manuallyRenamedSessionIdsRef.current.delete(renameSessionId);
+            }
+            onGenericError(error);
+        } finally {
+            pendingSessionRenamesRef.current.delete(renameSessionId);
+        }
+    }, [
+        chatKey,
+        handleCancelRenameSession,
+        onGenericError,
+        persistSessionTitle,
+        renameSessionId,
+        renameSessionTitle,
+    ]);
 
     const handleConfirmDeleteSession = useCallback(async () => {
         if (!deleteSessionId) return;
@@ -3890,6 +3956,7 @@ const Page: React.FC = () => {
             groupedSessions={groupedSessions}
             currentSessionId={currentSessionId}
             handleSelectSession={handleSelectSession}
+            requestRenameSession={requestRenameSession}
             requestDeleteSession={requestDeleteSession}
             openSettingsModal={openSettingsModal}
         />
@@ -4171,6 +4238,11 @@ const Page: React.FC = () => {
                 openModelSettings={openModelSettings}
                 openSystemPromptSettings={openSystemPromptSettings}
                 isSmall={isSmall}
+                renameSessionId={renameSessionId}
+                renameSessionTitle={renameSessionTitle}
+                setRenameSessionTitle={setRenameSessionTitle}
+                handleCancelRenameSession={handleCancelRenameSession}
+                handleConfirmRenameSession={handleConfirmRenameSession}
                 deleteSessionId={deleteSessionId}
                 deleteSessionLabel={deleteSessionLabel}
                 handleCancelDeleteSession={handleCancelDeleteSession}

--- a/web/apps/ensu/src/pages/chat.tsx
+++ b/web/apps/ensu/src/pages/chat.tsx
@@ -1844,16 +1844,13 @@ const Page: React.FC = () => {
 
     const updateSessionTitleInState = useCallback(
         (sessionUuid: string, title: string) => {
-            const updatedAt = Date.now() * 1000;
-            setSessions((prev) => {
-                const next = prev.map((session) =>
+            setSessions((prev) =>
+                prev.map((session) =>
                     session.sessionUuid === sessionUuid
-                        ? { ...session, title, updatedAt }
+                        ? { ...session, title }
                         : session,
-                );
-                next.sort((a, b) => b.updatedAt - a.updatedAt);
-                return next;
-            });
+                ),
+            );
         },
         [],
     );

--- a/web/apps/ensu/src/services/chat/store.ts
+++ b/web/apps/ensu/src/services/chat/store.ts
@@ -707,14 +707,17 @@ export const updateSessionTitle = async (
     }
 
     const db = await chatDb();
-    const session = await db.get("sessions", sessionUuid);
-    if (!session) return;
-
     const updated = await encryptChatPayload({ title: safe }, chatKey);
-    session.encryptedData = updated.encryptedData;
-    session.header = updated.header;
-    session.updatedAt = nowMicros();
-    await db.put("sessions", session);
+
+    const tx = db.transaction(["sessions"], "readwrite");
+    const sessionStore = tx.objectStore("sessions");
+    const session = await sessionStore.get(sessionUuid);
+    if (session) {
+        session.encryptedData = updated.encryptedData;
+        session.header = updated.header;
+        await sessionStore.put(session);
+    }
+    await tx.done;
 };
 
 export const updateMessage = async (


### PR DESCRIPTION
## Description
Added a feature to rename chats using dialog box in Ensu Desktop. I initially implemented inline renaming, but it introduced persistence and interaction-state issues, including focus, blur, and navigation conflicts. A dialog-based rename flow provides clearer save/cancel boundaries and was simpler and more reliable to implement.

## Tests

<img width="400" height="275" alt="Screencast_20260809_214324" src="https://github.com/user-attachments/assets/717afa01-d656-4aa6-890f-b054b38511a9" />

