### PR TITLE
[mob][photos] Fix search dismissal and Memories state handling

### DIFF
--- a/mobile/apps/photos/lib/services/memories_cache_service.dart
+++ b/mobile/apps/photos/lib/services/memories_cache_service.dart
@@ -208,7 +208,7 @@ class MemoriesCacheService {
   }
 
   bool _shouldInvalidateForDeletedFiles(EventType type) {
-    if (type == EventType.deletedFromEverywhere) {
+    if (type == EventType.deletedFromEverywhere || type == EventType.hide) {
       return true;
     }
 

--- a/mobile/apps/photos/lib/services/memories_cache_service.dart
+++ b/mobile/apps/photos/lib/services/memories_cache_service.dart
@@ -94,7 +94,8 @@ class MemoriesCacheService {
     Bus.instance
         .on<FilesUpdatedEvent>()
         .where((event) {
-          return _shouldInvalidateForDeletedFiles(event.type);
+          return _shouldInvalidateForDeletedFiles(event.type) &&
+              event.source != "moveFrom";
         })
         .listen((event) async {
           await _invalidateDeletedFiles(event.updatedFiles);

--- a/mobile/apps/photos/lib/ui/actions/file/file_actions.dart
+++ b/mobile/apps/photos/lib/ui/actions/file/file_actions.dart
@@ -44,10 +44,11 @@ Future<void> showSingleFileDeleteSheet(
           isRemote: false,
           onDeleteFromLocal: () async {
             final deletedFiles = await deleteFilesOnDeviceOnly(context, [file]);
-            if (deletedFiles.isNotEmpty &&
-                ((isLocal && !isRemote) || isLocalOnlyContext)) {
+            final didDelete = deletedFiles.isNotEmpty;
+            if (didDelete && ((isLocal && !isRemote) || isLocalOnlyContext)) {
               onFileRemoved?.call(file);
             }
+            return didDelete;
           },
           onDeleteFromRemote: () async {
             throw AssertionError("delete from remote in local gallery mode");
@@ -79,22 +80,28 @@ Future<void> showSingleFileDeleteSheet(
       count: 1,
       onDeleteFromLocal: () async {
         final deletedFiles = await deleteFilesOnDeviceOnly(context, [file]);
-        if (deletedFiles.isNotEmpty &&
-            ((isLocal && !isRemote) || isLocalOnlyContext)) {
+        final didDelete = deletedFiles.isNotEmpty;
+        if (didDelete && ((isLocal && !isRemote) || isLocalOnlyContext)) {
           onFileRemoved?.call(file);
         }
+        return didDelete;
       },
       onDeleteFromRemote: () async {
         await deleteFilesFromRemoteOnly(context, [file]);
-        if (!context.mounted) return;
+        if (!context.mounted) return false;
         showShortToast(context, l10n.movedToTrash);
         if (((isRemote && !isLocal) || !isLocalOnlyContext)) {
           onFileRemoved?.call(file);
         }
+        return true;
       },
       onDeleteFromBoth: () async {
-        await deleteFilesFromEverywhere(context, [file]);
-        onFileRemoved?.call(file);
+        final deletedFiles = await deleteFilesFromEverywhere(context, [file]);
+        final didDelete = deletedFiles.isNotEmpty;
+        if (didDelete) {
+          onFileRemoved?.call(file);
+        }
+        return didDelete;
       },
     ),
   );

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -69,7 +69,7 @@ _tryTrashOrDeleteFiles(List<String> assetIDs) async {
   }
 }
 
-Future<void> deleteFilesFromEverywhere(
+Future<List<EnteFile>> deleteFilesFromEverywhere(
   BuildContext context,
   List<EnteFile> files,
 ) async {
@@ -166,6 +166,7 @@ Future<void> deleteFilesFromEverywhere(
     // ignore: unawaited_futures
     RemoteSyncService.instance.sync(silently: true);
   }
+  return deletedFiles;
 }
 
 Future<void> deleteFilesFromRemoteOnly(
@@ -885,16 +886,39 @@ Future<void> showDeleteSheet(
   }
   final List<EnteFile> deletableFiles =
       filesSplit.ownedByCurrentUser + filesSplit.pendingUploads;
-  final Future<void> Function(BuildContext context, List<EnteFile> files)
-  deleteFromRemoteOnlyAction =
-      deleteFromRemoteOnlyOverride ?? deleteFilesFromRemoteOnly;
-  final Future<void> Function(BuildContext context, List<EnteFile> files)
-  deleteOnDeviceOnlyAction =
-      deleteOnDeviceOnlyOverride ??
-      (context, files) async => deleteFilesOnDeviceOnly(context, files);
-  final Future<void> Function(BuildContext context, List<EnteFile> files)
-  deleteFromEverywhereAction =
-      deleteFromEverywhereOverride ?? deleteFilesFromEverywhere;
+  Future<bool> deleteFromRemoteOnlyAction(
+    BuildContext context,
+    List<EnteFile> files,
+  ) async {
+    if (deleteFromRemoteOnlyOverride != null) {
+      await deleteFromRemoteOnlyOverride(context, files);
+    } else {
+      await deleteFilesFromRemoteOnly(context, files);
+    }
+    return true;
+  }
+
+  Future<bool> deleteOnDeviceOnlyAction(
+    BuildContext context,
+    List<EnteFile> files,
+  ) async {
+    if (deleteOnDeviceOnlyOverride != null) {
+      await deleteOnDeviceOnlyOverride(context, files);
+      return true;
+    }
+    return (await deleteFilesOnDeviceOnly(context, files)).isNotEmpty;
+  }
+
+  Future<bool> deleteFromEverywhereAction(
+    BuildContext context,
+    List<EnteFile> files,
+  ) async {
+    if (deleteFromEverywhereOverride != null) {
+      await deleteFromEverywhereOverride(context, files);
+      return true;
+    }
+    return (await deleteFilesFromEverywhere(context, files)).isNotEmpty;
+  }
 
   if (deletableFiles.isEmpty && filesSplit.ownedByOtherUsers.isNotEmpty) {
     showShortToast(context, l10n.cannotDeleteSharedFiles);
@@ -922,7 +946,7 @@ Future<void> showDeleteSheet(
               isLocal: true,
               isRemote: false,
               onDeleteFromLocal: () async {
-                await deleteOnDeviceOnlyAction(
+                return deleteOnDeviceOnlyAction(
                   context,
                   localGalleryDeletableFiles,
                 );
@@ -940,8 +964,10 @@ Future<void> showDeleteSheet(
           true;
     } else {
       if (!context.mounted) return;
-      await deleteOnDeviceOnlyAction(context, localGalleryDeletableFiles);
-      didDelete = true;
+      didDelete = await deleteOnDeviceOnlyAction(
+        context,
+        localGalleryDeletableFiles,
+      );
     }
     if (!didDelete) {
       return;
@@ -961,12 +987,6 @@ Future<void> showDeleteSheet(
     throw AssertionError("Unexpected state");
   }
 
-  Future<void> deleteFromEnte() async {
-    await deleteFromRemoteOnlyAction(context, deletableFiles);
-    if (!context.mounted) return;
-    showShortToast(context, l10n.movedToTrash);
-  }
-
   var didDeleteLocalFiles = false;
   final actionResult = await showBottomSheetComponent<bool>(
     context: context,
@@ -976,15 +996,30 @@ Future<void> showDeleteSheet(
       isRemote: hasRemoteFiles,
       count: deletableFiles.length,
       onDeleteFromLocal: () async {
-        await deleteOnDeviceOnlyAction(context, deletableFiles);
-        didDeleteLocalFiles = true;
+        final didDelete = await deleteOnDeviceOnlyAction(
+          context,
+          deletableFiles,
+        );
+        didDeleteLocalFiles = didDelete;
+        return didDelete;
       },
       onDeleteFromRemote: () async {
-        await deleteFromEnte();
+        final didDelete = await deleteFromRemoteOnlyAction(
+          context,
+          deletableFiles,
+        );
+        if (didDelete && context.mounted) {
+          showShortToast(context, l10n.movedToTrash);
+        }
+        return didDelete;
       },
       onDeleteFromBoth: () async {
-        await deleteFromEverywhereAction(context, deletableFiles);
-        didDeleteLocalFiles = true;
+        final didDelete = await deleteFromEverywhereAction(
+          context,
+          deletableFiles,
+        );
+        didDeleteLocalFiles = didDelete;
+        return didDelete;
       },
     ),
   );
@@ -1074,9 +1109,9 @@ class DeleteConfirmationSheet extends StatefulWidget {
   final bool isLocal;
   final bool isRemote;
   final int count;
-  final Future<void> Function() onDeleteFromLocal;
-  final Future<void> Function() onDeleteFromRemote;
-  final Future<void> Function() onDeleteFromBoth;
+  final Future<bool> Function() onDeleteFromLocal;
+  final Future<bool> Function() onDeleteFromRemote;
+  final Future<bool> Function() onDeleteFromBoth;
 
   const DeleteConfirmationSheet({
     super.key,
@@ -1109,12 +1144,12 @@ class DeleteConfirmationSheetState extends State<DeleteConfirmationSheet> {
 
   Future<void> _onDelete(
     BuildContext context,
-    Future<void> Function() callback,
+    Future<bool> Function() callback,
   ) async {
     try {
-      await callback();
+      final didDelete = await callback();
       if (context.mounted) {
-        Navigator.of(context).pop(true);
+        Navigator.of(context).pop(didDelete);
       }
     } catch (error) {
       if (context.mounted) {

--- a/mobile/packages/ui/lib/pages/settings_search_page.dart
+++ b/mobile/packages/ui/lib/pages/settings_search_page.dart
@@ -99,6 +99,7 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
 
   void _clearSearch() {
     _searchController.clear();
+    _searchFocusNode.unfocus();
     _onSearchChanged('');
   }
 
@@ -141,6 +142,7 @@ class _SettingsSearchPageState extends State<SettingsSearchPage> {
         controller: _searchController,
         focusNode: _searchFocusNode,
         hintText: context.strings.searchSettings,
+        shouldUnfocusOnClearOrSubmit: true,
         onChanged: _onSearchChanged,
         prefix: HugeIcon(
           icon: HugeIcons.strokeRoundedSearch01,


### PR DESCRIPTION
## Description

- Fixed Settings drawer search dismissal so the search closes when the user presses Enter or taps outside the field.
- Fixed Memories incorrectly removing photos when they are unfavourited or moved between albums. Hidden photos still correctly disappear from Memories.
- Fixed Memories advancing to another photo when the user denies the native device-deletion request. The current photo now remains visible when nothing was deleted.

