### PR TITLE
[mob][photos] Remove obsolete video asset warning

### DIFF
--- a/mobile/apps/photos/lib/module/download/file.dart
+++ b/mobile/apps/photos/lib/module/download/file.dart
@@ -88,11 +88,6 @@ Future<File?> _getLocalDiskFile(
   } else {
     return file.getAsset.then((asset) async {
       if (asset == null || !(await asset.exists)) {
-        if (isOrigin && file.isVideo) {
-          _logger.warning(
-            "Failed to get file for assetID: ${file.localID}, is asset null: ${asset == null}",
-          );
-        }
         return null;
       }
       return isOrigin ? asset.originFile : asset.file;


### PR DESCRIPTION
## What changed

Removed the video/original-file warning emitted when a local `AssetEntity` is missing.

## Why

The warning was introduced as targeted diagnostics for a historical null-video-sharing issue. Sharing now logs failed local resolution at the call site and falls back to the uploaded copy, so this lower-level warning is redundant. The missing-asset guard and its `null` return remain unchanged.

## Impact

No functional behavior changes. This only removes obsolete, narrowly scoped log noise.

## Validation

- `dart format --output=none --set-exit-if-changed lib/module/download/file.dart`
- `flutter analyze lib/module/download/file.dart`
