### PR TITLE
[server] Prevent revoked sessions from being re-cached

### DIFF
--- a/server/pkg/controller/authsession/controller.go
+++ b/server/pkg/controller/authsession/controller.go
@@ -1,0 +1,45 @@
+package authsession
+
+import (
+	"database/sql"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/pkg/repo"
+	"github.com/patrickmn/go-cache"
+)
+
+type cacheEntry struct {
+	userID  int64
+	revoked bool
+}
+
+func Authenticate(repo *repo.UserAuthRepository, authCache *cache.Cache, token string, app ente.App) (userID int64, expired, cached bool, err error) {
+	cacheKey := tokenCacheKey(app, token)
+	for {
+		if value, ok := authCache.Get(cacheKey); ok {
+			entry := value.(cacheEntry)
+			if entry.revoked {
+				return 0, false, false, sql.ErrNoRows
+			}
+			return entry.userID, false, true, nil
+		}
+
+		userID, expired, err = repo.GetUserIDWithToken(token, app)
+		if err != nil || expired {
+			return
+		}
+		if err = authCache.Add(cacheKey, cacheEntry{userID: userID}, cache.DefaultExpiration); err == nil {
+			return
+		}
+	}
+}
+
+func MarkRevoked(authCache *cache.Cache, tokens []repo.RevokedToken) {
+	for _, token := range tokens {
+		authCache.Set(tokenCacheKey(token.App, token.Token), cacheEntry{revoked: true}, cache.DefaultExpiration)
+	}
+}
+
+func tokenCacheKey(app ente.App, token string) string {
+	return string(app) + ":" + token
+}

--- a/server/pkg/controller/user/srp.go
+++ b/server/pkg/controller/user/srp.go
@@ -90,7 +90,7 @@ func (c *UserController) UpdateSrpAndKeyAttributes(context *gin.Context,
 
 	if shouldClearTokens {
 		token := auth.GetToken(context)
-		err = c.UserAuthRepo.RemoveAllOtherTokens(userID, token)
+		err = c.RemoveAllOtherTokens(userID, token)
 		if err != nil {
 			return nil, err
 		}

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -17,7 +17,9 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/ente/museum/ente"
+	"github.com/ente/museum/pkg/controller/authsession"
 	emailCtrl "github.com/ente/museum/pkg/controller/email"
+	"github.com/ente/museum/pkg/repo"
 	"github.com/ente/museum/pkg/utils/auth"
 	"github.com/ente/museum/pkg/utils/crypto"
 	emailUtil "github.com/ente/museum/pkg/utils/email"
@@ -545,58 +547,26 @@ func (c *UserController) AddTokenAndNotify(ctx *gin.Context, userID int64, app e
 }
 
 func (c *UserController) RemoveTokensForApps(userID int64, apps []ente.App) error {
-	if len(apps) == 0 {
-		return nil
-	}
-	if err := c.deleteActiveTokenCacheEntriesForApps(userID, apps); err != nil {
-		return err
-	}
-	if err := c.UserAuthRepo.RemoveTokensForApps(userID, apps); err != nil {
-		return stacktrace.Propagate(err, "failed to remove tokens")
-	}
-	return nil
+	return c.finishTokenRevocation(c.UserAuthRepo.RemoveTokensForApps(userID, apps))
 }
 
 func (c *UserController) RemoveAllTokens(userID int64) error {
-	apps, err := c.UserAuthRepo.GetAppsForUser(userID)
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to get user apps")
-	}
-	if err = c.deleteActiveTokenCacheEntriesForApps(userID, apps); err != nil {
-		return err
-	}
-	if err = c.UserAuthRepo.RemoveAllTokens(userID); err != nil {
-		return stacktrace.Propagate(err, "failed to remove tokens")
-	}
-	return nil
+	return c.finishTokenRevocation(c.UserAuthRepo.RemoveAllTokens(userID))
+}
+
+func (c *UserController) RemoveAllOtherTokens(userID int64, token string) error {
+	return c.finishTokenRevocation(c.UserAuthRepo.RemoveAllOtherTokens(userID, token))
 }
 
 func (c *UserController) TerminateSession(userID int64, token string) error {
-	apps, err := c.UserAuthRepo.GetAppsForUser(userID)
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to get user apps")
-	}
-	for _, app := range apps {
-		c.Cache.Delete(fmt.Sprintf("%s:%s", app, token))
-	}
-	return stacktrace.Propagate(c.UserAuthRepo.RemoveToken(userID, token), "")
+	return c.finishTokenRevocation(c.UserAuthRepo.RemoveToken(userID, token))
 }
 
-// Auth middleware trusts cached app:token entries for up to a minute, so token
-// revocation needs to evict those entries as well to take effect immediately.
-func (c *UserController) deleteActiveTokenCacheEntriesForApps(userID int64, apps []ente.App) error {
-	if len(apps) == 0 {
-		return nil
+func (c *UserController) finishTokenRevocation(tokens []repo.RevokedToken, err error) error {
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to remove tokens")
 	}
-	for _, app := range apps {
-		sessions, err := c.UserAuthRepo.GetActiveSessions(userID, app)
-		if err != nil {
-			return stacktrace.Propagate(err, "failed to get active sessions")
-		}
-		for _, session := range sessions {
-			c.Cache.Delete(fmt.Sprintf("%s:%s", app, session.Token))
-		}
-	}
+	authsession.MarkRevoked(c.Cache, tokens)
 	return nil
 }
 

--- a/server/pkg/middleware/auth.go
+++ b/server/pkg/middleware/auth.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ente/museum/ente"
 	"github.com/ente/museum/ente/jwt"
+	"github.com/ente/museum/pkg/controller/authsession"
 	"github.com/ente/museum/pkg/utils/network"
 	"github.com/sirupsen/logrus"
 
@@ -35,53 +36,51 @@ func (m *AuthMiddleware) TokenAuthMiddleware(jwtClaimScope *jwt.ClaimScope) gin.
 			return
 		}
 		app := auth.GetApp(c)
-		cacheKey := fmt.Sprintf("%s:%s", app, token)
-		isJWT := false
-		if jwtClaimScope != nil {
-			isJWT = true
-			cacheKey = fmt.Sprintf("%s:%s:%s", app, token, *jwtClaimScope)
-		}
-		userID, found := m.Cache.Get(cacheKey)
-		var err error
-		if !found {
-			if isJWT {
-				claim, claimErr := m.UserController.ValidateJWTToken(token, *jwtClaimScope)
-				if claimErr != nil {
-					err = claimErr
-				} else {
-					userID = claim.UserID
-				}
-			} else {
-				var isExpired bool
-				userID, isExpired, err = m.UserAuthRepo.GetUserIDWithToken(token, app)
-				if err != nil && !errors.Is(err, sql.ErrNoRows) {
-					logrus.Errorf("Failed to validate token: %s", err)
-					c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to validate token"})
-					return
-				}
-				if isExpired {
-					logrus.Warningf("User token expired: %d", userID)
-					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token expired"})
-					return
-				}
+		var userID int64
+		if jwtClaimScope == nil {
+			var expired, cached bool
+			var err error
+			userID, expired, cached, err = authsession.Authenticate(m.UserAuthRepo, m.Cache, token, app)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				logrus.Errorf("Failed to validate token: %s", err)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to validate token"})
+				return
 			}
 			if err != nil {
 				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
 				return
 			}
-			if !isJWT {
+			if expired {
+				logrus.Warningf("User token expired: %d", userID)
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token expired"})
+				return
+			}
+			if !cached {
 				ip := network.GetClientIP(c)
 				userAgent := c.Request.UserAgent()
 				// skip updating last used for requests routed via CF worker
 				if !network.IsCFWorkerIP(ip) {
 					go func() {
-						_ = m.UserAuthRepo.UpdateLastUsedAt(userID.(int64), token, ip, userAgent)
+						_ = m.UserAuthRepo.UpdateLastUsedAt(userID, token, ip, userAgent)
 					}()
 				}
 			}
-			m.Cache.Set(cacheKey, userID, cache.DefaultExpiration)
+		} else {
+			cacheKey := fmt.Sprintf("%s:%s:%s", app, token, *jwtClaimScope)
+			cachedUserID, found := m.Cache.Get(cacheKey)
+			if found {
+				userID = cachedUserID.(int64)
+			} else {
+				claim, err := m.UserController.ValidateJWTToken(token, *jwtClaimScope)
+				if err != nil {
+					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+					return
+				}
+				userID = claim.UserID
+				m.Cache.Set(cacheKey, userID, cache.DefaultExpiration)
+			}
 		}
-		c.Request.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID.(int64), 10))
+		c.Request.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))
 		c.Set(auth.AppContextKey, app)
 		c.Next()
 	}

--- a/server/pkg/repo/userauth.go
+++ b/server/pkg/repo/userauth.go
@@ -15,6 +15,11 @@ type UserAuthRepository struct {
 	DB *sql.DB
 }
 
+type RevokedToken struct {
+	App   ente.App
+	Token string
+}
+
 func (repo *UserAuthRepository) AddOTT(emailHash string, app ente.App, ott string, expirationTime int64) error {
 	_, err := repo.DB.Exec(`INSERT INTO otts(email_hash, ott, creation_time, expiration_time, app)
 				VALUES($1, $2, $3, $4, $5)
@@ -155,10 +160,11 @@ func (repo *UserAuthRepository) GetUserIDWithToken(token string, app ente.App) (
 	return id, isExpired, nil
 }
 
-func (repo *UserAuthRepository) RemoveToken(userID int64, token string) error {
-	_, err := repo.DB.Exec(`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND token = $2`,
-		userID, token)
-	return stacktrace.Propagate(err, "")
+func (repo *UserAuthRepository) RemoveToken(userID int64, token string) ([]RevokedToken, error) {
+	return repo.markTokensDeleted(
+		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND token = $2 RETURNING app, token`,
+		userID, token,
+	)
 }
 
 func (repo *UserAuthRepository) UpdateLastUsedAt(userID int64, token string, ip string, userAgent string) error {
@@ -167,10 +173,11 @@ func (repo *UserAuthRepository) UpdateLastUsedAt(userID int64, token string, ip 
 	return stacktrace.Propagate(err, "")
 }
 
-func (repo *UserAuthRepository) RemoveAllOtherTokens(userID int64, token string) error {
-	_, err := repo.DB.Exec(`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND token <> $2`,
-		userID, token)
-	return stacktrace.Propagate(err, "")
+func (repo *UserAuthRepository) RemoveAllOtherTokens(userID int64, token string) ([]RevokedToken, error) {
+	return repo.markTokensDeleted(
+		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND token <> $2 AND is_deleted = false RETURNING app, token`,
+		userID, token,
+	)
 }
 
 func (repo *UserAuthRepository) RemoveDeletedTokens(expiryTime int64) error {
@@ -178,22 +185,46 @@ func (repo *UserAuthRepository) RemoveDeletedTokens(expiryTime int64) error {
 	return stacktrace.Propagate(err, "")
 }
 
-func (repo *UserAuthRepository) RemoveTokensForApps(userID int64, apps []ente.App) error {
+func (repo *UserAuthRepository) RemoveTokensForApps(userID int64, apps []ente.App) ([]RevokedToken, error) {
 	if len(apps) == 0 {
-		return nil
+		return nil, nil
 	}
 	dbApps := make([]string, 0, len(apps))
 	for _, app := range apps {
 		dbApps = append(dbApps, string(app))
 	}
-	_, err := repo.DB.Exec(`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND app = ANY($2)`,
-		userID, pq.Array(dbApps))
-	return stacktrace.Propagate(err, "")
+	return repo.markTokensDeleted(
+		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND app = ANY($2) AND is_deleted = false RETURNING app, token`,
+		userID, pq.Array(dbApps),
+	)
 }
 
-func (repo *UserAuthRepository) RemoveAllTokens(userID int64) error {
-	_, err := repo.DB.Exec(`UPDATE tokens SET is_deleted = true WHERE user_id = $1`, userID)
-	return stacktrace.Propagate(err, "")
+func (repo *UserAuthRepository) RemoveAllTokens(userID int64) ([]RevokedToken, error) {
+	return repo.markTokensDeleted(
+		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND is_deleted = false RETURNING app, token`,
+		userID,
+	)
+}
+
+func (repo *UserAuthRepository) markTokensDeleted(query string, args ...interface{}) ([]RevokedToken, error) {
+	rows, err := repo.DB.Query(query, args...)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	defer rows.Close()
+
+	tokens := make([]RevokedToken, 0)
+	for rows.Next() {
+		var token RevokedToken
+		if err = rows.Scan(&token.App, &token.Token); err != nil {
+			return nil, stacktrace.Propagate(err, "")
+		}
+		tokens = append(tokens, token)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	return tokens, nil
 }
 
 func (repo *UserAuthRepository) GetActiveSessions(userID int64, app ente.App) ([]ente.Session, error) {


### PR DESCRIPTION
### Before

A cache miss could read a valid token just before revocation, then re-cache that stale result after the cache entry was cleared.

### After

Revocation stores one-minute markers for the exact app/token rows changed in PostgreSQL. Cache fills use an atomic add, so they cannot overwrite an active marker.

This assumes one Museum instance and token lookups completing within one minute.

Validation: `./scripts/lint.sh`; `./scripts/test-with-postgres.sh host`