### PR TITLE
[mobile][locker] Clean up shared legacy kit PDFs

### DIFF
--- a/mobile/packages/legacy/lib/pages/share_legacy_kit_page.dart
+++ b/mobile/packages/legacy/lib/pages/share_legacy_kit_page.dart
@@ -11,6 +11,7 @@ import "package:ente_legacy/pages/legacy_congratulations_page.dart";
 import "package:ente_legacy/services/legacy_kit_local_settings.dart";
 import "package:ente_legacy/services/legacy_kit_pdf_service.dart";
 import "package:ente_legacy/services/legacy_kit_service.dart";
+import "package:ente_legacy/services/legacy_kit_share_file_service.dart";
 import "package:ente_rust/ente_rust.dart" as rust;
 import "package:ente_strings/ente_strings.dart";
 import "package:ente_ui/components/alert_bottom_sheet.dart";
@@ -386,7 +387,7 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
       try {
         temporaryDirectory = await getTemporaryDirectory();
         shareDirectory = await temporaryDirectory.createTemp(
-          "ente_legacy_kit_share_",
+          legacyKitShareDirectoryPrefix,
         );
         final pdf = File("${shareDirectory.path}/$fileName");
         await pdf.writeAsBytes(bytes, flush: true);
@@ -676,7 +677,7 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
         .replaceAll(RegExp(r"-+"), "-")
         .replaceAll(RegExp(r"^-+|-+$"), "");
     final name = sanitized.isEmpty ? "part-${part.index}" : sanitized;
-    return "ente-legacy-kit-$name";
+    return "$legacyKitShareFilePrefix$name";
   }
 }
 
@@ -685,20 +686,14 @@ Future<void> _deleteSharedPdf(
   File sharePlusCopy,
   int? shareGeneration,
 ) async {
-  await Future<void>.delayed(const Duration(minutes: 5));
+  await Future<void>.delayed(legacyKitShareRetention);
   for (final entity in <FileSystemEntity>[
     shareDirectory,
     if (shareGeneration != null &&
         shareGeneration == _latestLegacyKitShareGeneration)
       sharePlusCopy,
   ]) {
-    try {
-      if (await entity.exists()) {
-        await entity.delete(recursive: entity is Directory);
-      }
-    } catch (_) {
-      // Best-effort cleanup must not surface after the share flow completes.
-    }
+    await deleteLegacyKitShareFile(entity);
   }
 }
 

--- a/mobile/packages/legacy/lib/pages/share_legacy_kit_page.dart
+++ b/mobile/packages/legacy/lib/pages/share_legacy_kit_page.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:io";
 import "dart:typed_data";
 
 import "package:collection/collection.dart";
@@ -19,10 +20,13 @@ import "package:flutter/material.dart";
 import "package:flutter_svg/flutter_svg.dart";
 import "package:hugeicons/hugeicons.dart";
 import "package:intl/intl.dart";
+import "package:path_provider/path_provider.dart";
 import "package:share_plus/share_plus.dart";
 
 typedef LegacyKitAuthenticator =
     Future<bool> Function(BuildContext context, String reason);
+
+int _latestLegacyKitShareGeneration = 0;
 
 const _partNameStyle = TextStyle(
   fontFamily: TextStyles.outfitFontFamily,
@@ -373,13 +377,23 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
       if (!mounted) {
         return;
       }
+      final fileName = "${_fileNameForPart(part)}.pdf";
       final size = MediaQuery.sizeOf(context);
       final ShareResult result;
+      Directory? temporaryDirectory;
+      Directory? shareDirectory;
+      int? shareGeneration;
       try {
+        temporaryDirectory = await getTemporaryDirectory();
+        shareDirectory = await temporaryDirectory.createTemp(
+          "ente_legacy_kit_share_",
+        );
+        final pdf = File("${shareDirectory.path}/$fileName");
+        await pdf.writeAsBytes(bytes, flush: true);
+        shareGeneration = ++_latestLegacyKitShareGeneration;
         result = await SharePlus.instance.share(
           ShareParams(
-            files: [XFile.fromData(bytes, mimeType: "application/pdf")],
-            fileNameOverrides: ["${_fileNameForPart(part)}.pdf"],
+            files: [XFile(pdf.path, mimeType: "application/pdf")],
             sharePositionOrigin: Offset.zero & size,
           ),
         );
@@ -388,6 +402,17 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
           showShortToast(context, context.strings.somethingWentWrong);
         }
         return;
+      } finally {
+        if (temporaryDirectory != null && shareDirectory != null) {
+          unawaited(
+            _deleteSharedPdf(
+              shareDirectory,
+              // share_plus copies path-backed files here on Android.
+              File("${temporaryDirectory.path}/share_plus/$fileName"),
+              shareGeneration,
+            ),
+          );
+        }
       }
       if (result.status == ShareResultStatus.dismissed || !mounted) {
         return;
@@ -652,6 +677,28 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
         .replaceAll(RegExp(r"^-+|-+$"), "");
     final name = sanitized.isEmpty ? "part-${part.index}" : sanitized;
     return "ente-legacy-kit-$name";
+  }
+}
+
+Future<void> _deleteSharedPdf(
+  Directory shareDirectory,
+  File sharePlusCopy,
+  int? shareGeneration,
+) async {
+  await Future<void>.delayed(const Duration(minutes: 5));
+  for (final entity in <FileSystemEntity>[
+    shareDirectory,
+    if (shareGeneration != null &&
+        shareGeneration == _latestLegacyKitShareGeneration)
+      sharePlusCopy,
+  ]) {
+    try {
+      if (await entity.exists()) {
+        await entity.delete(recursive: entity is Directory);
+      }
+    } catch (_) {
+      // Best-effort cleanup must not surface after the share flow completes.
+    }
   }
 }
 

--- a/mobile/packages/legacy/lib/pages/share_legacy_kit_page.dart
+++ b/mobile/packages/legacy/lib/pages/share_legacy_kit_page.dart
@@ -27,7 +27,7 @@ import "package:share_plus/share_plus.dart";
 typedef LegacyKitAuthenticator =
     Future<bool> Function(BuildContext context, String reason);
 
-int _latestLegacyKitShareGeneration = 0;
+final _legacyKitShareTokens = <String, Object>{};
 
 const _partNameStyle = TextStyle(
   fontFamily: TextStyles.outfitFontFamily,
@@ -383,7 +383,8 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
       final ShareResult result;
       Directory? temporaryDirectory;
       Directory? shareDirectory;
-      int? shareGeneration;
+      File? sharePlusCopy;
+      Object? shareToken;
       try {
         temporaryDirectory = await getTemporaryDirectory();
         shareDirectory = await temporaryDirectory.createTemp(
@@ -391,7 +392,10 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
         );
         final pdf = File("${shareDirectory.path}/$fileName");
         await pdf.writeAsBytes(bytes, flush: true);
-        shareGeneration = ++_latestLegacyKitShareGeneration;
+        // share_plus copies path-backed files here on Android.
+        sharePlusCopy = File("${temporaryDirectory.path}/share_plus/$fileName");
+        shareToken = Object();
+        _legacyKitShareTokens[sharePlusCopy.path] = shareToken;
         result = await SharePlus.instance.share(
           ShareParams(
             files: [XFile(pdf.path, mimeType: "application/pdf")],
@@ -406,12 +410,7 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
       } finally {
         if (temporaryDirectory != null && shareDirectory != null) {
           unawaited(
-            _deleteSharedPdf(
-              shareDirectory,
-              // share_plus copies path-backed files here on Android.
-              File("${temporaryDirectory.path}/share_plus/$fileName"),
-              shareGeneration,
-            ),
+            _deleteSharedPdf(shareDirectory, sharePlusCopy, shareToken),
           );
         }
       }
@@ -683,17 +682,18 @@ class _ShareLegacyKitPageState extends State<ShareLegacyKitPage> {
 
 Future<void> _deleteSharedPdf(
   Directory shareDirectory,
-  File sharePlusCopy,
-  int? shareGeneration,
+  File? sharePlusCopy,
+  Object? shareToken,
 ) async {
   await Future<void>.delayed(legacyKitShareRetention);
-  for (final entity in <FileSystemEntity>[
-    shareDirectory,
-    if (shareGeneration != null &&
-        shareGeneration == _latestLegacyKitShareGeneration)
-      sharePlusCopy,
-  ]) {
-    await deleteLegacyKitShareFile(entity);
+  await deleteLegacyKitShareFile(shareDirectory);
+  if (sharePlusCopy != null &&
+      shareToken != null &&
+      identical(_legacyKitShareTokens[sharePlusCopy.path], shareToken)) {
+    await deleteLegacyKitShareFile(sharePlusCopy);
+    if (identical(_legacyKitShareTokens[sharePlusCopy.path], shareToken)) {
+      _legacyKitShareTokens.remove(sharePlusCopy.path);
+    }
   }
 }
 

--- a/mobile/packages/legacy/lib/services/legacy_kit_service.dart
+++ b/mobile/packages/legacy/lib/services/legacy_kit_service.dart
@@ -1,9 +1,12 @@
+import "dart:async";
+
 import "package:ente_base/models/key_attributes.dart" as base;
 import "package:ente_configuration/base_configuration.dart";
 import "package:ente_contacts/contacts.dart" as contacts;
 import "package:ente_events/event_bus.dart";
 import "package:ente_legacy/events/legacy_kit_created_event.dart";
 import "package:ente_legacy/models/legacy_kit_models.dart";
+import "package:ente_legacy/services/legacy_kit_share_file_service.dart";
 import "package:ente_rust/ente_rust.dart" as rust;
 import "package:logging/logging.dart";
 
@@ -32,6 +35,7 @@ class LegacyKitService {
   }) async {
     _config = config;
     _sessionProvider = sessionProvider;
+    unawaited(cleanStaleLegacyKitShareFiles());
   }
 
   Future<List<LegacyKit>> getKits() async {

--- a/mobile/packages/legacy/lib/services/legacy_kit_service.dart
+++ b/mobile/packages/legacy/lib/services/legacy_kit_service.dart
@@ -1,5 +1,3 @@
-import "dart:async";
-
 import "package:ente_base/models/key_attributes.dart" as base;
 import "package:ente_configuration/base_configuration.dart";
 import "package:ente_contacts/contacts.dart" as contacts;
@@ -35,7 +33,7 @@ class LegacyKitService {
   }) async {
     _config = config;
     _sessionProvider = sessionProvider;
-    unawaited(cleanStaleLegacyKitShareFiles());
+    await cleanStaleLegacyKitShareFiles();
   }
 
   Future<List<LegacyKit>> getKits() async {

--- a/mobile/packages/legacy/lib/services/legacy_kit_service.dart
+++ b/mobile/packages/legacy/lib/services/legacy_kit_service.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:ente_base/models/key_attributes.dart" as base;
 import "package:ente_configuration/base_configuration.dart";
 import "package:ente_contacts/contacts.dart" as contacts;
@@ -33,7 +35,7 @@ class LegacyKitService {
   }) async {
     _config = config;
     _sessionProvider = sessionProvider;
-    await cleanStaleLegacyKitShareFiles();
+    unawaited(cleanStaleLegacyKitShareFiles());
   }
 
   Future<List<LegacyKit>> getKits() async {

--- a/mobile/packages/legacy/lib/services/legacy_kit_share_file_service.dart
+++ b/mobile/packages/legacy/lib/services/legacy_kit_share_file_service.dart
@@ -10,12 +10,17 @@ const legacyKitShareRetention = Duration(minutes: 5);
 final _logger = Logger("LegacyKitShareFiles");
 
 Future<void> cleanStaleLegacyKitShareFiles() async {
+  final cleanupStartedAt = DateTime.now();
+  await Future<void>.delayed(legacyKitShareRetention);
   try {
     final temporaryDirectory = await getTemporaryDirectory();
     await for (final entity in temporaryDirectory.list(followLinks: false)) {
       if (entity is Directory &&
           _entityName(entity).startsWith(legacyKitShareDirectoryPrefix)) {
-        await deleteLegacyKitShareFile(entity);
+        await deleteLegacyKitShareFile(
+          entity,
+          modifiedBefore: cleanupStartedAt,
+        );
       }
     }
 
@@ -30,7 +35,10 @@ Future<void> cleanStaleLegacyKitShareFiles() async {
       if (entity is File &&
           name.startsWith(legacyKitShareFilePrefix) &&
           name.endsWith(".pdf")) {
-        await deleteLegacyKitShareFile(entity);
+        await deleteLegacyKitShareFile(
+          entity,
+          modifiedBefore: cleanupStartedAt,
+        );
       }
     }
   } catch (e, s) {
@@ -38,11 +46,19 @@ Future<void> cleanStaleLegacyKitShareFiles() async {
   }
 }
 
-Future<void> deleteLegacyKitShareFile(FileSystemEntity entity) async {
+Future<void> deleteLegacyKitShareFile(
+  FileSystemEntity entity, {
+  DateTime? modifiedBefore,
+}) async {
   try {
-    if (await entity.exists()) {
-      await entity.delete(recursive: entity is Directory);
+    if (!await entity.exists()) {
+      return;
     }
+    if (modifiedBefore != null &&
+        (await entity.stat()).modified.isAfter(modifiedBefore)) {
+      return;
+    }
+    await entity.delete(recursive: entity is Directory);
   } catch (e, s) {
     _logger.warning("Failed to delete a Legacy Kit share file", e, s);
   }

--- a/mobile/packages/legacy/lib/services/legacy_kit_share_file_service.dart
+++ b/mobile/packages/legacy/lib/services/legacy_kit_share_file_service.dart
@@ -10,17 +10,12 @@ const legacyKitShareRetention = Duration(minutes: 5);
 final _logger = Logger("LegacyKitShareFiles");
 
 Future<void> cleanStaleLegacyKitShareFiles() async {
-  final cleanupStartedAt = DateTime.now();
-  await Future<void>.delayed(legacyKitShareRetention);
   try {
     final temporaryDirectory = await getTemporaryDirectory();
     await for (final entity in temporaryDirectory.list(followLinks: false)) {
       if (entity is Directory &&
           _entityName(entity).startsWith(legacyKitShareDirectoryPrefix)) {
-        await deleteLegacyKitShareFile(
-          entity,
-          modifiedBefore: cleanupStartedAt,
-        );
+        await deleteLegacyKitShareFile(entity);
       }
     }
 
@@ -35,10 +30,7 @@ Future<void> cleanStaleLegacyKitShareFiles() async {
       if (entity is File &&
           name.startsWith(legacyKitShareFilePrefix) &&
           name.endsWith(".pdf")) {
-        await deleteLegacyKitShareFile(
-          entity,
-          modifiedBefore: cleanupStartedAt,
-        );
+        await deleteLegacyKitShareFile(entity);
       }
     }
   } catch (e, s) {
@@ -46,23 +38,9 @@ Future<void> cleanStaleLegacyKitShareFiles() async {
   }
 }
 
-Future<void> deleteLegacyKitShareFile(
-  FileSystemEntity entity, {
-  DateTime? modifiedBefore,
-}) async {
+Future<void> deleteLegacyKitShareFile(FileSystemEntity entity) async {
   try {
-    if (!await entity.exists()) {
-      return;
-    }
-    final modified = (await entity.stat()).modified;
-    if (modifiedBefore != null && modified.isAfter(modifiedBefore)) {
-      return;
-    }
     if (await entity.exists()) {
-      if (modifiedBefore != null &&
-          (await entity.stat()).modified.isAfter(modifiedBefore)) {
-        return;
-      }
       await entity.delete(recursive: entity is Directory);
     }
   } catch (e, s) {

--- a/mobile/packages/legacy/lib/services/legacy_kit_share_file_service.dart
+++ b/mobile/packages/legacy/lib/services/legacy_kit_share_file_service.dart
@@ -1,0 +1,74 @@
+import "dart:io";
+
+import "package:logging/logging.dart";
+import "package:path_provider/path_provider.dart";
+
+const legacyKitShareDirectoryPrefix = "ente_legacy_kit_share_";
+const legacyKitShareFilePrefix = "ente-legacy-kit-";
+const legacyKitShareRetention = Duration(minutes: 5);
+
+final _logger = Logger("LegacyKitShareFiles");
+
+Future<void> cleanStaleLegacyKitShareFiles() async {
+  final cleanupStartedAt = DateTime.now();
+  await Future<void>.delayed(legacyKitShareRetention);
+  try {
+    final temporaryDirectory = await getTemporaryDirectory();
+    await for (final entity in temporaryDirectory.list(followLinks: false)) {
+      if (entity is Directory &&
+          _entityName(entity).startsWith(legacyKitShareDirectoryPrefix)) {
+        await deleteLegacyKitShareFile(
+          entity,
+          modifiedBefore: cleanupStartedAt,
+        );
+      }
+    }
+
+    final sharePlusDirectory = Directory(
+      "${temporaryDirectory.path}/share_plus",
+    );
+    if (!await sharePlusDirectory.exists()) {
+      return;
+    }
+    await for (final entity in sharePlusDirectory.list(followLinks: false)) {
+      final name = _entityName(entity);
+      if (entity is File &&
+          name.startsWith(legacyKitShareFilePrefix) &&
+          name.endsWith(".pdf")) {
+        await deleteLegacyKitShareFile(
+          entity,
+          modifiedBefore: cleanupStartedAt,
+        );
+      }
+    }
+  } catch (e, s) {
+    _logger.warning("Failed to clean stale Legacy Kit share files", e, s);
+  }
+}
+
+Future<void> deleteLegacyKitShareFile(
+  FileSystemEntity entity, {
+  DateTime? modifiedBefore,
+}) async {
+  try {
+    if (!await entity.exists()) {
+      return;
+    }
+    final modified = (await entity.stat()).modified;
+    if (modifiedBefore != null && modified.isAfter(modifiedBefore)) {
+      return;
+    }
+    if (await entity.exists()) {
+      if (modifiedBefore != null &&
+          (await entity.stat()).modified.isAfter(modifiedBefore)) {
+        return;
+      }
+      await entity.delete(recursive: entity is Directory);
+    }
+  } catch (e, s) {
+    _logger.warning("Failed to delete a Legacy Kit share file", e, s);
+  }
+}
+
+String _entityName(FileSystemEntity entity) =>
+    entity.uri.pathSegments.lastWhere((segment) => segment.isNotEmpty);

--- a/mobile/packages/legacy/pubspec.yaml
+++ b/mobile/packages/legacy/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   intl: 0.20.2
   logging: 1.3.0
   password_strength: 0.2.0
+  path_provider: 2.1.5
   pdf: 3.12.0
   pointycastle: 3.9.1
   rive: 0.14.0-dev.13


### PR DESCRIPTION
- Share generated Legacy Kit PDFs from app-owned cache files instead of `XFile.fromData`.
- Best-effort delete app-owned and Android `share_plus` copies after five minutes, and sweep pre-existing prefixed leftovers five minutes after the next launch without touching newer shares.

Validation: `dart format`; `flutter analyze --no-pub` (`mobile/packages/legacy`)