### PR TITLE
[mobile] Handle non-JSON v3 file URL 404s

### DIFF
--- a/mobile/apps/photos/changes/legacy-museum-file-url-404.md
+++ b/mobile/apps/photos/changes/legacy-museum-file-url-404.md
@@ -1,0 +1,1 @@
+- Fixed remote photos not loading on older self-hosted Ente servers.

--- a/mobile/apps/photos/lib/module/download/file_url.dart
+++ b/mobile/apps/photos/lib/module/download/file_url.dart
@@ -29,7 +29,7 @@ class FileUrl {
       return null;
     }
 
-    final response = await dio.get<Map<String, dynamic>>(
+    final response = await dio.get<Object?>(
       _v3Path(fileID, type),
       options: Options(
         headers: headers,
@@ -43,7 +43,7 @@ class FileUrl {
       _v3RetryAfter = DateTime.now().add(_v3RetryDelay);
       return null;
     }
-    return response.data!["url"] as String;
+    return (response.data as Map<String, dynamic>)["url"] as String;
   }
 
   static String getLegacyUrl(int fileID, FileUrlType type) {


### PR DESCRIPTION
Gracefully handle 404s from older Museum installations that lack v3 file URL endpoints. Ref #12090.

Validation: flutter analyze