### PR TITLE
[mobile][photos] fix tune slider active track at neutral position in image editor

### DIFF
--- a/mobile/apps/photos/changes/image-editor-tune-slider.md
+++ b/mobile/apps/photos/changes/image-editor-tune-slider.md
@@ -1,0 +1,1 @@
+- Fixed image editor tune slider showing an active track at the neutral position. (@r4khul)

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_tune_bar.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_tune_bar.dart
@@ -450,7 +450,7 @@ class _TuneAdjustWidget extends StatelessWidget {
                 overlayShape: const RoundSliderOverlayShape(overlayRadius: 0),
                 activeTrackColor: colors.primary,
                 inactiveTrackColor: colors.fillLight,
-                trackShape: const _CenterBasedTrackShape(),
+                trackShape: _CenterBasedTrackShape(isBipolar: min < 0),
                 trackHeight: 24,
               ),
               child: Slider(
@@ -502,6 +502,8 @@ class _TuneAdjustWidget extends StatelessWidget {
 class _ColorPickerThumbShape extends SliderComponentShape {
   const _ColorPickerThumbShape();
 
+  static const double thumbRadius = 15.0;
+
   @override
   Size getPreferredSize(bool isEnabled, bool isDiscrete) {
     return const Size(20, 20);
@@ -533,7 +535,10 @@ class _ColorPickerThumbShape extends SliderComponentShape {
     );
 
     final constrainedCenter = Offset(
-      center.dx.clamp(trackRect.left + 15, trackRect.right - 15),
+      center.dx.clamp(
+        trackRect.left + thumbRadius,
+        trackRect.right - thumbRadius,
+      ),
       center.dy,
     );
 
@@ -541,7 +546,7 @@ class _ColorPickerThumbShape extends SliderComponentShape {
       ..color = Colors.white
       ..style = PaintingStyle.fill;
 
-    canvas.drawCircle(constrainedCenter, 15, paint);
+    canvas.drawCircle(constrainedCenter, thumbRadius, paint);
 
     final innerPaint = Paint()
       ..color = const Color.fromRGBO(8, 194, 37, 1)
@@ -551,9 +556,11 @@ class _ColorPickerThumbShape extends SliderComponentShape {
 }
 
 class _CenterBasedTrackShape extends SliderTrackShape {
-  const _CenterBasedTrackShape();
+  const _CenterBasedTrackShape({this.isBipolar = true});
 
   static const double horizontalPadding = 6.0;
+
+  final bool isBipolar;
 
   @override
   Rect getPreferredRect({
@@ -597,9 +604,11 @@ class _CenterBasedTrackShape extends SliderTrackShape {
     final double centerX = trackRect.left + trackRect.width / 2;
 
     final double clampedThumbDx = thumbCenter.dx.clamp(
-      trackRect.left,
-      trackRect.right,
+      trackRect.left + _ColorPickerThumbShape.thumbRadius,
+      trackRect.right - _ColorPickerThumbShape.thumbRadius,
     );
+
+    final double activeStartDx = isBipolar ? centerX : trackRect.left;
 
     final Paint inactivePaint = Paint()
       ..color = sliderTheme.inactiveTrackColor!
@@ -612,22 +621,23 @@ class _CenterBasedTrackShape extends SliderTrackShape {
 
     canvas.drawRRect(inactiveRRect, inactivePaint);
 
-    if (clampedThumbDx != centerX) {
+    if ((clampedThumbDx - activeStartDx).abs() >
+        _ColorPickerThumbShape.thumbRadius) {
       final Paint activePaint = Paint()
         ..color = sliderTheme.activeTrackColor!
         ..style = PaintingStyle.fill;
 
-      final Rect activeRect = clampedThumbDx >= centerX
+      final Rect activeRect = clampedThumbDx >= activeStartDx
           ? Rect.fromLTWH(
-              centerX,
+              activeStartDx,
               trackRect.top,
-              clampedThumbDx - centerX,
+              clampedThumbDx - activeStartDx,
               trackRect.height,
             )
           : Rect.fromLTWH(
               clampedThumbDx,
               trackRect.top,
-              centerX - clampedThumbDx,
+              activeStartDx - clampedThumbDx,
               trackRect.height,
             );
 

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_tune_bar.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_tune_bar.dart
@@ -506,7 +506,7 @@ class _ColorPickerThumbShape extends SliderComponentShape {
 
   @override
   Size getPreferredSize(bool isEnabled, bool isDiscrete) {
-    return const Size(20, 20);
+    return const Size(thumbRadius * 2, thumbRadius * 2);
   }
 
   @override

--- a/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_tune_bar.dart
+++ b/mobile/apps/photos/lib/ui/tools/editor/image_editor/image_editor_tune_bar.dart
@@ -259,7 +259,7 @@ class _CircularProgressWithValueState extends State<CircularProgressWithValue>
     super.didUpdateWidget(oldWidget);
     if ((oldWidget.value < 0 && widget.value >= 0) ||
         (oldWidget.value > 0 && widget.value <= 0)) {
-      HapticFeedback.vibrate();
+      HapticFeedback.selectionClick();
     }
     if (oldWidget.value != widget.value) {
       _previousValue = oldWidget.value;


### PR DESCRIPTION
## Description

The tune bar slider paints its own track and thumb. It usually assumes the neutral 0 value sits right in the middle. This breaks for the `sharpness` tool because its range is 0 to 1. The neutral point should be the left edge, but at value 0, the slider was coloring the entire left half as active even when nothing was changed.

Fixes in `image_editor_tune_bar.dart`:

1. **Handling slider polarity:** The track shape now checks if it is bipolar (if the minimum value is less than 0). Bipolar sliders grow the active segment from the center, while unipolar ones grow from the left edge. Now a 0 value is totally clean.
2. **Keeping track and thumb in sync:** I noticed a visual bug while working on the polarity fix where i could see a bit of leftover colored space poking out on the left side (at neutral position - extreme left). To fix this, both shapes now share the same `thumbRadius` limit. The active segment always ends exactly under the thumb instead of drifting past it at the edges. Any segment fully covered by the thumb just isn't painted at all.

### Before - (Confusing Bipolar)


https://github.com/user-attachments/assets/713a5665-9b1d-4370-8803-5995029b80f9



### After - (Clear Unipolar)


https://github.com/user-attachments/assets/2396ef12-09bc-44bd-9012-84cbddd81224

## Tests
Verified with physical devices - realme c67 5g & realme pad 2.