### PR TITLE
[mobile] Add floating action button component

### DIFF
--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -3,7 +3,6 @@ import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/models/file/file_type.dart';
-import "package:photos/models/file/trash_file.dart";
 import 'package:photos/models/location/location.dart';
 import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/module/download/file_url.dart";
@@ -116,9 +115,6 @@ class EnteFile {
   Future<AssetEntity?> get getAsset {
     if (localID == null) {
       return Future.value(null);
-    }
-    if (this is TrashFile && (this as TrashFile).systemTrashID != null) {
-      return AssetEntity.fromId((this as TrashFile).systemTrashID!.toString());
     }
     return AssetEntity.fromId(localID!);
   }

--- a/mobile/apps/photos/lib/models/file/file.dart
+++ b/mobile/apps/photos/lib/models/file/file.dart
@@ -3,6 +3,7 @@ import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photos/core/constants.dart';
 import 'package:photos/models/file/file_type.dart';
+import "package:photos/models/file/trash_file.dart";
 import 'package:photos/models/location/location.dart';
 import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/module/download/file_url.dart";
@@ -115,6 +116,9 @@ class EnteFile {
   Future<AssetEntity?> get getAsset {
     if (localID == null) {
       return Future.value(null);
+    }
+    if (this is TrashFile && (this as TrashFile).systemTrashID != null) {
+      return AssetEntity.fromId((this as TrashFile).systemTrashID!.toString());
     }
     return AssetEntity.fromId(localID!);
   }

--- a/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/trash_sync_service.dart
@@ -260,16 +260,11 @@ class TrashSyncService {
   }
 
   Future<void> emptyTrash() async {
-    try {
-      await _gateway.emptyTrash(_getSyncTime());
-      await _trashDB.clearTable();
-      unawaited(syncTrash());
-      Bus.instance.fire(TrashUpdatedEvent());
-      Bus.instance.fire(ForceReloadTrashPageEvent());
-    } catch (e, s) {
-      _logger.severe("failed to empty trash", e, s);
-      rethrow;
-    }
+    await _gateway.emptyTrash(_getSyncTime());
+    await _trashDB.clearTable();
+    unawaited(syncTrash());
+    Bus.instance.fire(TrashUpdatedEvent());
+    Bus.instance.fire(ForceReloadTrashPageEvent());
   }
 }
 

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -52,7 +52,6 @@ import "package:photos/ui/viewer/gallery/hooks/edit_album_details_sheet.dart";
 import "package:photos/ui/viewer/gallery/state/inherited_search_filter_data.dart";
 import "package:photos/ui/viewer/hierarchicial_search/app_bar_filter_chips.dart";
 import "package:photos/ui/viewer/location/edit_location_sheet.dart";
-import 'package:photos/utils/delete_file_util.dart';
 import 'package:photos/utils/dialog_util.dart';
 import 'package:photos/utils/magic_util.dart';
 
@@ -178,7 +177,6 @@ enum AlbumPopupAction {
   downloadAlbum,
   sortByMostRecent,
   sortByMostRelevant,
-  emptyTrash,
   editLocation,
   deleteLocation,
   galleryGuestView,
@@ -670,8 +668,6 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
             await onCleanUncategorizedClick(context);
           } else if (value == AlbumPopupAction.downloadAlbum) {
             await _downloadPublicAlbumToGallery(widget.files!);
-          } else if (value == AlbumPopupAction.emptyTrash) {
-            await emptyTrash(context);
           } else if (value == AlbumPopupAction.editLocation) {
             editLocation();
           } else if (value == AlbumPopupAction.deleteLocation) {

--- a/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
@@ -143,18 +143,26 @@ class _TrashPageState extends State<_TrashPage> {
               ],
             ),
           ),
-          floatingActionButton: Padding(
-            padding: const EdgeInsets.only(bottom: 4),
-            child: FABComponent(
-              label: l10n.deleteAll,
-              icon: const HugeIcon(icon: HugeIcons.strokeRoundedDelete02),
-              shouldShowSuccessConfirmation: false,
-              shouldShowSuccessState: false,
-              shouldSurfaceExecutionStates: false,
-              onTap: () async {
-                await emptyTrash(context, _isOnEnteTrash);
-              },
-            ),
+          floatingActionButton: ListenableBuilder(
+            listenable: _selectedFiles,
+            builder: (context, _) {
+              if (_selectedFiles.files.isNotEmpty) {
+                return const SizedBox.shrink();
+              }
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: FABComponent(
+                  label: l10n.deleteAll,
+                  icon: const HugeIcon(icon: HugeIcons.strokeRoundedDelete02),
+                  shouldShowSuccessConfirmation: false,
+                  shouldShowSuccessState: false,
+                  shouldSurfaceExecutionStates: false,
+                  onTap: () async {
+                    await emptyTrash(context, _isOnEnteTrash);
+                  },
+                ),
+              );
+            },
           ),
           floatingActionButtonLocation:
               FloatingActionButtonLocation.centerFloat,

--- a/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
@@ -153,9 +153,10 @@ class _TrashPageState extends State<_TrashPage> {
                 child: FABComponent(
                   label: l10n.deleteAll,
                   icon: const HugeIcon(icon: HugeIcons.strokeRoundedDelete02),
-                  onTap: () async {
-                    await emptyTrash(context, _isOnEnteTrash);
-                  },
+                  onTap: () => showConfirmDeleteAllTrashSheet(
+                    context,
+                    _isOnEnteTrash,
+                  ),
                 ),
               );
             },

--- a/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
@@ -51,6 +51,7 @@ class _TrashPage extends StatefulWidget {
 
 class _TrashPageState extends State<_TrashPage> {
   bool _isOnEnteTrash = !isLocalGalleryMode;
+  bool _hasTrashFiles = false;
   final _selectedFiles = SelectedFiles();
 
   @override
@@ -71,6 +72,7 @@ class _TrashPageState extends State<_TrashPage> {
                       setState(() {
                         _selectedFiles.clearAll();
                         _isOnEnteTrash = true;
+                        _hasTrashFiles = false;
                       });
                     }
                   },
@@ -83,6 +85,7 @@ class _TrashPageState extends State<_TrashPage> {
                       setState(() {
                         _selectedFiles.clearAll();
                         _isOnEnteTrash = false;
+                        _hasTrashFiles = false;
                       });
                     }
                   },
@@ -145,7 +148,7 @@ class _TrashPageState extends State<_TrashPage> {
           floatingActionButton: ListenableBuilder(
             listenable: _selectedFiles,
             builder: (context, _) {
-              if (_selectedFiles.files.isNotEmpty) {
+              if (_selectedFiles.files.isNotEmpty || !_hasTrashFiles) {
                 return const SizedBox.shrink();
               }
               return Padding(
@@ -153,10 +156,8 @@ class _TrashPageState extends State<_TrashPage> {
                 child: FABComponent(
                   label: l10n.deleteAll,
                   icon: const HugeIcon(icon: HugeIcons.strokeRoundedDelete02),
-                  onTap: () => showConfirmDeleteAllTrashSheet(
-                    context,
-                    _isOnEnteTrash,
-                  ),
+                  onTap: () =>
+                      showConfirmDeleteAllTrashSheet(context, _isOnEnteTrash),
                 ),
               );
             },
@@ -176,30 +177,40 @@ class _TrashPageState extends State<_TrashPage> {
     int? limit,
     bool? asc,
   }) async {
-    if (_isOnEnteTrash) {
-      return await TrashDB.instance.getTrashedFiles(
+    final isOnEnteTrash = _isOnEnteTrash;
+    late final FileLoadResult result;
+    if (isOnEnteTrash) {
+      result = await TrashDB.instance.getTrashedFiles(
         creationStartTime,
         creationEndTime,
         limit: limit,
         asc: asc,
       );
-    }
-    final deviceTrash = await DeviceTrashClient.instance.getFiles();
-    final deviceTrashAssets = await Future.wait(
-      deviceTrash.map((t) => AssetEntity.fromId(t.localID.toString())),
-    );
-    final List<EnteFile> files = [];
-    for (var i = 0; i < deviceTrash.length; i++) {
-      final trash = deviceTrash[i];
-      final asset = deviceTrashAssets[i];
-      if (asset == null) continue;
-      files.add(
-        DeviceTrashFile.from(
-          fileFromAsset(trash.deviceFolder, asset),
-          deleteBy: trash.deleteBy,
-        ),
+    } else {
+      final deviceTrash = await DeviceTrashClient.instance.getFiles();
+      final deviceTrashAssets = await Future.wait(
+        deviceTrash.map((t) => AssetEntity.fromId(t.localID.toString())),
       );
+      final List<EnteFile> files = [];
+      for (var i = 0; i < deviceTrash.length; i++) {
+        final trash = deviceTrash[i];
+        final asset = deviceTrashAssets[i];
+        if (asset == null) continue;
+        files.add(
+          DeviceTrashFile.from(
+            fileFromAsset(trash.deviceFolder, asset),
+            deleteBy: trash.deleteBy,
+          ),
+        );
+      }
+      result = FileLoadResult(files, false);
     }
-    return FileLoadResult(files, false);
+    if (mounted && _isOnEnteTrash == isOnEnteTrash) {
+      final hasTrashFiles = result.files.isNotEmpty;
+      if (_hasTrashFiles != hasTrashFiles) {
+        setState(() => _hasTrashFiles = hasTrashFiles);
+      }
+    }
+    return result;
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
@@ -1,12 +1,14 @@
 import "dart:io";
 
 import "package:collection/collection.dart";
+import "package:ente_components/components/buttons/fab_component.dart";
 import "package:ente_components/ente_components.dart";
 import "package:ente_photos_platform/ente_photos_platform.dart"
     show DeviceTrashClient;
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_strings/extensions.dart";
 import 'package:flutter/material.dart';
+import "package:hugeicons/hugeicons.dart";
 import "package:photo_manager/photo_manager.dart";
 import "package:photos/core/constants.dart";
 import "package:photos/core/event_bus.dart";
@@ -27,6 +29,7 @@ import "package:photos/ui/viewer/gallery/gallery_app_bar_widget.dart";
 import "package:photos/ui/viewer/gallery/state/gallery_boundaries_provider.dart";
 import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:photos/ui/viewer/gallery/state/selection_state.dart";
+import "package:photos/utils/delete_file_util.dart";
 import "package:photos/utils/device_info.dart";
 
 Future<void> showTrashPage(BuildContext context) async {
@@ -140,6 +143,23 @@ class _TrashPageState extends State<_TrashPage> {
               ],
             ),
           ),
+          floatingActionButton: Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: FABComponent(
+              label: l10n.deleteAll,
+              icon: const HugeIcon(icon: HugeIcons.strokeRoundedDelete02),
+              shouldShowSuccessConfirmation: false,
+              shouldShowSuccessState: false,
+              shouldSurfaceExecutionStates: false,
+              onTap: () async {
+                await emptyTrash(context, _isOnEnteTrash);
+              },
+            ),
+          ),
+          floatingActionButtonLocation:
+              FloatingActionButtonLocation.centerFloat,
+          floatingActionButtonAnimator:
+              FloatingActionButtonAnimator.noAnimation,
         ),
       ),
     );

--- a/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/trash_page.dart
@@ -1,7 +1,6 @@
 import "dart:io";
 
 import "package:collection/collection.dart";
-import "package:ente_components/components/buttons/fab_component.dart";
 import "package:ente_components/ente_components.dart";
 import "package:ente_photos_platform/ente_photos_platform.dart"
     show DeviceTrashClient;
@@ -154,9 +153,6 @@ class _TrashPageState extends State<_TrashPage> {
                 child: FABComponent(
                   label: l10n.deleteAll,
                   icon: const HugeIcon(icon: HugeIcons.strokeRoundedDelete02),
-                  shouldShowSuccessConfirmation: false,
-                  shouldShowSuccessState: false,
-                  shouldSurfaceExecutionStates: false,
                   onTap: () async {
                     await emptyTrash(context, _isOnEnteTrash);
                   },

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:ente_components/ente_components.dart';
-import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_strings/ente_strings.dart";
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -339,38 +339,49 @@ Future<bool> deleteFromEnteTrash(
   }
 }
 
-Future<bool> emptyTrash(BuildContext context, bool isOnEnteTrash) async {
-  final actionResult = await showChoiceActionSheet(
-    context,
-    title: context.strings.emptyTrashQuestion,
-    body: context.strings.permDeleteWarning,
-    firstButtonLabel: context.strings.empty,
-    isCritical: true,
-    firstButtonOnTap: () async {
-      try {
-        if (isOnEnteTrash) {
-          await trashSyncService.emptyTrash();
-        } else {
-          await _emptyDeviceTrash(context);
-        }
-      } catch (e, s) {
-        _logger.info("failed empty trash", e, s);
-        rethrow;
+Future<void> showConfirmDeleteAllTrashSheet(
+  BuildContext context,
+  bool isOnEnteTrash,
+) async {
+  var didDeleteDeviceTrash = false;
+
+  Future<void> emptyTrash() async {
+    try {
+      if (isOnEnteTrash) {
+        await trashSyncService.emptyTrash();
+      } else {
+        didDeleteDeviceTrash = await _emptyDeviceTrash();
       }
-    },
+    } catch (e, s) {
+      final trashKind = isOnEnteTrash ? "Ente" : "device";
+      _logger.severe("failed to empty $trashKind trash", e, s);
+      if (context.mounted) {
+        await showGenericErrorDialog(context: context, error: e);
+      }
+      rethrow;
+    }
+  }
+
+  await showBottomSheetComponent<void>(
+    context: context,
+    useRootNavigator: Platform.isIOS,
+    builder: (sheetContext) => BottomSheetComponent(
+      title: sheetContext.strings.emptyTrashQuestion,
+      message: sheetContext.strings.permDeleteWarning,
+      closeTooltip: sheetContext.strings.close,
+      actions: [
+        ButtonComponent(
+          label: sheetContext.strings.empty,
+          variant: ButtonComponentVariant.critical,
+          dismissModalOnSuccess: true,
+          onTap: emptyTrash,
+        ),
+      ],
+    ),
   );
-  if (actionResult?.action == null ||
-      actionResult!.action == ButtonAction.cancel) {
-    return false;
-  } else if (actionResult.action == ButtonAction.error) {
-    if (!context.mounted) return false;
-    await showGenericErrorDialog(
-      context: context,
-      error: actionResult.exception,
-    );
-    return false;
-  } else {
-    return true;
+
+  if (didDeleteDeviceTrash && context.mounted) {
+    await showMediaManagementHintSheet(context);
   }
 }
 
@@ -1421,7 +1432,7 @@ Future<(Set<String>, Object?)> _deleteFromDeviceTrash(
   }
 }
 
-Future<void> _emptyDeviceTrash(BuildContext context) async {
+Future<bool> _emptyDeviceTrash() async {
   final trash = (await NativeService.getTrash())
       .map((f) => f.localID.toString())
       .toList();
@@ -1432,6 +1443,7 @@ Future<void> _emptyDeviceTrash(BuildContext context) async {
       deletedIDs.addAll(result);
       if (result.length != batch.length) break;
     }
+    return deletedIDs.isNotEmpty;
   } finally {
     if (deletedIDs.isNotEmpty) {
       Bus.instance.fire(ForceReloadTrashPageEvent());

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:ente_components/ente_components.dart';
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_strings/ente_strings.dart";
 import 'package:flutter/material.dart';
@@ -26,7 +27,6 @@ import 'package:photos/module/download/file.dart';
 import "package:photos/service_locator.dart";
 import "package:photos/services/files_service.dart";
 import "package:photos/services/free_space/deletion_batch_runner.dart";
-import "package:photos/services/native_service.dart";
 import "package:photos/services/sync/local_sync_service.dart";
 import 'package:photos/services/sync/remote_sync_service.dart';
 import 'package:photos/services/sync/sync_service.dart';
@@ -1433,7 +1433,7 @@ Future<(Set<String>, Object?)> _deleteFromDeviceTrash(
 }
 
 Future<bool> _emptyDeviceTrash() async {
-  final trash = (await NativeService.getTrash())
+  final trash = (await DeviceTrashClient.instance.getFiles())
       .map((f) => f.localID.toString())
       .toList();
   final deletedIDs = <String>{};

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -1147,6 +1147,8 @@ class _DeleteConfirmationSheet extends StatefulWidget {
   final Future<bool> Function() onDeleteFromRemote;
   final Future<bool> Function() onDeleteFromBoth;
 
+  const DeleteConfirmationSheet({super.key});
+
   const _DeleteConfirmationSheet({
     required this.isLocal,
     required this.isRemote,

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -1153,8 +1153,6 @@ class _DeleteConfirmationSheet extends StatefulWidget {
   final Future<bool> Function() onDeleteFromRemote;
   final Future<bool> Function() onDeleteFromBoth;
 
-  const DeleteConfirmationSheet({super.key});
-
   const _DeleteConfirmationSheet({
     required this.isLocal,
     required this.isRemote,

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:ente_components/ente_components.dart';
+import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_strings/ente_strings.dart";
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';

--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -25,6 +25,7 @@ import 'package:photos/module/download/file.dart';
 import "package:photos/service_locator.dart";
 import "package:photos/services/files_service.dart";
 import "package:photos/services/free_space/deletion_batch_runner.dart";
+import "package:photos/services/native_service.dart";
 import "package:photos/services/sync/local_sync_service.dart";
 import 'package:photos/services/sync/remote_sync_service.dart';
 import 'package:photos/services/sync/sync_service.dart';
@@ -337,7 +338,7 @@ Future<bool> deleteFromEnteTrash(
   }
 }
 
-Future<bool> emptyTrash(BuildContext context) async {
+Future<bool> emptyTrash(BuildContext context, bool isOnEnteTrash) async {
   final actionResult = await showChoiceActionSheet(
     context,
     title: context.strings.emptyTrashQuestion,
@@ -346,7 +347,11 @@ Future<bool> emptyTrash(BuildContext context) async {
     isCritical: true,
     firstButtonOnTap: () async {
       try {
-        await trashSyncService.emptyTrash();
+        if (isOnEnteTrash) {
+          await trashSyncService.emptyTrash();
+        } else {
+          await _emptyDeviceTrash(context);
+        }
       } catch (e, s) {
         _logger.info("failed empty trash", e, s);
         rethrow;
@@ -1404,11 +1409,30 @@ Future<(Set<String>, Object?)> _deleteFromDeviceTrash(
     for (final batch in fileIDs.chunks(batchSize)) {
       final result = await PhotoManager.editor.deleteWithIds(batch);
       deletedIDs.addAll(result);
+      if (result.length != batch.length) break;
     }
     return (deletedIDs, null);
   } catch (e, s) {
     _logger.severe("failed to delete from device trash:", e, s);
     return (deletedIDs, e);
+  } finally {
+    if (deletedIDs.isNotEmpty) {
+      Bus.instance.fire(ForceReloadTrashPageEvent());
+    }
+  }
+}
+
+Future<void> _emptyDeviceTrash(BuildContext context) async {
+  final trash = (await NativeService.getTrash())
+      .map((f) => f.localID.toString())
+      .toList();
+  final deletedIDs = <String>{};
+  try {
+    for (final batch in trash.chunks(batchSize)) {
+      final result = await PhotoManager.editor.deleteWithIds(batch);
+      deletedIDs.addAll(result);
+      if (result.length != batch.length) break;
+    }
   } finally {
     if (deletedIDs.isNotEmpty) {
       Bus.instance.fire(ForceReloadTrashPageEvent());

--- a/mobile/packages/ente_components/example/lib/main.dart
+++ b/mobile/packages/ente_components/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:ente_components/components/buttons/fab_component.dart';
 import 'package:ente_components/ente_components.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';

--- a/mobile/packages/ente_components/example/lib/main.dart
+++ b/mobile/packages/ente_components/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:ente_components/components/buttons/fab_component.dart';
 import 'package:ente_components/ente_components.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -252,6 +253,19 @@ class _CatalogHomeState extends State<CatalogHome> {
         previewBuilder: (_) => const _ButtonMatrix(),
       ),
       CatalogSection(
+        title: 'Floating action button',
+        icon: HugeIcons.strokeRoundedAdd01,
+        components: const [
+          'Primary',
+          'Secondary',
+          'Icon',
+          'Medium',
+          'Medium with icon',
+        ],
+        previewBuilder: (_) => const SizedBox.shrink(),
+        routeBuilder: _buildFABDemo,
+      ),
+      CatalogSection(
         title: 'Bottom sheets',
         icon: HugeIcons.strokeRoundedLayoutTable01,
         components: const [
@@ -353,6 +367,17 @@ Widget _buildHeaderAppBarDemo(
   ValueChanged<ThemeMode> onThemeModeChanged,
 ) {
   return HeaderAppBarDemoPage(
+    themeMode: themeMode,
+    onThemeModeChanged: onThemeModeChanged,
+  );
+}
+
+Widget _buildFABDemo(
+  BuildContext context,
+  ThemeMode themeMode,
+  ValueChanged<ThemeMode> onThemeModeChanged,
+) {
+  return FABDemoPage(
     themeMode: themeMode,
     onThemeModeChanged: onThemeModeChanged,
   );
@@ -1453,6 +1478,234 @@ class _ButtonMatrix extends StatelessWidget {
           child: _IconButtonMatrix(),
         ),
       ],
+    );
+  }
+}
+
+class FABDemoPage extends StatefulWidget {
+  const FABDemoPage({
+    super.key,
+    required this.themeMode,
+    required this.onThemeModeChanged,
+  });
+
+  final ThemeMode themeMode;
+  final ValueChanged<ThemeMode> onThemeModeChanged;
+
+  @override
+  State<FABDemoPage> createState() => _FABDemoPageState();
+}
+
+class _FABDemoPageState extends State<FABDemoPage> {
+  late ThemeMode _themeMode = widget.themeMode;
+
+  void _setThemeMode(ThemeMode mode) {
+    setState(() => _themeMode = mode);
+    widget.onThemeModeChanged(mode);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.componentColors;
+    return Scaffold(
+      body: AppBarComponent(
+        title: 'Floating action button',
+        subtitle: 'Primary, Secondary, Icon, Medium',
+        onBack: () => Navigator.of(context).pop(),
+        actions: [
+          _CatalogThemeCycleButton(
+            themeMode: _themeMode,
+            onChanged: _setThemeMode,
+          ),
+        ],
+        slivers: [
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(
+              Spacing.lg,
+              Spacing.xs,
+              Spacing.lg,
+              Spacing.lg,
+            ),
+            sliver: SliverToBoxAdapter(
+              child: _FABDemoList(
+                themeMode: _themeMode,
+                onThemeModeChanged: _setThemeMode,
+              ),
+            ),
+          ),
+        ],
+      ),
+      backgroundColor: colors.backgroundBase,
+    );
+  }
+}
+
+class _FABDemoList extends StatelessWidget {
+  const _FABDemoList({
+    required this.themeMode,
+    required this.onThemeModeChanged,
+  });
+
+  final ThemeMode themeMode;
+  final ValueChanged<ThemeMode> onThemeModeChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuGroupComponent(
+      items: [
+        _FABDemoLink(
+          title: 'Primary medium',
+          variant: FABComponentVariant.primary,
+          hasIcon: false,
+          label: 'Add',
+          themeMode: themeMode,
+          onThemeModeChanged: onThemeModeChanged,
+        ),
+        _FABDemoLink(
+          title: 'Primary medium with icon',
+          variant: FABComponentVariant.primary,
+          hasIcon: true,
+          label: 'Add',
+          themeMode: themeMode,
+          onThemeModeChanged: onThemeModeChanged,
+        ),
+        _FABDemoLink(
+          title: 'Primary icon',
+          variant: FABComponentVariant.primary,
+          hasIcon: true,
+          themeMode: themeMode,
+          onThemeModeChanged: onThemeModeChanged,
+        ),
+        _FABDemoLink(
+          title: 'Secondary medium',
+          variant: FABComponentVariant.secondary,
+          hasIcon: false,
+          label: 'Add',
+          themeMode: themeMode,
+          onThemeModeChanged: onThemeModeChanged,
+        ),
+        _FABDemoLink(
+          title: 'Secondary medium with icon',
+          variant: FABComponentVariant.secondary,
+          hasIcon: true,
+          label: 'Add',
+          themeMode: themeMode,
+          onThemeModeChanged: onThemeModeChanged,
+        ),
+        _FABDemoLink(
+          title: 'Secondary icon',
+          variant: FABComponentVariant.secondary,
+          hasIcon: true,
+          themeMode: themeMode,
+          onThemeModeChanged: onThemeModeChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class _FABDemoLink extends StatelessWidget {
+  const _FABDemoLink({
+    required this.title,
+    required this.variant,
+    required this.hasIcon,
+    this.label,
+    required this.themeMode,
+    required this.onThemeModeChanged,
+  });
+
+  final String title;
+  final FABComponentVariant variant;
+  final bool hasIcon;
+  final String? label;
+  final ThemeMode themeMode;
+  final ValueChanged<ThemeMode> onThemeModeChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuComponent(
+      title: title,
+      trailing: const _CatalogHugeIcon(
+        HugeIcons.strokeRoundedArrowRight02,
+        size: IconSizes.small,
+      ),
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => _FABDemoSubPage(
+            title: title,
+            variant: variant,
+            hasIcon: hasIcon,
+            label: label,
+            themeMode: themeMode,
+            onThemeModeChanged: onThemeModeChanged,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FABDemoSubPage extends StatefulWidget {
+  const _FABDemoSubPage({
+    required this.title,
+    required this.variant,
+    required this.hasIcon,
+    this.label,
+    required this.themeMode,
+    required this.onThemeModeChanged,
+  });
+
+  final String title;
+  final FABComponentVariant variant;
+  final bool hasIcon;
+  final String? label;
+  final ThemeMode themeMode;
+  final ValueChanged<ThemeMode> onThemeModeChanged;
+
+  @override
+  State<_FABDemoSubPage> createState() => _FABDemoSubPageState();
+}
+
+class _FABDemoSubPageState extends State<_FABDemoSubPage> {
+  late ThemeMode _themeMode = widget.themeMode;
+
+  void _setThemeMode(ThemeMode mode) {
+    setState(() => _themeMode = mode);
+    widget.onThemeModeChanged(mode);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.componentColors;
+    return Scaffold(
+      body: AppBarComponent(
+        title: widget.title,
+        subtitle: 'Floating action button',
+        onBack: () => Navigator.of(context).pop(),
+        actions: [
+          _CatalogThemeCycleButton(
+            themeMode: _themeMode,
+            onChanged: _setThemeMode,
+          ),
+        ],
+        slivers: const [],
+      ),
+      floatingActionButton: Padding(
+        padding: const EdgeInsets.only(bottom: 4),
+        child: FABComponent(
+          icon: widget.hasIcon
+              ? const _CatalogHugeIcon(
+                  HugeIcons.strokeRoundedAdd01,
+                  size: IconSizes.small,
+                )
+              : null,
+          label: widget.label,
+          variant: widget.variant,
+          onTap: () {},
+        ),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      backgroundColor: colors.backgroundBase,
     );
   }
 }

--- a/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
@@ -1,6 +1,5 @@
 import "dart:async";
 
-import "package:ente_components/theme/icon_sizes.dart";
 import "package:ente_components/theme/motion.dart";
 import "package:ente_components/theme/text_styles.dart";
 import "package:ente_components/theme/theme.dart";
@@ -95,10 +94,7 @@ class _FABComponentState extends State<FABComponent> {
                 children: [
                   if (widget.icon != null)
                     IconTheme.merge(
-                      data: IconThemeData(
-                        color: foregroundColor,
-                        size: IconSizes.small,
-                      ),
+                      data: IconThemeData(color: foregroundColor),
                       child: widget.icon!,
                     ),
                   if (widget.label != null)

--- a/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
@@ -1,12 +1,10 @@
 import "dart:async";
 
-import "package:ente_components/models/component_execution_state.dart";
 import "package:ente_components/theme/icon_sizes.dart";
 import "package:ente_components/theme/motion.dart";
 import "package:ente_components/theme/text_styles.dart";
 import "package:ente_components/theme/theme.dart";
 import "package:flutter/material.dart";
-import "package:hugeicons/hugeicons.dart";
 
 enum FABComponentVariant { primary, secondary }
 
@@ -35,41 +33,18 @@ class FABComponent extends StatefulWidget {
     this.onTap,
     this.variant = FABComponentVariant.primary,
     this.isDisabled = false,
-    this.shouldSurfaceExecutionStates = true,
-    this.shouldShowSuccessState = true,
-    this.shouldShowSuccessConfirmation = false,
-  });
-
-  final bool shouldSurfaceExecutionStates;
-
-  final bool shouldShowSuccessState;
-
-  final bool shouldShowSuccessConfirmation;
+  }) : assert(
+         icon != null || label != null,
+         "Either icon or label is required",
+       );
 
   @override
   State<FABComponent> createState() => _FABComponentState();
 }
 
-class _FABComponentState extends State<FABComponent>
-    with SingleTickerProviderStateMixin {
-  static const Duration _loadingDelay = Duration(milliseconds: 300);
-  static const Duration _successDisplayDuration = Duration(seconds: 1);
-
-  late final AnimationController _loadingController;
+class _FABComponentState extends State<FABComponent> {
+  bool _isExecuting = false;
   bool _isPressed = false;
-  Timer? _loadingTimer;
-  Timer? _successResetTimer;
-  bool _loadingVisible = false;
-  ComponentExecutionState _executionState = ComponentExecutionState.idle;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadingController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 800),
-    );
-  }
 
   @override
   void didUpdateWidget(covariant FABComponent oldWidget) {
@@ -77,24 +52,12 @@ class _FABComponentState extends State<FABComponent>
     if (widget.isDisabled && !oldWidget.isDisabled) {
       _isPressed = false;
     }
-    _syncLoadingController();
-  }
-
-  @override
-  void dispose() {
-    _loadingTimer?.cancel();
-    _successResetTimer?.cancel();
-    _loadingController.dispose();
-    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final isEnabled =
-        !widget.isDisabled &&
-        widget.onTap != null &&
-        !_isExecuting &&
-        !_isSuccessful;
+        !widget.isDisabled && widget.onTap != null && !_isExecuting;
     final colors = context.componentColors;
     final backgroundColor = switch (widget.variant) {
       FABComponentVariant.primary =>
@@ -124,16 +87,34 @@ class _FABComponentState extends State<FABComponent>
             borderRadius: BorderRadius.circular(9999),
           ),
           child: ConstrainedBox(
-            constraints: const BoxConstraints(minWidth: 56, minHeight: 56),
+            constraints: const BoxConstraints(minWidth: 52, minHeight: 52),
             child: Padding(
-              padding: EdgeInsets.symmetric(
-                horizontal: widget.label == null ? 0 : 24,
-              ),
-              child: AnimatedSwitcher(
-                duration: Motion.quick,
-                switchInCurve: Curves.easeOutCubic,
-                switchOutCurve: Curves.easeInCubic,
-                child: _content(foregroundColor),
+              padding: switch ((widget.icon, widget.label)) {
+                (_, null) => EdgeInsets.zero,
+                (null, _) => const EdgeInsets.symmetric(horizontal: 24),
+                (_, _) => const EdgeInsets.only(left: 20, right: 24),
+              },
+              child: Row(
+                spacing: 8,
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  if (widget.icon != null)
+                    IconTheme.merge(
+                      data: IconThemeData(
+                        color: foregroundColor,
+                        size: IconSizes.small,
+                      ),
+                      child: widget.icon!,
+                    ),
+                  if (widget.label != null)
+                    Text(
+                      widget.label!,
+                      style: TextStyles.bodyBold.copyWith(
+                        color: foregroundColor,
+                      ),
+                    ),
+                ],
               ),
             ),
           ),
@@ -147,171 +128,22 @@ class _FABComponentState extends State<FABComponent>
     setState(() => _isPressed = value);
   }
 
-  Widget _content(Color foreground) {
-    if (_showLoading) {
-      return _executionContent(
-        key: const ValueKey("loading"),
-        child: RotationTransition(
-          turns: _loadingController,
-          child: HugeIcon(
-            icon: HugeIcons.strokeRoundedLoading03,
-            size: IconSizes.small,
-            color: foreground,
-          ),
-        ),
-      );
-    }
-    if (_showSuccess) {
-      return _executionContent(
-        key: const ValueKey("success"),
-        child: HugeIcon(
-          icon: HugeIcons.strokeRoundedTick02,
-          size: IconSizes.small,
-          color: foreground,
-        ),
-      );
-    }
-    return _idleContent(foreground);
-  }
-
-  Widget _idleContent(Color foreground) {
-    return Row(
-      key: const ValueKey("content"),
-      spacing: 8,
-      mainAxisSize: MainAxisSize.min,
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        if (widget.icon != null)
-          IconTheme.merge(
-            data: IconThemeData(color: foreground, size: IconSizes.small),
-            child: widget.icon!,
-          ),
-        if (widget.label != null)
-          Text(
-            widget.label!,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 1,
-            style: TextStyles.bodyBold.copyWith(color: foreground),
-          ),
-      ],
-    );
-  }
-
-  Widget _executionContent({required Key key, required Widget child}) {
-    return Stack(
-      key: key,
-      alignment: Alignment.center,
-      children: [
-        Visibility(
-          visible: false,
-          maintainAnimation: true,
-          maintainSize: true,
-          maintainState: true,
-          child: _idleContent(Colors.transparent),
-        ),
-        child,
-      ],
-    );
-  }
-
-  bool get _isExecuting =>
-      _executionState == ComponentExecutionState.inProgress;
-
-  bool get _isSuccessful =>
-      _executionState == ComponentExecutionState.successful;
-
-  bool get _showLoading =>
-      widget.shouldSurfaceExecutionStates && _isExecuting && _loadingVisible;
-
-  bool get _showSuccess =>
-      widget.shouldSurfaceExecutionStates &&
-      widget.shouldShowSuccessState &&
-      _isSuccessful;
-
-  void _syncLoadingController() {
-    if (_showLoading) {
-      if (!_loadingController.isAnimating) {
-        _loadingController.repeat();
-      }
-      return;
-    }
-
-    if (_loadingController.isAnimating || _loadingController.value != 0) {
-      _loadingController.stop();
-      _loadingController.reset();
-    }
-  }
-
   Future<void> _handleTap() async {
     final callback = widget.onTap;
-    if (callback == null) return;
+    if (callback == null || _isExecuting) return;
 
-    _successResetTimer?.cancel();
-    var loadingSurfaced = false;
-    _loadingTimer?.cancel();
     setState(() {
-      _executionState = ComponentExecutionState.inProgress;
-      _loadingVisible = false;
+      _isExecuting = true;
       _isPressed = false;
-    });
-    _loadingTimer = Timer(_loadingDelay, () {
-      if (!mounted) return;
-      loadingSurfaced = true;
-      setState(() {
-        _loadingVisible = true;
-        _isPressed = false;
-      });
-      _syncLoadingController();
     });
 
     try {
       await Future.sync(callback);
-      if (!mounted) return;
-
-      final loadingPending = _loadingTimer?.isActive ?? false;
-      _loadingTimer?.cancel();
-      _loadingTimer = null;
-
-      final shouldShowSuccess =
-          widget.shouldSurfaceExecutionStates &&
-          widget.shouldShowSuccessState &&
-          (loadingSurfaced ||
-              (loadingPending && widget.shouldShowSuccessConfirmation));
-
-      if (shouldShowSuccess) {
-        _showSuccessForDuration();
-      } else {
-        _clearExecutionState();
-      }
     } catch (_) {
-      _loadingTimer?.cancel();
-      _loadingTimer = null;
+    } finally {
       if (mounted) {
-        _clearExecutionState();
+        setState(() => _isExecuting = false);
       }
     }
-  }
-
-  void _clearExecutionState() {
-    setState(() {
-      _executionState = ComponentExecutionState.idle;
-      _loadingVisible = false;
-      _isPressed = false;
-    });
-    _syncLoadingController();
-  }
-
-  void _showSuccessForDuration() {
-    setState(() {
-      _executionState = ComponentExecutionState.successful;
-      _loadingVisible = false;
-      _isPressed = false;
-    });
-    _syncLoadingController();
-    _successResetTimer?.cancel();
-    _successResetTimer = Timer(_successDisplayDuration, () {
-      if (!mounted) return;
-      _clearExecutionState();
-    });
   }
 }

--- a/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
@@ -9,12 +9,6 @@ import "package:flutter/material.dart";
 enum FABComponentVariant { primary, secondary }
 
 /// Figma: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=21843-6537&m=dev
-/// Section: Buttons / Floating action button
-/// Specs: Extended is 56px high with 20px leading padding, 24px trailing
-/// padding, an 8px gap, and a 999px radius. Icon is 52px square with a 30px
-/// radius.
-/// Types: Extended, Icon.
-/// States: Extended has default and pressed. Icon has default.
 class FABComponent extends StatefulWidget {
   final String? label;
 

--- a/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
@@ -1,0 +1,317 @@
+import "dart:async";
+
+import "package:ente_components/models/component_execution_state.dart";
+import "package:ente_components/theme/icon_sizes.dart";
+import "package:ente_components/theme/motion.dart";
+import "package:ente_components/theme/text_styles.dart";
+import "package:ente_components/theme/theme.dart";
+import "package:flutter/material.dart";
+import "package:hugeicons/hugeicons.dart";
+
+enum FABComponentVariant { primary, secondary }
+
+/// Figma: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=21843-6537&m=dev
+/// Section: Buttons / Floating action button
+/// Specs: Extended is 56px high with 20px leading padding, 24px trailing
+/// padding, an 8px gap, and a 999px radius. Icon is 52px square with a 30px
+/// radius.
+/// Types: Extended, Icon.
+/// States: Extended has default and pressed. Icon has default.
+class FABComponent extends StatefulWidget {
+  final String? label;
+
+  final FutureOr<void> Function()? onTap;
+
+  final FABComponentVariant variant;
+
+  final bool isDisabled;
+
+  final Widget? icon;
+
+  const FABComponent({
+    super.key,
+    this.icon,
+    this.label,
+    this.onTap,
+    this.variant = FABComponentVariant.primary,
+    this.isDisabled = false,
+    this.shouldSurfaceExecutionStates = true,
+    this.shouldShowSuccessState = true,
+    this.shouldShowSuccessConfirmation = false,
+  });
+
+  final bool shouldSurfaceExecutionStates;
+
+  final bool shouldShowSuccessState;
+
+  final bool shouldShowSuccessConfirmation;
+
+  @override
+  State<FABComponent> createState() => _FABComponentState();
+}
+
+class _FABComponentState extends State<FABComponent>
+    with SingleTickerProviderStateMixin {
+  static const Duration _loadingDelay = Duration(milliseconds: 300);
+  static const Duration _successDisplayDuration = Duration(seconds: 1);
+
+  late final AnimationController _loadingController;
+  bool _isPressed = false;
+  Timer? _loadingTimer;
+  Timer? _successResetTimer;
+  bool _loadingVisible = false;
+  ComponentExecutionState _executionState = ComponentExecutionState.idle;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadingController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant FABComponent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isDisabled && !oldWidget.isDisabled) {
+      _isPressed = false;
+    }
+    _syncLoadingController();
+  }
+
+  @override
+  void dispose() {
+    _loadingTimer?.cancel();
+    _successResetTimer?.cancel();
+    _loadingController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEnabled =
+        !widget.isDisabled &&
+        widget.onTap != null &&
+        !_isExecuting &&
+        !_isSuccessful;
+    final colors = context.componentColors;
+    final backgroundColor = switch (widget.variant) {
+      FABComponentVariant.primary =>
+        _isPressed ? colors.primaryDark : colors.primary,
+      FABComponentVariant.secondary =>
+        _isPressed ? colors.fillDarker : colors.fillDark,
+    };
+    final foregroundColor = switch (widget.variant) {
+      FABComponentVariant.primary => colors.specialWhite,
+      FABComponentVariant.secondary => colors.primary,
+    };
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: isEnabled ? _handleTap : null,
+      onTapDown: isEnabled ? (_) => _setPressed(true) : null,
+      onTapUp: isEnabled ? (_) => _setPressed(false) : null,
+      onTapCancel: isEnabled ? () => _setPressed(false) : null,
+      child: AnimatedScale(
+        scale: _isPressed ? 0.98 : 1,
+        duration: Motion.quick,
+        curve: Curves.easeOutCubic,
+        child: AnimatedContainer(
+          duration: Motion.standard,
+          curve: Curves.easeInOutCubic,
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            borderRadius: BorderRadius.circular(9999),
+          ),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 56, minHeight: 56),
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: widget.label == null ? 0 : 24,
+              ),
+              child: AnimatedSwitcher(
+                duration: Motion.quick,
+                switchInCurve: Curves.easeOutCubic,
+                switchOutCurve: Curves.easeInCubic,
+                child: _content(foregroundColor),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _setPressed(bool value) {
+    if (_isPressed == value) return;
+    setState(() => _isPressed = value);
+  }
+
+  Widget _content(Color foreground) {
+    if (_showLoading) {
+      return _executionContent(
+        key: const ValueKey("loading"),
+        child: RotationTransition(
+          turns: _loadingController,
+          child: HugeIcon(
+            icon: HugeIcons.strokeRoundedLoading03,
+            size: IconSizes.small,
+            color: foreground,
+          ),
+        ),
+      );
+    }
+    if (_showSuccess) {
+      return _executionContent(
+        key: const ValueKey("success"),
+        child: HugeIcon(
+          icon: HugeIcons.strokeRoundedTick02,
+          size: IconSizes.small,
+          color: foreground,
+        ),
+      );
+    }
+    return _idleContent(foreground);
+  }
+
+  Widget _idleContent(Color foreground) {
+    return Row(
+      key: const ValueKey("content"),
+      spacing: 8,
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        if (widget.icon != null)
+          IconTheme.merge(
+            data: IconThemeData(color: foreground, size: IconSizes.small),
+            child: widget.icon!,
+          ),
+        if (widget.label != null)
+          Text(
+            widget.label!,
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+            style: TextStyles.bodyBold.copyWith(color: foreground),
+          ),
+      ],
+    );
+  }
+
+  Widget _executionContent({required Key key, required Widget child}) {
+    return Stack(
+      key: key,
+      alignment: Alignment.center,
+      children: [
+        Visibility(
+          visible: false,
+          maintainAnimation: true,
+          maintainSize: true,
+          maintainState: true,
+          child: _idleContent(Colors.transparent),
+        ),
+        child,
+      ],
+    );
+  }
+
+  bool get _isExecuting =>
+      _executionState == ComponentExecutionState.inProgress;
+
+  bool get _isSuccessful =>
+      _executionState == ComponentExecutionState.successful;
+
+  bool get _showLoading =>
+      widget.shouldSurfaceExecutionStates && _isExecuting && _loadingVisible;
+
+  bool get _showSuccess =>
+      widget.shouldSurfaceExecutionStates &&
+      widget.shouldShowSuccessState &&
+      _isSuccessful;
+
+  void _syncLoadingController() {
+    if (_showLoading) {
+      if (!_loadingController.isAnimating) {
+        _loadingController.repeat();
+      }
+      return;
+    }
+
+    if (_loadingController.isAnimating || _loadingController.value != 0) {
+      _loadingController.stop();
+      _loadingController.reset();
+    }
+  }
+
+  Future<void> _handleTap() async {
+    final callback = widget.onTap;
+    if (callback == null) return;
+
+    _successResetTimer?.cancel();
+    var loadingSurfaced = false;
+    _loadingTimer?.cancel();
+    setState(() {
+      _executionState = ComponentExecutionState.inProgress;
+      _loadingVisible = false;
+      _isPressed = false;
+    });
+    _loadingTimer = Timer(_loadingDelay, () {
+      if (!mounted) return;
+      loadingSurfaced = true;
+      setState(() {
+        _loadingVisible = true;
+        _isPressed = false;
+      });
+      _syncLoadingController();
+    });
+
+    try {
+      await Future.sync(callback);
+      if (!mounted) return;
+
+      final loadingPending = _loadingTimer?.isActive ?? false;
+      _loadingTimer?.cancel();
+      _loadingTimer = null;
+
+      final shouldShowSuccess =
+          widget.shouldSurfaceExecutionStates &&
+          widget.shouldShowSuccessState &&
+          (loadingSurfaced ||
+              (loadingPending && widget.shouldShowSuccessConfirmation));
+
+      if (shouldShowSuccess) {
+        _showSuccessForDuration();
+      } else {
+        _clearExecutionState();
+      }
+    } catch (_) {
+      _loadingTimer?.cancel();
+      _loadingTimer = null;
+      if (mounted) {
+        _clearExecutionState();
+      }
+    }
+  }
+
+  void _clearExecutionState() {
+    setState(() {
+      _executionState = ComponentExecutionState.idle;
+      _loadingVisible = false;
+      _isPressed = false;
+    });
+    _syncLoadingController();
+  }
+
+  void _showSuccessForDuration() {
+    setState(() {
+      _executionState = ComponentExecutionState.successful;
+      _loadingVisible = false;
+      _isPressed = false;
+    });
+    _syncLoadingController();
+    _successResetTimer?.cancel();
+    _successResetTimer = Timer(_successDisplayDuration, () {
+      if (!mounted) return;
+      _clearExecutionState();
+    });
+  }
+}

--- a/mobile/packages/ente_components/lib/ente_components.dart
+++ b/mobile/packages/ente_components/lib/ente_components.dart
@@ -5,6 +5,7 @@ export 'components/banner_component.dart';
 export 'components/bottom_sheet/bottom_sheet_component.dart';
 export 'components/bottom_sheet/error_bottom_sheet_component.dart';
 export 'components/buttons/button_component.dart';
+export 'components/buttons/fab_component.dart';
 export 'components/buttons/icon_button_component.dart';
 export 'components/centered_constrained_component.dart';
 export 'components/divider_component.dart';


### PR DESCRIPTION
## What changed

- add a reusable floating action button to `ente_components`
- support primary and secondary styles with icon-only, label-only, and icon-plus-label content
- handle async taps with guarded loading and success states
- add the component to the catalog with light and dark theme previews
- link the component to its Figma spec

## Why

This gives mobile apps one shared FAB that follows the Ente design system and the same async execution rules as the existing button components.

## Checks

- `fvm dart analyze lib/components/buttons/fab_component.dart example/lib/main.dart`
