### PR TITLE
docs: cover Photos 1.3.60 features

### DIFF
--- a/docs/docs/photos/features/utilities/cast/index.md
+++ b/docs/docs/photos/features/utilities/cast/index.md
@@ -29,7 +29,9 @@ With Ente Cast, you can play a slideshow of your favourite albums on your Google
 
     </div>
 
-    On Google Chrome and other Chromium browsers, you will see a button labeled "Auto Pair". This option will prompt you to select a Chromecast supported device on your local network. Note: this option requires connecting to Google servers to load necessary dependencies. This option does not transmit any sensitive data through Google servers, such as your photos. Once your Chromecast device is connected, you're all set.
+    In the mobile app, **Auto Pair** discovers compatible Cast devices on your local network. Select a device from the list to connect. On iOS, allow the local network permission when prompted so Ente can discover devices.
+
+    On Google Chrome and other Chromium browsers, **Auto Pair** prompts you to select a Chromecast-supported device on your local network. This option requires connecting to Google servers to load necessary dependencies, but does not transmit sensitive data such as your photos through Google servers.
 
     On all browsers, you'll see the option to "Pair with PIN". This option works with all devices, Chromecast-enabled or not. You'll be required to load up [cast.ente.com](https://cast.ente.com) on your large screen device.
 
@@ -57,13 +59,13 @@ This is especially useful if you cast the same album to different screens at dif
 
 ## Pairing options explained
 
-### Auto Pair (Chromium browsers only)
+### Auto Pair
 
-- Available in Google Chrome and other Chromium-based browsers
-- Automatically detects Chromecast devices on your local network
-- Requires connecting to Google servers to load necessary dependencies
-- Does not transmit sensitive data (like your photos) through Google servers
-- Quickest option if you have a Chromecast-enabled device
+- Available in the Ente mobile app and in Chromium-based browsers
+- Automatically detects compatible Cast devices on your local network
+- On iOS, requires local network permission for device discovery
+- In Chromium browsers, requires connecting to Google servers to load necessary dependencies
+- Does not transmit sensitive data such as your photos through Google servers
 
 ### Pair with PIN (All browsers & devices)
 

--- a/docs/docs/photos/features/utilities/home-widgets.md
+++ b/docs/docs/photos/features/utilities/home-widgets.md
@@ -57,6 +57,8 @@ Displays photos featuring selected people from your library. This widget helps y
 
 ## Configuring Widgets
 
+If a widget has not been configured yet, tap it on your home screen to open its customization screen directly in Ente. You can also configure widgets from the app settings.
+
 ### Widget Settings
 
 Open `Settings > Widgets` in the Ente app to configure your widgets.

--- a/docs/docs/photos/features/utilities/video-streaming.md
+++ b/docs/docs/photos/features/utilities/video-streaming.md
@@ -62,6 +62,7 @@ Open the specific video, tap the overflow menu (⋮) in the top-right corner, an
 
 ### On mobile
 
+- Use the mute button in the video player to turn sound on or off; Ente remembers this preference for other videos
 - Open `Settings > Backup > Backup status` to see processing status
 - Processed videos show a green play button
 - Tap processed videos to see a `Play stream` button

--- a/docs/docs/photos/features/utilities/video-streaming.md
+++ b/docs/docs/photos/features/utilities/video-streaming.md
@@ -62,7 +62,6 @@ Open the specific video, tap the overflow menu (⋮) in the top-right corner, an
 
 ### On mobile
 
-- Use the mute button in the video player to turn sound on or off; Ente remembers this preference for other videos
 - Open `Settings > Backup > Backup status` to see processing status
 - Processed videos show a green play button
 - Tap processed videos to see a `Play stream` button


### PR DESCRIPTION
## Summary

- document mobile Cast auto-pairing and the iOS local-network permission
- explain that tapping an unconfigured home widget opens its customization screen
- document the persistent video mute control

These user-visible changes shipped in Photos v1.3.60.

## Checks

- `npx prettier --check --log-level warn docs/photos/features/utilities/cast/index.md docs/photos/features/utilities/home-widgets.md docs/photos/features/utilities/video-streaming.md`
- `npm run build`
- `git diff --check`