### PR TITLE
[docs] Update delete empty albums to add desktop and release component path

### DIFF
--- a/desktop/docs/release.md
+++ b/desktop/docs/release.md
@@ -18,7 +18,7 @@ Nightly and RC builds go to [ente/nightly](https://github.com/ente/nightly) like
 
 ## In-app "What's new"
 
-Separate from the GitHub and help-site notes: for a release with user-facing changes, update [WhatsNew.tsx](../../web/packages/new/photos/components/WhatsNew.tsx) and bump `changelogVersion` in [changelog.ts](../../web/packages/new/photos/services/changelog.ts) on `main` before cutting the RC.
+Separate from the GitHub and help-site notes: for a release with user-facing changes, update [WhatsNew.tsx](../../web/apps/photos/src/components/WhatsNew.tsx) and bump `changelogVersion` in [changelog.ts](../../web/apps/photos/src/services/changelog.ts) on `main` before cutting the RC.
 
 The dialog shows once when the installed `changelogVersion` is newer than the one the user last saw.
 

--- a/docs/docs/photos/features/albums-and-organization/albums.md
+++ b/docs/docs/photos/features/albums-and-organization/albums.md
@@ -142,7 +142,7 @@ If you have multiple empty albums cluttering your album list, you can bulk delet
 3. Tap the button
 4. Confirm the deletion
 
-On mobile, this feature appears after the initial sync is complete and when you have more than 2 empty albums.
+This will delete all empty albums from your library. The feature only appears after your initial sync is complete and when you have more than 2 empty albums.
 
 **On web / desktop:**
 

--- a/docs/docs/photos/features/albums-and-organization/albums.md
+++ b/docs/docs/photos/features/albums-and-organization/albums.md
@@ -142,7 +142,17 @@ If you have multiple empty albums cluttering your album list, you can bulk delet
 3. Tap the button
 4. Confirm the deletion
 
-This will delete all empty albums from your library. The feature only appears after your initial sync is complete and when you have more than 2 empty albums.
+On mobile, this feature appears after the initial sync is complete and when you have more than 2 empty albums.
+
+**On web / desktop:**
+
+1. Open **All Albums**
+2. Select the **Empty** filter
+3. Make sure the album search field is empty
+4. Click **Delete empty albums** at the bottom of the dialog
+5. Confirm the deletion
+
+The **Empty** filter appears when you have at least 3 eligible empty albums. Only empty albums that you own and that are not shared or archived are deleted.
 
 ## Uploading nested folders from desktop {#preserving-folder-structure}
 


### PR DESCRIPTION
## Description

We recently added the feature for deletion of empty albums to web as well, and last week we moved the photos-only component to the photos folder. this PR updates the docs to include the empty album deletion feature and updates the release helper to point to the newer paths.