### PR TITLE
[mobile] Keep OCR selection controls reachable

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/inline_text_detection.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/inline_text_detection.dart
@@ -653,29 +653,29 @@ class _InlineTextDetectionState extends State<InlineTextDetection> {
         final Size viewportSize = constraints.biggest;
         return _OcrGestureHitTestBox(
           hitTest: (localPosition, globalPosition) {
-            if (textRegionsOnly &&
-                _detectorController.isPointOnInteractiveSelectionUi(
-                  globalPosition,
-                )) {
-              return true;
-            }
             final zoomTransform = InheritedDetailPageState.of(
               context,
             ).zoomTransformNotifier.value;
-            if (!_isLocalPointEligibleForOcrGesture(
-              localPosition,
-              viewportSize,
-              zoomTransform,
-            )) {
-              return false;
-            }
-            return !textRegionsOnly ||
-                _detectorController.isPointOnSelectableText(globalPosition) ||
-                _isLocalPointInDetectedTextRegion(
-                  localPosition,
-                  viewportSize,
-                  zoomTransform,
-                );
+            return shouldCaptureOcrGesture(
+              pointOnInteractiveSelectionUi: _detectorController
+                  .isPointOnInteractiveSelectionUi(globalPosition),
+              pointEligibleForOcr: _isLocalPointEligibleForOcrGesture(
+                localPosition,
+                viewportSize,
+                zoomTransform,
+              ),
+              textRegionsOnly: textRegionsOnly,
+              pointOnSelectableText:
+                  textRegionsOnly &&
+                  _detectorController.isPointOnSelectableText(globalPosition),
+              pointInDetectedTextRegion:
+                  textRegionsOnly &&
+                  _isLocalPointInDetectedTextRegion(
+                    localPosition,
+                    viewportSize,
+                    zoomTransform,
+                  ),
+            );
           },
           child: child,
         );

--- a/mobile/apps/photos/lib/ui/viewer/file/ocr/text_region_hit_test.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/ocr/text_region_hit_test.dart
@@ -1,6 +1,18 @@
 import "package:flutter/widgets.dart";
 import "package:mobile_ocr/models/text_region.dart";
 
+bool shouldCaptureOcrGesture({
+  required bool pointOnInteractiveSelectionUi,
+  required bool pointEligibleForOcr,
+  required bool textRegionsOnly,
+  required bool pointOnSelectableText,
+  required bool pointInDetectedTextRegion,
+}) {
+  if (pointOnInteractiveSelectionUi) return true;
+  if (!pointEligibleForOcr) return false;
+  return !textRegionsOnly || pointOnSelectableText || pointInDetectedTextRegion;
+}
+
 Offset viewportPointBeforeZoom({
   required Offset point,
   required Size viewportSize,

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -165,8 +165,8 @@ dependencies:
   ml_linalg: 13.12.6
   mobile_ocr:
     git:
-      url: https://github.com/ente/mobile_ocr
-      ref: 37aee4c4ff77c59a4ab46e272e31a53a035f628e
+      url: https://github.com/laurens-pilot/mobile_ocr
+      ref: 09fc9b7e9366e568de0047a369ac4c852529f748
   modal_bottom_sheet: 3.0.0
   motionphoto:
     git:

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -165,8 +165,8 @@ dependencies:
   ml_linalg: 13.12.6
   mobile_ocr:
     git:
-      url: https://github.com/laurens-pilot/mobile_ocr
-      ref: 09fc9b7e9366e568de0047a369ac4c852529f748
+      url: https://github.com/ente/mobile_ocr
+      ref: 0c68f88f20607cfcb10286422860350ccb024acd
   modal_bottom_sheet: 3.0.0
   motionphoto:
     git:

--- a/mobile/apps/photos/test/ui/viewer/file/ocr/text_region_hit_test_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/file/ocr/text_region_hit_test_test.dart
@@ -53,6 +53,32 @@ void main() {
     );
   });
 
+  test("keeps interactive selection controls tappable outside the image", () {
+    expect(
+      shouldCaptureOcrGesture(
+        pointOnInteractiveSelectionUi: true,
+        pointEligibleForOcr: false,
+        textRegionsOnly: false,
+        pointOnSelectableText: false,
+        pointInDetectedTextRegion: false,
+      ),
+      isTrue,
+    );
+  });
+
+  test("does not capture non-interactive points outside the image", () {
+    expect(
+      shouldCaptureOcrGesture(
+        pointOnInteractiveSelectionUi: false,
+        pointEligibleForOcr: false,
+        textRegionsOnly: false,
+        pointOnSelectableText: false,
+        pointInDetectedTextRegion: false,
+      ),
+      isFalse,
+    );
+  });
+
   test("applies hit slop in viewport pixels", () {
     expect(
       isViewportPointInTextRegions(

--- a/mobile/apps/photos/test/ui/viewer/file/ocr/text_region_hit_test_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/file/ocr/text_region_hit_test_test.dart
@@ -53,32 +53,6 @@ void main() {
     );
   });
 
-  test("keeps interactive selection controls tappable outside the image", () {
-    expect(
-      shouldCaptureOcrGesture(
-        pointOnInteractiveSelectionUi: true,
-        pointEligibleForOcr: false,
-        textRegionsOnly: false,
-        pointOnSelectableText: false,
-        pointInDetectedTextRegion: false,
-      ),
-      isTrue,
-    );
-  });
-
-  test("does not capture non-interactive points outside the image", () {
-    expect(
-      shouldCaptureOcrGesture(
-        pointOnInteractiveSelectionUi: false,
-        pointEligibleForOcr: false,
-        textRegionsOnly: false,
-        pointOnSelectableText: false,
-        pointInDetectedTextRegion: false,
-      ),
-      isFalse,
-    );
-  });
-
   test("applies hit slop in viewport pixels", () {
     expect(
       isViewportPointInTextRegions(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1774,9 +1774,9 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: "37aee4c4ff77c59a4ab46e272e31a53a035f628e"
-      resolved-ref: "37aee4c4ff77c59a4ab46e272e31a53a035f628e"
-      url: "https://github.com/ente/mobile_ocr"
+      ref: "09fc9b7e9366e568de0047a369ac4c852529f748"
+      resolved-ref: "09fc9b7e9366e568de0047a369ac4c852529f748"
+      url: "https://github.com/laurens-pilot/mobile_ocr"
     source: git
     version: "1.0.0"
   mockito:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1774,9 +1774,9 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: "09fc9b7e9366e568de0047a369ac4c852529f748"
-      resolved-ref: "09fc9b7e9366e568de0047a369ac4c852529f748"
-      url: "https://github.com/laurens-pilot/mobile_ocr"
+      ref: "0c68f88f20607cfcb10286422860350ccb024acd"
+      resolved-ref: "0c68f88f20607cfcb10286422860350ccb024acd"
+      url: "https://github.com/ente/mobile_ocr"
     source: git
     version: "1.0.0"
   mockito:


### PR DESCRIPTION
## Summary

- use the updated `mobile_ocr` selection layout so full selections keep Copy and Select all centered and clear of viewer controls
- make selected highlights passive so tapping selected text clears the selection
- allow active OCR toolbar and handle hit targets outside a letterboxed photo while leaving other off-photo gestures untouched

Merged companion package PR: https://github.com/ente/mobile_ocr/pull/23

## Validation

- `flutter pub get` in `mobile/apps/photos`
- `flutter analyze` in `mobile/apps/photos`
- `flutter analyze` in `mobile_ocr`
- iOS 26 simulator: all 6 photos in the Received/OCR Test album
  - partial selection remains contextual
  - Select all moves the toolbar to y=418.5, clear of viewer chrome
  - Copy writes the selected OCR text to the clipboard
  - tapping selected text clears the selection
  - off-photo controls on the wide letterboxed image remain tappable