### PR TITLE
[server] Revoke sessions after storage warning grace expires

### DIFF
--- a/server/pkg/controller/email/storage_warning.go
+++ b/server/pkg/controller/email/storage_warning.go
@@ -371,6 +371,48 @@ func (c *EmailNotificationController) clearStorageWarningLoginGrace(userID int64
 	return nil
 }
 
+func (c *EmailNotificationController) resetUserAccessAfterStorageWarningGrace(
+	ctx context.Context,
+	snapshot storageWarningSnapshot,
+	templateID string,
+	logger *log.Entry,
+) error {
+	if c.NotificationHistoryRepo == nil {
+		return errors.New("storage warning notification history repo is not configured")
+	}
+	if c.UserAccessResetter == nil {
+		return errors.New("storage warning user access resetter is not configured")
+	}
+
+	return c.NotificationHistoryRepo.WithStorageWarningLoginStateLock(snapshot.RecipientID, func() error {
+		graceActive, graceUntil, err := c.NotificationHistoryRepo.IsStorageWarningLoginGraceActive(snapshot.RecipientID, time.Microseconds())
+		if err != nil {
+			return err
+		}
+		if graceActive {
+			logger.WithField("login_grace_until", graceUntil).Info("Skipping storage warning re-block after renewed login grace")
+			return nil
+		}
+
+		deletionScheduled, err := c.NotificationHistoryRepo.IsStorageWarningDeletionScheduled(snapshot.RecipientID)
+		if err != nil {
+			return err
+		}
+		if !deletionScheduled {
+			if err := persistStorageWarningHistory(c.NotificationHistoryRepo, snapshot, templateID); err != nil {
+				return err
+			}
+			logger.Info("Restored storage warning scheduled deletion history")
+		}
+
+		if err := c.UserAccessResetter.ResetUserAccess(ctx, snapshot.RecipientID, logger); err != nil {
+			return err
+		}
+		logger.Info("Restricted user access after storage warning login grace expired")
+		return c.clearStorageWarningLoginGrace(snapshot.RecipientID, logger)
+	})
+}
+
 func (c *EmailNotificationController) clearRecoveredStorageWarningLoginState(userID int64, logger *log.Entry) error {
 	if c.NotificationHistoryRepo == nil {
 		return nil
@@ -573,15 +615,20 @@ func (c *EmailNotificationController) processStorageWarningSnapshot(ctx context.
 		return storageWarningProcessResultSkipped, nil
 	}
 
+	shouldResetUserAccess := storageWarningShouldResetUserAccess(snapshot)
 	if storageWarningTemplateSentInCycle(snapshot.NotificationHistory, templateID, snapshot.WarningCycleStart) {
-		if graceExpired {
+		if graceExpired && shouldResetUserAccess {
+			if err := c.resetUserAccessAfterStorageWarningGrace(ctx, snapshot, templateID, logger); err != nil {
+				logger.WithError(err).Error("Failed to re-block user after storage warning login grace expired")
+				return storageWarningProcessResultSkipped, err
+			}
+		} else if graceExpired {
 			if err := c.clearStorageWarningLoginGrace(snapshot.RecipientID, logger); err != nil {
 				return storageWarningProcessResultSkipped, err
 			}
 		}
 		return storageWarningProcessResultSkipped, nil
 	}
-	shouldResetUserAccess := storageWarningShouldResetUserAccess(snapshot)
 	if cadenceBroken, cadenceAlert := storageWarningCadenceBroken(snapshot); cadenceBroken {
 		if shouldResetUserAccess && graceExpired {
 			logger.WithFields(log.Fields{

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -434,6 +434,22 @@ func storageWarningDeletionScheduledError() error {
 	}, "storage warning deletion scheduled")
 }
 
+func (c *UserController) addTokenIfStorageWarningLoginAllowed(userID int64, app ente.App, token string, ip string, userAgent string) error {
+	addToken := func() error {
+		if err := c.ensureStorageWarningDeletionLoginAllowed(userID, app); err != nil {
+			return err
+		}
+		if err := c.UserAuthRepo.AddToken(userID, app, token, ip, userAgent); err != nil {
+			return stacktrace.Propagate(err, "failed to insert token")
+		}
+		return nil
+	}
+	if c.NotificationHistoryRepo == nil || !shouldEnforceStorageWarningDeletionLoginBlock(app) {
+		return addToken()
+	}
+	return c.NotificationHistoryRepo.WithStorageWarningLoginStateLock(userID, addToken)
+}
+
 func (c *UserController) alertStorageWarningDeletionScheduledLoginBlock(userID int64, app ente.App) {
 	log.WithFields(log.Fields{
 		"user_id": userID,
@@ -488,12 +504,8 @@ func (c *UserController) ClearStorageWarningDeletionLoginBlock(userID int64) err
 }
 
 func (c *UserController) AddTokenAndNotify(ctx *gin.Context, userID int64, app ente.App, token string, ip string, userAgent string) error {
-	if err := c.ensureStorageWarningDeletionLoginAllowed(userID, app); err != nil {
+	if err := c.addTokenIfStorageWarningLoginAllowed(userID, app, token, ip, userAgent); err != nil {
 		return err
-	}
-	err := c.UserAuthRepo.AddToken(userID, app, token, ip, userAgent)
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to insert token")
 	}
 
 	isEmailMFAEnabled, emailMFAErr := c.UserAuthRepo.IsEmailMFAEnabled(ctx, userID)
@@ -685,10 +697,7 @@ func (c *UserController) onVerificationSuccess(context *gin.Context, email strin
 		if errors.Is(err, sql.ErrNoRows) {
 			// user creation is pending on key attributes set based on the password.
 			// No need to send login notification
-			if err := c.ensureStorageWarningDeletionLoginAllowed(userID, app); err != nil {
-				return ente.EmailAuthorizationResponse{}, err
-			}
-			err = c.UserAuthRepo.AddToken(userID, app, token,
+			err = c.addTokenIfStorageWarningLoginAllowed(userID, app, token,
 				network.GetClientIP(context), context.Request.UserAgent())
 			if err != nil {
 				return ente.EmailAuthorizationResponse{}, stacktrace.Propagate(err, "")

--- a/server/pkg/repo/notificationhistory.go
+++ b/server/pkg/repo/notificationhistory.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"database/sql"
+	"sync"
 
 	"github.com/ente/stacktrace"
 	"github.com/lib/pq"
@@ -13,6 +14,8 @@ import (
 type NotificationHistoryRepository struct {
 	DB *sql.DB
 }
+
+var storageWarningLoginStateMu [64]sync.Mutex
 
 const (
 	StorageWarningExpiredScheduledDeletionTemplateID       = "storage_warning_expired_scheduled_deletion"
@@ -209,10 +212,27 @@ func (repo *NotificationHistoryRepository) IsStorageWarningLoginGraceActive(user
 	return StorageWarningLoginGraceActive(graceSentAt, now), graceUntil, nil
 }
 
+func storageWarningLoginStateLock(userID int64) *sync.Mutex {
+	return &storageWarningLoginStateMu[uint64(userID)%uint64(len(storageWarningLoginStateMu))]
+}
+
+// WithStorageWarningLoginStateLock coordinates admin grace, cron re-blocking,
+// and token creation within one Museum instance.
+func (repo *NotificationHistoryRepository) WithStorageWarningLoginStateLock(userID int64, action func() error) error {
+	stateLock := storageWarningLoginStateLock(userID)
+	stateLock.Lock()
+	defer stateLock.Unlock()
+	return action()
+}
+
 // GrantStorageWarningLoginGrace replaces terminal login-block rows with a
 // soft-unblock marker. Duplicate grace rows are allowed; readers use the latest
 // sent_time so a later admin action starts a fresh window.
 func (repo *NotificationHistoryRepository) GrantStorageWarningLoginGrace(userID int64) (int64, bool, error) {
+	stateLock := storageWarningLoginStateLock(userID)
+	stateLock.Lock()
+	defer stateLock.Unlock()
+
 	now := time.Microseconds()
 	tx, err := repo.DB.Begin()
 	if err != nil {


### PR DESCRIPTION
Before: When an admin unblock raced the storage-warning cron and terminal notification history already existed, grace expiry cleared the marker without resetting user access. Tokens created during grace could remain valid.

After: Grace expiry resets user access before clearing the marker, without sending another terminal email. A reset failure keeps the marker so the cron can retry.

Validation: ./scripts/lint.sh; ./scripts/test-with-postgres.sh host