### PR TITLE
[web][photos] Refractor CollectionMapDialog - MapView

### DIFF
--- a/web/apps/photos/src/components/Collections/CollectionHeader.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionHeader.tsx
@@ -42,13 +42,11 @@ import {
     CollectionSubType,
     type Collection,
 } from "ente-media/collection";
-import type { EnteFile } from "ente-media/file";
 import { ItemVisibility } from "ente-media/file-metadata";
 import {
     GalleryItemsHeaderAdapter,
     GalleryItemsSummary,
 } from "ente-new/photos/components/gallery/ListHeader";
-import { useSettingsSnapshot } from "ente-new/photos/components/utils/use-snapshot";
 import {
     cleanUncategorized,
     defaultHiddenCollectionUserFacingName,
@@ -72,31 +70,15 @@ import {
     savedCollectionFiles,
     savedCollections,
 } from "ente-new/photos/services/photos-fdb";
-import { updateMapEnabled } from "ente-new/photos/services/settings";
 import { emptyTrash } from "ente-new/photos/services/trash";
 import { usePhotosAppContext } from "ente-new/photos/types/context";
 import { t } from "i18next";
 import React, { useCallback, useRef } from "react";
 import { Trans } from "react-i18next";
-import type { FileListWithViewerProps } from "../FileListWithViewer";
-import { CollectionMapDialog } from "./CollectionMapDialog";
 
-export interface CollectionHeaderProps extends Pick<
-    FileListWithViewerProps,
-    | "onMarkTempDeleted"
-    | "onAddFileToCollection"
-    | "onRemoteFilesPull"
-    | "onVisualFeedback"
-    | "fileNormalCollectionIDs"
-    | "collectionNameByID"
-    | "emailByUserID"
-    | "onSelectCollection"
-    | "onSelectPerson"
-> {
+export interface CollectionHeaderProps {
     collectionSummary: CollectionSummary;
     activeCollection: Collection | undefined;
-    files: EnteFile[];
-    mapFileSource?: FileListWithViewerProps["mapFileSource"];
     setActiveCollectionID: (collectionID: number) => void;
     isActiveCollectionDownloadInProgress: () => boolean;
     onRemotePull: (opts?: RemotePullOpts) => Promise<void>;
@@ -107,6 +89,7 @@ export interface CollectionHeaderProps extends Pick<
     onSetAlbumCover: () => void;
     hasActiveFileSelection: boolean;
     onAddSaveGroup: AddSaveGroup;
+    onShowMap: () => void;
 }
 
 export const CollectionHeader: React.FC<CollectionHeaderProps> = (props) => {
@@ -150,8 +133,6 @@ const shouldShowOptions = (type: CollectionSummaryType) =>
 const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
     activeCollection,
     collectionSummary,
-    files,
-    mapFileSource,
     setActiveCollectionID,
     onRemotePull,
     onCollectionShare,
@@ -162,27 +143,16 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
     hasActiveFileSelection,
     onAddSaveGroup,
     isActiveCollectionDownloadInProgress,
-    onMarkTempDeleted,
-    onAddFileToCollection,
-    onRemoteFilesPull,
-    onVisualFeedback,
-    fileNormalCollectionIDs,
-    collectionNameByID,
-    emailByUserID,
-    onSelectCollection,
-    onSelectPerson,
+    onShowMap,
 }) => {
     const { showMiniDialog, onGenericError } = useBaseContext();
     const { showLoadingBar, hideLoadingBar, showNotification } =
         usePhotosAppContext();
-    const { mapEnabled } = useSettingsSnapshot();
     const overflowMenuIconRef = useRef<SVGSVGElement | null>(null);
 
     const { show: showSortOrderMenu, props: sortOrderMenuVisibilityProps } =
         useModalVisibility();
     const { show: showAlbumNameInput, props: albumNameInputVisibilityProps } =
-        useModalVisibility();
-    const { show: showMapDialog, props: mapDialogVisibilityProps } =
         useModalVisibility();
 
     const { type: collectionSummaryType, fileCount } = collectionSummary;
@@ -458,18 +428,6 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
         await updateCollectionSortOrder(activeCollection, false);
     });
 
-    const handleShowMap = useCallback(async () => {
-        if (!mapEnabled) {
-            try {
-                await updateMapEnabled(true);
-            } catch (e) {
-                onGenericError(e);
-                return;
-            }
-        }
-        showMapDialog();
-    }, [mapEnabled, onGenericError, showMapDialog]);
-
     let menuOptions: React.ReactNode[] = [];
     // MUI rejects fragments here, so return keyed arrays.
     switch (collectionSummaryType) {
@@ -504,7 +462,7 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
                 shouldShowMapOption(collectionSummary) && (
                     <OverflowMenuOption
                         key="map"
-                        onClick={handleShowMap}
+                        onClick={onShowMap}
                         startIcon={<MapOutlinedIcon />}
                     >
                         {t("map")}
@@ -587,7 +545,7 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
                     shouldShowMapOption(collectionSummary) && (
                         <OverflowMenuOption
                             key="map"
-                            onClick={handleShowMap}
+                            onClick={onShowMap}
                             startIcon={<MapOutlinedIcon />}
                         >
                             {t("map")}
@@ -650,7 +608,7 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
                 shouldShowMapOption(collectionSummary) && (
                     <OverflowMenuOption
                         key="map"
-                        onClick={handleShowMap}
+                        onClick={onShowMap}
                         startIcon={<MapOutlinedIcon />}
                     >
                         {t("map")}
@@ -745,7 +703,7 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
                 isQuickLinkAlbum={isQuickLinkAlbum}
                 hasActiveFileSelection={hasActiveFileSelection}
                 isDownloadInProgress={isActiveCollectionDownloadInProgress}
-                onMapClick={handleShowMap}
+                onMapClick={onShowMap}
                 onEmptyTrashClick={confirmEmptyTrash}
                 onDownloadClick={downloadCollection}
                 onShareClick={
@@ -772,24 +730,6 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
                 sortAsc={activeCollection?.pubMagicMetadata?.data.asc ?? false}
                 onAscClick={changeSortOrderAsc}
                 onDescClick={changeSortOrderDesc}
-            />
-            <CollectionMapDialog
-                {...mapDialogVisibilityProps}
-                collectionSummary={collectionSummary}
-                activeCollection={activeCollection}
-                files={files}
-                mapFileSource={mapFileSource}
-                onRemotePull={onRemotePull}
-                onAddSaveGroup={onAddSaveGroup}
-                onMarkTempDeleted={onMarkTempDeleted}
-                onAddFileToCollection={onAddFileToCollection}
-                onRemoteFilesPull={onRemoteFilesPull}
-                onVisualFeedback={onVisualFeedback}
-                fileNormalCollectionIDs={fileNormalCollectionIDs}
-                collectionNameByID={collectionNameByID}
-                emailByUserID={emailByUserID}
-                onSelectCollection={onSelectCollection}
-                onSelectPerson={onSelectPerson}
             />
             <SingleInputDialog
                 {...albumNameInputVisibilityProps}

--- a/web/apps/photos/src/components/Collections/CollectionMapDialog.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionMapDialog.tsx
@@ -1,5 +1,4 @@
 import type { RemotePullOpts } from "@/components/gallery";
-import type { SelectedState } from "@/utils/file";
 import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
@@ -22,7 +21,6 @@ import type { ModalVisibilityProps } from "ente-base/components/utils/modal";
 import { useBaseContext } from "ente-base/context";
 import { downloadManager } from "ente-gallery/services/download";
 import { uniqueFilesByID } from "ente-gallery/utils/file";
-import type { Collection } from "ente-media/collection";
 import type { EnteFile } from "ente-media/file";
 import {
     fileCreationPhotoSortTime,
@@ -36,13 +34,8 @@ import {
 } from "ente-new/photos/services/collection";
 import type { CollectionSummary } from "ente-new/photos/services/collection-summary";
 import { updateFilesVisibility } from "ente-new/photos/services/file";
-import {
-    savedCollectionFiles,
-    savedCollections,
-} from "ente-new/photos/services/photos-fdb";
 import { t } from "i18next";
 import "leaflet/dist/leaflet.css";
-import type { Dispatch, SetStateAction } from "react";
 import React, {
     startTransition,
     useCallback,
@@ -51,9 +44,22 @@ import React, {
     useRef,
     useState,
 } from "react";
-import Supercluster from "supercluster";
+import Supercluster, {
+    type ClusterFeature,
+    type ClusterOrPoint,
+    type PointFeature,
+} from "supercluster";
 import type { FileListWithViewerProps } from "../FileListWithViewer";
 import { FileListWithViewer } from "../FileListWithViewer";
+
+interface MapFileSource {
+    collectionFiles: EnteFile[];
+    favoriteFileIDs: Set<number>;
+    hiddenFileIDs: Set<number>;
+    archivedFileIDs: Set<number>;
+    tempDeletedFileIDs: Set<number>;
+    tempHiddenFileIDs: Set<number>;
+}
 
 interface CollectionMapDialogProps
     extends
@@ -69,13 +75,12 @@ interface CollectionMapDialogProps
             | "collectionNameByID"
             | "onSelectCollection"
             | "onSelectPerson"
-            | "mapFileSource"
             | "emailByUserID"
         > {
     collectionSummary: CollectionSummary;
-    activeCollection: Collection | undefined;
     files: EnteFile[];
-    onRemotePull?: (opts?: RemotePullOpts) => Promise<void>;
+    mapFileSource: MapFileSource;
+    onRemotePull: (opts?: RemotePullOpts) => Promise<void>;
 }
 
 interface MapDataState {
@@ -101,12 +106,7 @@ interface MapDataResult extends MapDataState {
     queueThumbnailFetch: (fileIDs: number[]) => void;
 }
 
-interface MapComponents {
-    MapContainer: typeof import("react-leaflet").MapContainer;
-    TileLayer: typeof import("react-leaflet").TileLayer;
-    Marker: typeof import("react-leaflet").Marker;
-    useMap: typeof import("react-leaflet").useMap;
-}
+type MapComponents = typeof import("react-leaflet");
 
 interface MapIndexPoint {
     fileId: number;
@@ -115,69 +115,23 @@ interface MapIndexPoint {
     timestamp: number;
 }
 
-interface MapPhotoPoint {
-    lat: number;
-    lng: number;
-    name: string;
-    country: string;
-    image: string;
-    fileId: number;
-}
-
 interface MapPointProperties {
     fileId: number;
     timestamp: number;
+    cluster?: false;
 }
 
-interface MapPointFeature {
-    type: "Feature";
-    properties: MapPointProperties & { cluster?: false };
-    geometry: { type: "Point"; coordinates: [number, number] };
-}
+type MapPointFeature = PointFeature<MapPointProperties>;
 
 interface MapClusterProperties {
     latestTimestamp: number;
     latestFileId: number;
 }
 
-interface MapClusterFeature {
-    type: "Feature";
-    properties: MapClusterProperties & {
-        cluster: true;
-        cluster_id: number;
-        point_count: number;
-        point_count_abbreviated?: number | string;
-    };
-    geometry: { type: "Point"; coordinates: [number, number] };
-}
+type MapClusterFeature = ClusterFeature<MapClusterProperties>;
 
-type MapFeature = MapClusterFeature | MapPointFeature;
-
-interface MapIndex {
-    load(points: MapPointFeature[]): MapIndex;
-    getClusters(
-        bbox: [number, number, number, number],
-        zoom: number,
-    ): MapFeature[];
-    getLeaves(
-        clusterId: number,
-        limit: number,
-        offset: number,
-    ): MapPointFeature[];
-    getClusterExpansionZoom(clusterId: number): number;
-}
-
-interface MapClusterOptions {
-    radius?: number;
-    maxZoom?: number;
-    map?: (props: MapPointProperties) => MapClusterProperties;
-    reduce?: (
-        accumulated: MapClusterProperties,
-        props: MapClusterProperties,
-    ) => void;
-}
-
-type SuperclusterConstructor = new (options?: MapClusterOptions) => MapIndex;
+type MapFeature = ClusterOrPoint<MapPointProperties, MapClusterProperties>;
+type MapIndex = Supercluster<MapPointProperties, MapClusterProperties>;
 
 const MAX_MAP_ZOOM = 19;
 const DEFAULT_MAP_ZOOM = 10;
@@ -194,14 +148,7 @@ function useMapComponents() {
         if (typeof window === "undefined") return;
 
         void import("react-leaflet")
-            .then((leaflet) =>
-                setMapComponents({
-                    MapContainer: leaflet.MapContainer,
-                    TileLayer: leaflet.TileLayer,
-                    Marker: leaflet.Marker,
-                    useMap: leaflet.useMap,
-                }),
-            )
+            .then(setMapComponents)
             .catch((e: unknown) => {
                 console.error("Failed to load map components", e);
             });
@@ -237,28 +184,20 @@ interface DeriveLocationAwareMapFilesParams {
     tempHiddenFileIDs: Set<number>;
 }
 
-const emptyFileIDs = new Set<number>();
-
-const shouldUseLocationAwareMapRepresentatives = (
-    collectionSummaryType: CollectionSummary["type"],
-) => collectionSummaryType == "all" || collectionSummaryType == "userFavorites";
-
 const canUseFileAsMapEquivalent = (
     file: EnteFile,
     hiddenFileIDs: Set<number>,
     archivedFileIDs: Set<number>,
     tempDeletedFileIDs: Set<number>,
     tempHiddenFileIDs: Set<number>,
-) => {
+) =>
     // A mutation can be remote before the next pull updates collectionFiles.
-    if (tempDeletedFileIDs.has(file.id)) return false;
-    if (hiddenFileIDs.has(file.id)) return false;
-    if (tempHiddenFileIDs.has(file.id)) return false;
-    if (archivedFileIDs.has(file.id)) return false;
-
-    const visibility = file.magicMetadata?.data.visibility;
-    return visibility === undefined || visibility === ItemVisibility.visible;
-};
+    !tempDeletedFileIDs.has(file.id) &&
+    !hiddenFileIDs.has(file.id) &&
+    !tempHiddenFileIDs.has(file.id) &&
+    !archivedFileIDs.has(file.id) &&
+    (file.magicMetadata?.data.visibility === undefined ||
+        file.magicMetadata.data.visibility === ItemVisibility.visible);
 
 const addUniqueMapFile = (
     files: EnteFile[],
@@ -283,7 +222,8 @@ const deriveLocationAwareMapFiles = ({
 }: DeriveLocationAwareMapFilesParams) => {
     if (
         !currentUserID ||
-        !shouldUseLocationAwareMapRepresentatives(collectionSummaryType)
+        (collectionSummaryType != "all" &&
+            collectionSummaryType != "userFavorites")
     ) {
         return files;
     }
@@ -351,55 +291,18 @@ const deriveLocationAwareMapFiles = ({
         const ownedFilesWithLocation = ownedFiles.filter(fileLocation);
         const sharedFilesWithLocation = sharedFiles.filter(fileLocation);
 
-        if (ownedFilesWithLocation.length && sharedFilesWithLocation.length) {
-            for (const sharedFile of sharedFilesWithLocation) {
-                addUniqueMapFile(mapFiles, mapFileIDs, sharedFile);
-            }
-            for (const ownedFile of ownedFilesWithLocation) {
-                addUniqueMapFile(mapFiles, mapFileIDs, ownedFile);
-            }
-        } else if (sharedFilesWithLocation.length) {
-            for (const sharedFile of sharedFilesWithLocation) {
-                addUniqueMapFile(mapFiles, mapFileIDs, sharedFile);
-            }
-        } else if (ownedFilesWithLocation.length) {
-            for (const ownedFile of ownedFilesWithLocation) {
-                addUniqueMapFile(mapFiles, mapFileIDs, ownedFile);
-            }
-        } else {
-            addUniqueMapFile(mapFiles, mapFileIDs, file);
+        const filesWithLocation = [
+            ...sharedFilesWithLocation,
+            ...ownedFilesWithLocation,
+        ];
+        for (const mapFile of filesWithLocation.length
+            ? filesWithLocation
+            : [file]) {
+            addUniqueMapFile(mapFiles, mapFileIDs, mapFile);
         }
     }
 
     return mapFiles;
-};
-
-const deriveFavoriteFileIDs = (
-    userID: number,
-    favoritesCollectionID: number,
-    collectionFiles: EnteFile[],
-) => {
-    const favoriteFiles = collectionFiles.filter(
-        (file) => file.collectionID == favoritesCollectionID,
-    );
-    const favoriteFileIDs = new Set(favoriteFiles.map((file) => file.id));
-    const favoriteFileHashAndTypeKeys = new Set(
-        favoriteFiles.flatMap((file) => {
-            const key = favoriteFileHashAndTypeKey(file);
-            return key ? [key] : [];
-        }),
-    );
-
-    for (const file of collectionFiles) {
-        if (file.ownerID == userID) continue;
-
-        const key = favoriteFileHashAndTypeKey(file);
-        if (key && favoriteFileHashAndTypeKeys.has(key)) {
-            favoriteFileIDs.add(file.id);
-        }
-    }
-
-    return favoriteFileIDs;
 };
 
 const buildMapIndexPoints = async (files: EnteFile[]) => {
@@ -408,8 +311,7 @@ const buildMapIndexPoints = async (files: EnteFile[]) => {
     let latestFileId: number | undefined;
 
     for (let index = 0; index < files.length; index += 1) {
-        const file = files[index];
-        if (!file) continue;
+        const file = files[index]!;
         const loc = fileLocation(file);
         if (!loc) continue;
 
@@ -436,7 +338,7 @@ const buildMapIndexPoints = async (files: EnteFile[]) => {
 };
 
 const buildClusterIndex = (points: MapIndexPoint[]): MapIndex => {
-    const options: MapClusterOptions = {
+    const index = new Supercluster<MapPointProperties, MapClusterProperties>({
         radius: 80,
         maxZoom: MAX_MAP_ZOOM,
         map: (props) => ({
@@ -449,10 +351,7 @@ const buildClusterIndex = (points: MapIndexPoint[]): MapIndex => {
                 accumulated.latestFileId = props.latestFileId;
             }
         },
-    };
-
-    const SuperclusterCtor = Supercluster as unknown as SuperclusterConstructor;
-    const index = new SuperclusterCtor(options);
+    });
 
     const features: MapPointFeature[] = points.map((point) => ({
         type: "Feature" as const,
@@ -838,7 +737,7 @@ function useFavorites(
     open: boolean,
     user: ReturnType<typeof useCurrentUser>,
     favoriteEquivalenceFiles: EnteFile[],
-    syncedFavoriteFileIDs?: Set<number>,
+    syncedFavoriteFileIDs: Set<number>,
 ): FavoritesState & {
     handleToggleFavorite: (file: EnteFile) => Promise<void>;
     handleFileVisibilityUpdate: (
@@ -846,8 +745,8 @@ function useFavorites(
         visibility: ItemVisibility,
     ) => Promise<void>;
 } {
-    const [favoriteFileIDs, setFavoriteFileIDs] = useState<Set<number>>(
-        syncedFavoriteFileIDs ?? new Set(),
+    const [favoriteFileIDs, setFavoriteFileIDs] = useState(
+        syncedFavoriteFileIDs,
     );
     const [pendingFavoriteUpdates, setPendingFavoriteUpdates] = useState<
         Set<number>
@@ -857,35 +756,7 @@ function useFavorites(
     >(new Set());
 
     useEffect(() => {
-        if (!open || !user) return;
-
-        if (syncedFavoriteFileIDs) {
-            setFavoriteFileIDs(syncedFavoriteFileIDs);
-            return;
-        }
-
-        const loadFavorites = async () => {
-            const collections = await savedCollections();
-            const collectionFiles = await savedCollectionFiles();
-
-            for (const collection of collections) {
-                if (
-                    collection.type === "favorites" &&
-                    collection.owner.id === user.id
-                ) {
-                    setFavoriteFileIDs(
-                        deriveFavoriteFileIDs(
-                            user.id,
-                            collection.id,
-                            collectionFiles,
-                        ),
-                    );
-                    break;
-                }
-            }
-        };
-
-        void loadFavorites();
+        if (open && user) setFavoriteFileIDs(syncedFavoriteFileIDs);
     }, [open, syncedFavoriteFileIDs, user]);
 
     const addToSet = useCallback((set: Set<number>, id: number) => {
@@ -1023,92 +894,9 @@ function useFavorites(
     };
 }
 
-function useVisiblePhotos() {
-    const [visiblePhotos, setVisiblePhotos] = useState<MapPhotoPoint[]>([]);
-    const [isVisiblePhotosUpdating, setIsVisiblePhotosUpdating] =
-        useState(false);
-
-    return {
-        visiblePhotos,
-        setVisiblePhotos,
-        isVisiblePhotosUpdating,
-        setIsVisiblePhotosUpdating,
-    };
-}
-
 function createMarkerIcon(
     imageSrc: string,
-    size: number,
-): import("leaflet").DivIcon | null {
-    if (typeof window === "undefined") return null;
-
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const leaflet = require("leaflet") as typeof import("leaflet");
-
-    const pinSize = size + 16;
-    const triangleHeight = 10;
-    const pinHeight = pinSize + triangleHeight + 2;
-    const hasImage = imageSrc && imageSrc.trim() !== "";
-
-    const outerBorderRadius = 16;
-    const innerBorderRadius = 12;
-
-    return leaflet.divIcon({
-        html: `
-            <div class="photo-pin" style="
-                width: ${pinSize}px;
-                height: ${pinHeight}px;
-                position: relative;
-                cursor: pointer;
-                transition: all 0.3s ease;
-                filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3)) drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
-            ">
-              <div style="
-                  width: ${pinSize}px;
-                  height: ${pinSize}px;
-                  border-radius: ${outerBorderRadius}px;
-                  background: white;
-                  border: 2px solid #ffffff;
-                  padding: 4px;
-                  position: relative;
-                  overflow: hidden;
-                  transition: background-color 0.3s ease, border-color 0.3s ease;
-              "
-              onmouseover="this.style.background='#22c55e'; this.style.borderColor='#22c55e'; this.nextElementSibling.style.borderTopColor='#22c55e';"
-              onmouseout="this.style.background='white'; this.style.borderColor='#ffffff'; this.nextElementSibling.style.borderTopColor='white';"
-              >
-                ${
-                    hasImage
-                        ? `<img src="${imageSrc}" style="width:100%;height:100%;object-fit:cover;border-radius:${innerBorderRadius}px;" alt="Location" />`
-                        : `<div style="width:100%;height:100%;border-radius:${innerBorderRadius}px;animation:skeleton-pulse 1.5s ease-in-out infinite;"></div>
-                           <style>@keyframes skeleton-pulse{0%{background-color:#ffffff}50%{background-color:#f0f0f0}100%{background-color:#ffffff}}</style>`
-                }
-              </div>
-              <div style="
-                  position: absolute;
-                  bottom: 2px;
-                  left: 50%;
-                  transform: translateX(-50%);
-                  width: 0;
-                  height: 0;
-                  border-left: ${triangleHeight}px solid transparent;
-                  border-right: ${triangleHeight}px solid transparent;
-                  border-top: ${triangleHeight}px solid white;
-                  transition: border-top-color 0.3s ease;
-              "></div>
-            </div>
-        `,
-        className: "collection-marker",
-        iconSize: [pinSize, pinHeight],
-        iconAnchor: [pinSize / 2, pinHeight],
-        popupAnchor: [0, -pinHeight],
-    });
-}
-
-function createClusterIcon(
-    imageSrc: string,
-    size: number,
-    clusterCount: number,
+    clusterCount?: number,
     interactive = true,
 ): import("leaflet").DivIcon | null {
     if (typeof window === "undefined") return null;
@@ -1116,11 +904,12 @@ function createClusterIcon(
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const leaflet = require("leaflet") as typeof import("leaflet");
 
-    const pinSize = size + 16;
+    const pinSize = 84;
     const triangleHeight = 10;
     const pinHeight = pinSize + triangleHeight + 2;
-    const hasImage = imageSrc && imageSrc.trim() !== "";
-    const badgeOverflow = 6;
+    const hasImage = imageSrc.trim() !== "";
+    const isCluster = clusterCount !== undefined;
+    const badgeOverflow = isCluster ? 6 : 0;
 
     const outerBorderRadius = 16;
     const innerBorderRadius = 12;
@@ -1130,13 +919,11 @@ function createClusterIcon(
         : "";
 
     const badgeLabel =
-        clusterCount >= 2000
+        clusterCount !== undefined && clusterCount >= 2000
             ? `${Math.floor((clusterCount - 1) / 1000)}K+`
-            : clusterCount >= 1000
+            : clusterCount !== undefined && clusterCount >= 1000
               ? "1K+"
-              : clusterCount > 999
-                ? `${Math.floor(clusterCount / 100)}00+`
-                : `${clusterCount}`;
+              : `${clusterCount}`;
 
     return leaflet.divIcon({
         html: `
@@ -1146,7 +933,7 @@ function createClusterIcon(
                 position: relative;
                 cursor: ${interactive ? "pointer" : "default"};
                 transition: all 0.3s ease;
-                overflow: visible;
+                ${isCluster ? "overflow: visible;" : ""}
                 filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3)) drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
             ">
               <div style="
@@ -1169,25 +956,25 @@ function createClusterIcon(
                            <style>@keyframes skeleton-pulse{0%{background-color:#ffffff}50%{background-color:#f0f0f0}100%{background-color:#ffffff}}</style>`
                 }
               </div>
-              <div style="
-                  position: absolute;
-                  top: -${badgeOverflow}px;
-                  right: -${badgeOverflow}px;
-                  background: #22c55e;
-                  color: #ffffff;
-                  border-radius: 7px;
-                  padding: 4px 7px;
-                  font-size: 12px;
-                  font-weight: 700;
-                  line-height: 1;
-                  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
-                  z-index: 1;
-              ">
-                  ${badgeLabel}
-              </div>
-              <style>
-                .leaflet-marker-icon.collection-cluster-marker { overflow: visible !important; }
-              </style>
+              ${
+                  isCluster
+                      ? `<div style="
+                            position: absolute;
+                            top: -${badgeOverflow}px;
+                            right: -${badgeOverflow}px;
+                            background: #22c55e;
+                            color: #ffffff;
+                            border-radius: 7px;
+                            padding: 4px 7px;
+                            font-size: 12px;
+                            font-weight: 700;
+                            line-height: 1;
+                            box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+                            z-index: 1;
+                         ">${badgeLabel}</div>
+                         <style>.leaflet-marker-icon.collection-cluster-marker { overflow: visible !important; }</style>`
+                      : ""
+              }
               <div class="triangle" style="
                   position: absolute;
                   bottom: 2px;
@@ -1202,10 +989,11 @@ function createClusterIcon(
               "></div>
             </div>
         `,
-        className: "collection-cluster-marker",
+        className: isCluster
+            ? "collection-cluster-marker"
+            : "collection-marker",
         iconSize: [pinSize + badgeOverflow, pinHeight + badgeOverflow],
         iconAnchor: [pinSize / 2, pinHeight],
-        popupAnchor: [0, -pinHeight],
     });
 }
 
@@ -1213,7 +1001,6 @@ export const CollectionMapDialog: React.FC<CollectionMapDialogProps> = ({
     open,
     onClose,
     collectionSummary,
-    activeCollection,
     files,
     onRemotePull,
     onAddSaveGroup,
@@ -1232,8 +1019,14 @@ export const CollectionMapDialog: React.FC<CollectionMapDialogProps> = ({
     const mapComponents = useMapComponents();
     const user = useCurrentUser();
     const [isFileViewerOpen, setIsFileViewerOpen] = useState(false);
-    const optimalZoom = DEFAULT_MAP_ZOOM;
-    const mapSourceCollectionFiles = mapFileSource?.collectionFiles ?? files;
+    const {
+        collectionFiles: mapSourceCollectionFiles,
+        favoriteFileIDs: syncedFavoriteFileIDs,
+        hiddenFileIDs,
+        archivedFileIDs,
+        tempDeletedFileIDs,
+        tempHiddenFileIDs,
+    } = mapFileSource;
 
     const {
         favoriteFileIDs,
@@ -1245,15 +1038,8 @@ export const CollectionMapDialog: React.FC<CollectionMapDialogProps> = ({
         open,
         user,
         mapSourceCollectionFiles,
-        mapFileSource?.favoriteFileIDs,
+        syncedFavoriteFileIDs,
     );
-    const mapSourceHiddenFileIDs = mapFileSource?.hiddenFileIDs ?? emptyFileIDs;
-    const mapSourceArchivedFileIDs =
-        mapFileSource?.archivedFileIDs ?? emptyFileIDs;
-    const mapSourceTempDeletedFileIDs =
-        mapFileSource?.tempDeletedFileIDs ?? emptyFileIDs;
-    const mapSourceTempHiddenFileIDs =
-        mapFileSource?.tempHiddenFileIDs ?? emptyFileIDs;
 
     const mapFiles = useMemo(
         () =>
@@ -1263,20 +1049,20 @@ export const CollectionMapDialog: React.FC<CollectionMapDialogProps> = ({
                 collectionSummaryType: collectionSummary.type,
                 currentUserID: user?.id,
                 favoriteFileIDs,
-                hiddenFileIDs: mapSourceHiddenFileIDs,
-                archivedFileIDs: mapSourceArchivedFileIDs,
-                tempDeletedFileIDs: mapSourceTempDeletedFileIDs,
-                tempHiddenFileIDs: mapSourceTempHiddenFileIDs,
+                hiddenFileIDs,
+                archivedFileIDs,
+                tempDeletedFileIDs,
+                tempHiddenFileIDs,
             }),
         [
             collectionSummary.type,
             favoriteFileIDs,
             files,
-            mapSourceArchivedFileIDs,
+            archivedFileIDs,
             mapSourceCollectionFiles,
-            mapSourceHiddenFileIDs,
-            mapSourceTempDeletedFileIDs,
-            mapSourceTempHiddenFileIDs,
+            hiddenFileIDs,
+            tempDeletedFileIDs,
+            tempHiddenFileIDs,
             user?.id,
         ],
     );
@@ -1295,204 +1081,125 @@ export const CollectionMapDialog: React.FC<CollectionMapDialogProps> = ({
         queueThumbnailFetch,
     } = useMapData(open, collectionSummary, mapFiles, onGenericError);
 
-    const {
-        visiblePhotos,
-        setVisiblePhotos,
-        isVisiblePhotosUpdating,
-        setIsVisiblePhotosUpdating,
-    } = useVisiblePhotos();
+    const [visibleFileIDs, setVisibleFileIDs] = useState<number[]>([]);
+    const [isVisiblePhotosUpdating, setIsVisiblePhotosUpdating] =
+        useState(false);
 
     useEffect(() => {
         if (!open) {
             setIsVisiblePhotosUpdating(false);
         }
-    }, [open, setIsVisiblePhotosUpdating]);
-
-    const handleSetFileViewerOpen: Dispatch<SetStateAction<boolean>> =
-        useCallback(
-            (next) => {
-                const nextValue =
-                    typeof next === "function" ? next(isFileViewerOpen) : next;
-                setIsFileViewerOpen(nextValue);
-            },
-            [isFileViewerOpen],
-        );
+    }, [open]);
 
     const visibleFiles = useMemo(() => {
-        return visiblePhotos
-            .map((p) => filesByID.get(p.fileId))
+        return visibleFileIDs
+            .map((fileID) => filesByID.get(fileID))
             .filter((f): f is EnteFile => f !== undefined);
-    }, [visiblePhotos, filesByID]);
+    }, [visibleFileIDs, filesByID]);
 
     const handleRemotePull = useCallback(
-        () =>
-            onRemotePull
-                ? onRemotePull({ silent: true, source: "map-dialog" })
-                : Promise.resolve(),
+        () => onRemotePull({ silent: true, source: "map-dialog" }),
         [onRemotePull],
     );
-    const visualFeedback = useMemo(() => onVisualFeedback, [onVisualFeedback]);
-
-    const emptySelected = useMemo<SelectedState>(
-        () => ({
-            ownCount: 0,
-            count: 0,
-            context: undefined,
-            collectionID: activeCollection?.id ?? collectionSummary.id,
-        }),
-        [activeCollection?.id, collectionSummary.id],
-    );
-
-    const noOpSetSelected = useCallback(() => undefined, []);
 
     const handleMarkTempDeleted = useCallback(
         (files: EnteFile[]) => {
             onMarkTempDeleted?.(files);
 
             const idsToRemove = new Set(files.map((file) => file.id));
-            setVisiblePhotos((prev) =>
-                prev.filter((photo) => !idsToRemove.has(photo.fileId)),
+            setVisibleFileIDs((prev) =>
+                prev.filter((fileID) => !idsToRemove.has(fileID)),
             );
             removeFilesFromMap([...idsToRemove]);
         },
-        [onMarkTempDeleted, removeFilesFromMap, setVisiblePhotos],
+        [onMarkTempDeleted, removeFilesFromMap],
     );
 
     const handleFileVisibilityUpdateWithLocalState = useCallback(
         async (file: EnteFile, visibility: ItemVisibility) => {
             await handleFileVisibilityUpdate(file, visibility);
-            const updatedMagicMetadata = file.magicMetadata
-                ? {
-                      ...file.magicMetadata,
-                      data: { ...file.magicMetadata.data, visibility },
-                  }
-                : undefined;
-            const updatedFile =
-                updatedMagicMetadata !== undefined
-                    ? { ...file, magicMetadata: updatedMagicMetadata }
-                    : file;
-            updateFileVisibility(updatedFile, visibility);
+            updateFileVisibility(file, visibility);
         },
         [handleFileVisibilityUpdate, updateFileVisibility],
     );
 
-    const body = useMemo(() => {
-        // Background reloads keep the map and viewer mounted.
-        if (isLoading && !mapIndex) {
-            return (
-                <CenteredBox>
-                    <ActivityIndicator size="28px" />
-                </CenteredBox>
-            );
-        }
-
-        if (error) {
-            return (
-                <CenteredBox>
-                    <Typography variant="body" sx={{ color: "text.secondary" }}>
-                        {error}
-                    </Typography>
-                </CenteredBox>
-            );
-        }
-
-        if (!mapComponents) {
-            return (
-                <CenteredBox>
-                    <ActivityIndicator size="28px" />
-                </CenteredBox>
-            );
-        }
-
-        if (!mapPoints.length || !mapCenter || !mapIndex) {
-            return (
-                <CenteredBox onClose={onClose} closeLabel={t("close")}>
-                    <Typography variant="body" sx={{ color: "text.secondary" }}>
-                        {t("no_geotagged_photos")}
-                    </Typography>
-                </CenteredBox>
-            );
-        }
-
-        return (
-            <MapLayout
-                collectionSummary={collectionSummary}
-                visiblePhotos={visiblePhotos}
-                visibleFiles={visibleFiles}
-                mapIndex={mapIndex}
-                latestFileId={latestFileId}
-                thumbByFileID={thumbByFileID}
-                mapComponents={mapComponents}
-                mapCenter={mapCenter}
-                optimalZoom={optimalZoom}
-                onClose={onClose}
-                onVisiblePhotosChange={setVisiblePhotos}
-                onVisiblePhotosLoadingChange={setIsVisiblePhotosUpdating}
-                visiblePhotosUpdating={isVisiblePhotosUpdating}
-                onPrefetchThumbnails={queueThumbnailFetch}
-                user={user}
-                favoriteFileIDs={favoriteFileIDs}
-                pendingFavoriteUpdates={pendingFavoriteUpdates}
-                pendingVisibilityUpdates={pendingVisibilityUpdates}
-                onToggleFavorite={handleToggleFavorite}
-                onFileVisibilityUpdate={
-                    handleFileVisibilityUpdateWithLocalState
-                }
-                onRemotePull={handleRemotePull}
-                onVisualFeedback={visualFeedback}
-                onAddSaveGroup={onAddSaveGroup}
-                onMarkTempDeleted={handleMarkTempDeleted}
-                onAddFileToCollection={onAddFileToCollection}
-                onRemoteFilesPull={onRemoteFilesPull}
-                fileNormalCollectionIDs={fileNormalCollectionIDs}
-                collectionNameByID={collectionNameByID}
-                onSelectCollection={onSelectCollection}
-                onSelectPerson={onSelectPerson}
-                emailByUserID={emailByUserID}
-                selected={emptySelected}
-                setSelected={noOpSetSelected}
-                onSetOpenFileViewer={handleSetFileViewerOpen}
-            />
+    let body: React.ReactNode;
+    // Background reloads keep the map and viewer mounted.
+    if (isLoading && !mapIndex) {
+        body = (
+            <CenteredBox>
+                <ActivityIndicator size="28px" />
+            </CenteredBox>
         );
-    }, [
-        collectionSummary,
-        emptySelected,
-        error,
-        favoriteFileIDs,
-        handleFileVisibilityUpdateWithLocalState,
-        handleRemotePull,
-        handleToggleFavorite,
-        visualFeedback,
-        isLoading,
-        mapCenter,
-        mapComponents,
-        mapIndex,
-        mapPoints,
-        latestFileId,
-        noOpSetSelected,
-        optimalZoom,
-        onAddFileToCollection,
-        onAddSaveGroup,
-        onRemoteFilesPull,
-        pendingFavoriteUpdates,
-        pendingVisibilityUpdates,
-        setIsVisiblePhotosUpdating,
-        setVisiblePhotos,
-        collectionNameByID,
-        fileNormalCollectionIDs,
-        handleMarkTempDeleted,
-        onSelectCollection,
-        onSelectPerson,
-        thumbByFileID,
-        queueThumbnailFetch,
-        user,
-        visibleFiles,
-        visiblePhotos,
-        isVisiblePhotosUpdating,
-        onClose,
-        handleSetFileViewerOpen,
-        emailByUserID,
-    ]);
+    } else if (error) {
+        body = (
+            <CenteredBox>
+                <Typography variant="body" sx={{ color: "text.secondary" }}>
+                    {error}
+                </Typography>
+            </CenteredBox>
+        );
+    } else if (!mapComponents) {
+        body = (
+            <CenteredBox>
+                <ActivityIndicator size="28px" />
+            </CenteredBox>
+        );
+    } else if (!mapPoints.length || !mapCenter || !mapIndex) {
+        body = (
+            <CenteredBox onClose={onClose} closeLabel={t("close")}>
+                <Typography variant="body" sx={{ color: "text.secondary" }}>
+                    {t("no_geotagged_photos")}
+                </Typography>
+            </CenteredBox>
+        );
+    } else {
+        body = (
+            <Box sx={{ position: "relative", height: "100%", width: "100%" }}>
+                <CollectionSidebar
+                    collectionSummary={collectionSummary}
+                    visibleFiles={visibleFiles}
+                    isVisiblePhotosUpdating={isVisiblePhotosUpdating}
+                    latestFileId={latestFileId}
+                    thumbByFileID={thumbByFileID}
+                    onClose={onClose}
+                    user={user}
+                    favoriteFileIDs={favoriteFileIDs}
+                    pendingFavoriteUpdates={pendingFavoriteUpdates}
+                    pendingVisibilityUpdates={pendingVisibilityUpdates}
+                    onToggleFavorite={handleToggleFavorite}
+                    onFileVisibilityUpdate={
+                        handleFileVisibilityUpdateWithLocalState
+                    }
+                    onRemotePull={handleRemotePull}
+                    onVisualFeedback={onVisualFeedback}
+                    onAddSaveGroup={onAddSaveGroup}
+                    onMarkTempDeleted={handleMarkTempDeleted}
+                    onAddFileToCollection={onAddFileToCollection}
+                    onRemoteFilesPull={onRemoteFilesPull}
+                    fileNormalCollectionIDs={fileNormalCollectionIDs}
+                    collectionNameByID={collectionNameByID}
+                    onSelectCollection={onSelectCollection}
+                    onSelectPerson={onSelectPerson}
+                    emailByUserID={emailByUserID}
+                    onSetOpenFileViewer={setIsFileViewerOpen}
+                />
+                <Box sx={{ width: "100%", height: "100%" }}>
+                    <MapCanvas
+                        mapComponents={mapComponents}
+                        mapCenter={mapCenter}
+                        mapIndex={mapIndex}
+                        thumbByFileID={thumbByFileID}
+                        onVisibleFileIDsChange={setVisibleFileIDs}
+                        onVisiblePhotosLoadingChange={
+                            setIsVisiblePhotosUpdating
+                        }
+                        onPrefetchThumbnails={queueThumbnailFetch}
+                    />
+                </Box>
+            </Box>
+        );
+    }
 
     return (
         <Dialog
@@ -1524,132 +1231,8 @@ export const CollectionMapDialog: React.FC<CollectionMapDialogProps> = ({
     );
 };
 
-interface MapLayoutProps {
-    collectionSummary: CollectionSummary;
-    visiblePhotos: MapPhotoPoint[];
-    visibleFiles: EnteFile[];
-    visiblePhotosUpdating: boolean;
-    mapIndex: MapIndex | null;
-    latestFileId: number | undefined;
-    thumbByFileID: Map<number, string>;
-    mapComponents: MapComponents;
-    mapCenter: [number, number];
-    optimalZoom: number;
-    onClose: () => void;
-    onVisiblePhotosChange: (photosInView: MapPhotoPoint[]) => void;
-    onVisiblePhotosLoadingChange: (loading: boolean) => void;
-    onPrefetchThumbnails: (fileIDs: number[]) => void;
-    user: ReturnType<typeof useCurrentUser>;
-    favoriteFileIDs: Set<number>;
-    pendingFavoriteUpdates: Set<number>;
-    pendingVisibilityUpdates: Set<number>;
-    onToggleFavorite: (file: EnteFile) => Promise<void>;
-    onFileVisibilityUpdate: (
-        file: EnteFile,
-        visibility: ItemVisibility,
-    ) => Promise<void>;
-    onRemotePull: () => Promise<void>;
-    onVisualFeedback: () => void;
-    onAddSaveGroup: FileListWithViewerProps["onAddSaveGroup"];
-    onMarkTempDeleted?: FileListWithViewerProps["onMarkTempDeleted"];
-    onAddFileToCollection?: FileListWithViewerProps["onAddFileToCollection"];
-    onRemoteFilesPull?: FileListWithViewerProps["onRemoteFilesPull"];
-    fileNormalCollectionIDs?: FileListWithViewerProps["fileNormalCollectionIDs"];
-    collectionNameByID?: FileListWithViewerProps["collectionNameByID"];
-    onSelectCollection?: FileListWithViewerProps["onSelectCollection"];
-    onSelectPerson?: FileListWithViewerProps["onSelectPerson"];
-    emailByUserID: FileListWithViewerProps["emailByUserID"];
-    onSetOpenFileViewer?: (open: boolean) => void;
-    selected: SelectedState;
-    setSelected: () => void;
-}
-
-function MapLayout({
-    collectionSummary,
-    visiblePhotos,
-    visibleFiles,
-    visiblePhotosUpdating,
-    mapIndex,
-    latestFileId,
-    thumbByFileID,
-    mapComponents,
-    mapCenter,
-    optimalZoom,
-    onClose,
-    onVisiblePhotosChange,
-    onVisiblePhotosLoadingChange,
-    onPrefetchThumbnails,
-    user,
-    favoriteFileIDs,
-    pendingFavoriteUpdates,
-    pendingVisibilityUpdates,
-    onToggleFavorite,
-    onFileVisibilityUpdate,
-    onRemotePull,
-    onVisualFeedback,
-    onAddSaveGroup,
-    onMarkTempDeleted,
-    onAddFileToCollection,
-    onRemoteFilesPull,
-    fileNormalCollectionIDs,
-    collectionNameByID,
-    onSelectCollection,
-    onSelectPerson,
-    emailByUserID,
-    onSetOpenFileViewer,
-    selected,
-    setSelected,
-}: MapLayoutProps) {
-    return (
-        <Box sx={{ position: "relative", height: "100%", width: "100%" }}>
-            <CollectionSidebar
-                collectionSummary={collectionSummary}
-                visibleCount={visiblePhotos.length}
-                visibleFiles={visibleFiles}
-                isVisiblePhotosUpdating={visiblePhotosUpdating}
-                latestFileId={latestFileId}
-                thumbByFileID={thumbByFileID}
-                onClose={onClose}
-                user={user}
-                favoriteFileIDs={favoriteFileIDs}
-                pendingFavoriteUpdates={pendingFavoriteUpdates}
-                pendingVisibilityUpdates={pendingVisibilityUpdates}
-                onToggleFavorite={onToggleFavorite}
-                onFileVisibilityUpdate={onFileVisibilityUpdate}
-                onRemotePull={onRemotePull}
-                onVisualFeedback={onVisualFeedback}
-                onAddSaveGroup={onAddSaveGroup}
-                onMarkTempDeleted={onMarkTempDeleted}
-                onAddFileToCollection={onAddFileToCollection}
-                onRemoteFilesPull={onRemoteFilesPull}
-                fileNormalCollectionIDs={fileNormalCollectionIDs}
-                collectionNameByID={collectionNameByID}
-                onSelectCollection={onSelectCollection}
-                onSelectPerson={onSelectPerson}
-                emailByUserID={emailByUserID}
-                selected={selected}
-                setSelected={setSelected}
-                onSetOpenFileViewer={onSetOpenFileViewer}
-            />
-            <Box sx={{ width: "100%", height: "100%" }}>
-                <MapCanvas
-                    mapComponents={mapComponents}
-                    mapCenter={mapCenter}
-                    mapIndex={mapIndex}
-                    optimalZoom={optimalZoom}
-                    thumbByFileID={thumbByFileID}
-                    onVisiblePhotosChange={onVisiblePhotosChange}
-                    onVisiblePhotosLoadingChange={onVisiblePhotosLoadingChange}
-                    onPrefetchThumbnails={onPrefetchThumbnails}
-                />
-            </Box>
-        </Box>
-    );
-}
-
 interface CollectionSidebarProps {
     collectionSummary: CollectionSummary;
-    visibleCount: number;
     visibleFiles: EnteFile[];
     isVisiblePhotosUpdating: boolean;
     latestFileId: number | undefined;
@@ -1676,8 +1259,6 @@ interface CollectionSidebarProps {
     onSelectPerson?: FileListWithViewerProps["onSelectPerson"];
     emailByUserID: FileListWithViewerProps["emailByUserID"];
     onSetOpenFileViewer?: (open: boolean) => void;
-    selected: SelectedState;
-    setSelected: () => void;
 }
 
 const COVER_IMAGE_HEIGHT = 320;
@@ -1709,8 +1290,6 @@ function CollectionSidebar({
     onSelectPerson,
     emailByUserID,
     onSetOpenFileViewer,
-    selected,
-    setSelected,
 }: CollectionSidebarProps) {
     const [currentDate, setCurrentDate] = useState<string | undefined>(
         undefined,
@@ -1721,53 +1300,30 @@ function CollectionSidebar({
     const isDarkMode = theme.palette.mode === "dark";
     const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
-    const coverFile = collectionSummary.coverFile;
-    const coverImageUrl = useMemo(() => {
-        const coverThumb = coverFile && thumbByFileID.get(coverFile.id);
-        if (coverThumb) return coverThumb;
-
-        const fallbackId = latestFileId;
-        return fallbackId ? thumbByFileID.get(fallbackId) : undefined;
-    }, [coverFile, latestFileId, thumbByFileID]);
-
-    const coverHeader = useMemo(() => {
-        if (!shouldShowCover) return undefined;
-        return {
-            component: (
-                <MapCover
-                    name={collectionSummary.name}
-                    coverImageUrl={coverImageUrl}
-                    totalCount={collectionSummary.fileCount}
-                    onClose={onClose}
-                />
-            ),
-            height: COVER_HEADER_HEIGHT,
-            extendToInlineEdges: true,
-        };
-    }, [
-        shouldShowCover,
-        collectionSummary.name,
-        collectionSummary.fileCount,
-        coverImageUrl,
-        onClose,
-    ]);
-
-    const handleScroll = useCallback((offset: number) => {
-        setScrollOffset(offset);
-    }, []);
-
-    const handleVisibleDateChange = useCallback((date: string | undefined) => {
-        setCurrentDate(date);
-    }, []);
+    const coverImageUrl =
+        (collectionSummary.coverFile &&
+            thumbByFileID.get(collectionSummary.coverFile.id)) ||
+        (latestFileId ? thumbByFileID.get(latestFileId) : undefined);
+    const coverHeader = shouldShowCover
+        ? {
+              component: (
+                  <MapCover
+                      name={collectionSummary.name}
+                      coverImageUrl={coverImageUrl}
+                      totalCount={collectionSummary.fileCount}
+                      onClose={onClose}
+                  />
+              ),
+              height: COVER_HEADER_HEIGHT,
+              extendToInlineEdges: true,
+          }
+        : undefined;
 
     const showStickyHeader =
         !shouldShowCover ||
         (scrollOffset > COVER_HEADER_HEIGHT && !!currentDate);
-    const hasScrolled = scrollOffset > 0;
-    const hideDateForAllNoScroll = !shouldShowCover && !hasScrolled;
-    const hideDateForMobileNoScroll = isMobile && !hasScrolled;
     const visibleDate =
-        currentDate && !hideDateForAllNoScroll && !hideDateForMobileNoScroll
+        currentDate && (scrollOffset > 0 || (shouldShowCover && !isMobile))
             ? currentDate
             : undefined;
 
@@ -1802,25 +1358,17 @@ function CollectionSidebar({
                                 {visibleDate && ` · ${visibleDate}`}
                             </Typography>
                         </Box>
-                        <Box
+                        <IconButton
+                            onClick={onClose}
+                            size="small"
                             sx={{
-                                display: "flex",
-                                alignItems: "center",
-                                gap: 1,
+                                color: "text.secondary",
+                                bgcolor: "fill.faint",
+                                "&:hover": { bgcolor: "fill.muted" },
                             }}
                         >
-                            <IconButton
-                                onClick={onClose}
-                                size="small"
-                                sx={{
-                                    color: "text.secondary",
-                                    bgcolor: "fill.faint",
-                                    "&:hover": { bgcolor: "fill.muted" },
-                                }}
-                            >
-                                <CloseIcon />
-                            </IconButton>
-                        </Box>
+                            <CloseIcon />
+                        </IconButton>
                     </Box>
                 </StickyDateHeader>
                 <FileListContainer>
@@ -1847,16 +1395,21 @@ function CollectionSidebar({
                             enableImageEditing={false}
                             enableDownload={true}
                             activeCollectionID={collectionSummary.id}
-                            selected={selected}
-                            setSelected={setSelected}
+                            selected={{
+                                ownCount: 0,
+                                count: 0,
+                                context: undefined,
+                                collectionID: collectionSummary.id,
+                            }}
+                            setSelected={() => undefined}
                             onSetOpenFileViewer={onSetOpenFileViewer}
                             listBorderRadius={isMobile ? "0" : "0 0 32px 32px"}
                             header={coverHeader}
-                            onScroll={handleScroll}
-                            onVisibleDateChange={handleVisibleDateChange}
+                            onScroll={setScrollOffset}
+                            onVisibleDateChange={setCurrentDate}
                         />
                     ) : isVisiblePhotosUpdating ? null : (
-                        <EmptyState>
+                        <EmptyStateContainer>
                             {shouldShowCover && (
                                 <MapCover
                                     name={collectionSummary.name}
@@ -1879,7 +1432,7 @@ function CollectionSidebar({
                                     {t("zoom_out_to_see_photos")}
                                 </Typography>
                             </EmptyStateMessage>
-                        </EmptyState>
+                        </EmptyStateContainer>
                     )}
                 </FileListContainer>
             </SidebarContainer>
@@ -1891,10 +1444,9 @@ function CollectionSidebar({
 interface MapCanvasProps {
     mapComponents: MapComponents;
     mapCenter: [number, number];
-    mapIndex: MapIndex | null;
-    optimalZoom: number;
+    mapIndex: MapIndex;
     thumbByFileID: Map<number, string>;
-    onVisiblePhotosChange: (photosInView: MapPhotoPoint[]) => void;
+    onVisibleFileIDsChange: (fileIDs: number[]) => void;
     onVisiblePhotosLoadingChange: (loading: boolean) => void;
     onPrefetchThumbnails: (fileIDs: number[]) => void;
 }
@@ -1909,9 +1461,8 @@ const MapCanvas = React.memo(function MapCanvas({
     mapComponents,
     mapCenter,
     mapIndex,
-    optimalZoom,
     thumbByFileID,
-    onVisiblePhotosChange,
+    onVisibleFileIDsChange,
     onVisiblePhotosLoadingChange,
     onPrefetchThumbnails,
 }: MapCanvasProps) {
@@ -1921,7 +1472,7 @@ const MapCanvas = React.memo(function MapCanvas({
         <MapCanvasContainer>
             <MapContainer
                 center={mapCenter}
-                zoom={optimalZoom}
+                zoom={DEFAULT_MAP_ZOOM}
                 scrollWheelZoom
                 zoomControl={false}
                 style={{ width: "100%", height: "100%" }}
@@ -1933,19 +1484,15 @@ const MapCanvas = React.memo(function MapCanvas({
                     updateWhenZooming
                 />
                 <MapControls useMap={useMap} />
-                {mapIndex && (
-                    <MapClusters
-                        useMap={useMap}
-                        mapIndex={mapIndex}
-                        thumbByFileID={thumbByFileID}
-                        onVisiblePhotosChange={onVisiblePhotosChange}
-                        onVisiblePhotosLoadingChange={
-                            onVisiblePhotosLoadingChange
-                        }
-                        onPrefetchThumbnails={onPrefetchThumbnails}
-                        Marker={Marker}
-                    />
-                )}
+                <MapClusters
+                    useMap={useMap}
+                    mapIndex={mapIndex}
+                    thumbByFileID={thumbByFileID}
+                    onVisibleFileIDsChange={onVisibleFileIDsChange}
+                    onVisiblePhotosLoadingChange={onVisiblePhotosLoadingChange}
+                    onPrefetchThumbnails={onPrefetchThumbnails}
+                    Marker={Marker}
+                />
             </MapContainer>
         </MapCanvasContainer>
     );
@@ -2023,11 +1570,14 @@ const MapControls = React.memo(function MapControls({
     );
 });
 
+const isClusterFeature = (feature: MapFeature): feature is MapClusterFeature =>
+    feature.properties.cluster === true;
+
 interface MapClustersProps {
     useMap: typeof import("react-leaflet").useMap;
     mapIndex: MapIndex;
     thumbByFileID: Map<number, string>;
-    onVisiblePhotosChange: (photosInView: MapPhotoPoint[]) => void;
+    onVisibleFileIDsChange: (fileIDs: number[]) => void;
     onVisiblePhotosLoadingChange: (loading: boolean) => void;
     onPrefetchThumbnails: (fileIDs: number[]) => void;
     Marker: typeof import("react-leaflet").Marker;
@@ -2037,7 +1587,7 @@ const MapClusters = React.memo(function MapClusters({
     useMap,
     mapIndex,
     thumbByFileID,
-    onVisiblePhotosChange,
+    onVisibleFileIDsChange,
     onVisiblePhotosLoadingChange,
     onPrefetchThumbnails,
     Marker,
@@ -2048,12 +1598,6 @@ const MapClusters = React.memo(function MapClusters({
     const visibleRequestIdRef = useRef(0);
     const iconCacheRef = useRef(
         new Map<string, ReturnType<typeof createMarkerIcon>>(),
-    );
-
-    const isClusterFeature = useCallback(
-        (feature: MapFeature): feature is MapClusterFeature =>
-            feature.properties.cluster === true,
-        [],
     );
 
     const updateVisibleLeaves = useCallback(
@@ -2125,19 +1669,10 @@ const MapClusters = React.memo(function MapClusters({
 
             if (idsChanged) {
                 previousVisibleIdsRef.current = visibleIds;
-                const nextVisiblePhotos = leaves.map((leaf) => {
-                    const [lng, lat] = leaf.geometry.coordinates;
-                    return {
-                        lat,
-                        lng,
-                        name: "",
-                        country: "",
-                        image: "",
-                        fileId: leaf.properties.fileId,
-                    };
-                });
                 startTransition(() => {
-                    onVisiblePhotosChange(nextVisiblePhotos);
+                    onVisibleFileIDsChange(
+                        leaves.map((leaf) => leaf.properties.fileId),
+                    );
                 });
             }
 
@@ -2145,12 +1680,7 @@ const MapClusters = React.memo(function MapClusters({
                 onVisiblePhotosLoadingChange(false);
             }
         },
-        [
-            isClusterFeature,
-            mapIndex,
-            onVisiblePhotosChange,
-            onVisiblePhotosLoadingChange,
-        ],
+        [mapIndex, onVisibleFileIDsChange, onVisiblePhotosLoadingChange],
     );
 
     const updateClusters = useCallback(() => {
@@ -2192,29 +1722,14 @@ const MapClusters = React.memo(function MapClusters({
         collectTargets(clusters);
         collectTargets(mapIndex.getClusters(prefetchBbox, nextZoom));
 
-        if (prefetchTargets.size > 0) {
-            onPrefetchThumbnails(Array.from(prefetchTargets));
-        }
-    }, [
-        isClusterFeature,
-        map,
-        mapIndex,
-        onPrefetchThumbnails,
-        updateVisibleLeaves,
-    ]);
+        onPrefetchThumbnails(Array.from(prefetchTargets));
+    }, [map, mapIndex, onPrefetchThumbnails, updateVisibleLeaves]);
 
     useEffect(() => {
         iconCacheRef.current.clear();
         previousVisibleIdsRef.current = new Set();
         visibleRequestIdRef.current += 1;
     }, [mapIndex]);
-
-    const handleClusterClick = useCallback(
-        (lat: number, lng: number, expansionZoom: number) => {
-            map.setView([lat, lng], expansionZoom, { animate: true });
-        },
-        [map],
-    );
 
     useEffect(() => {
         updateClusters();
@@ -2251,12 +1766,7 @@ const MapClusters = React.memo(function MapClusters({
                     const cacheKey = `cluster-${clusterId}-${count}-${thumb}-${isInteractive ? "i" : "n"}`;
                     let icon = iconCacheRef.current.get(cacheKey);
                     if (!icon) {
-                        icon = createClusterIcon(
-                            thumb,
-                            68,
-                            count,
-                            isInteractive,
-                        );
+                        icon = createMarkerIcon(thumb, count, isInteractive);
                         if (icon) {
                             iconCacheRef.current.set(cacheKey, icon);
                         }
@@ -2270,10 +1780,10 @@ const MapClusters = React.memo(function MapClusters({
                                 isInteractive
                                     ? {
                                           click: () =>
-                                              handleClusterClick(
-                                                  lat,
-                                                  lng,
+                                              map.setView(
+                                                  [lat, lng],
                                                   expansionZoom,
+                                                  { animate: true },
                                               ),
                                       }
                                     : undefined
@@ -2287,7 +1797,7 @@ const MapClusters = React.memo(function MapClusters({
                 const cacheKey = `point-${fileId}-${thumb}`;
                 let icon = iconCacheRef.current.get(cacheKey);
                 if (!icon) {
-                    icon = createMarkerIcon(thumb, 68);
+                    icon = createMarkerIcon(thumb);
                     if (icon) {
                         iconCacheRef.current.set(cacheKey, icon);
                     }
@@ -2306,20 +1816,13 @@ const MapClusters = React.memo(function MapClusters({
 
 const FloatingIconButton: React.FC<IconButtonProps> = ({ sx, ...props }) => {
     const baseSx = {
-        bgcolor: (theme: {
-            vars: { palette: { background: { paper: string } } };
-        }) => theme.vars.palette.background.paper,
-        boxShadow: (theme: { shadows: string[] }) => theme.shadows[4],
+        bgcolor: "background.paper",
+        boxShadow: 4,
         width: 48,
         height: 48,
         borderRadius: "16px",
         transition: "transform 0.2s ease-out",
-        "&:hover": {
-            bgcolor: (theme: {
-                vars: { palette: { background: { paper: string } } };
-            }) => theme.vars.palette.background.paper,
-            transform: "scale(1.05)",
-        },
+        "&:hover": { bgcolor: "background.paper", transform: "scale(1.05)" },
     };
 
     const mergedSx =
@@ -2353,10 +1856,6 @@ function CenteredBox({ children, onClose, closeLabel }: CenteredBoxProps) {
             {children}
         </CenteredBoxContainer>
     );
-}
-
-function EmptyState({ children }: React.PropsWithChildren) {
-    return <EmptyStateContainer>{children}</EmptyStateContainer>;
 }
 
 interface MapCoverProps {
@@ -2431,7 +1930,7 @@ const CoverImageContainer = styled(Box)(({ theme }) => ({
     backgroundColor: "#333",
     borderRadius: "36px 36px 24px 24px",
     marginTop: "2px",
-    [theme.breakpoints.down("md")]: { borderRadius: "20px 20px 20px 20px" },
+    [theme.breakpoints.down("md")]: { borderRadius: "20px" },
 }));
 
 const CoverGradientOverlay = styled(Box)({
@@ -2516,7 +2015,6 @@ const SidebarGradient = styled(Box)(({ theme }) => ({
     background:
         "linear-gradient(to top, rgba(0,0,0,1) 0%, rgba(0,0,0,0.65) 2%, rgba(0,0,0,0) 100%)",
     pointerEvents: "none",
-    borderRadius: "0",
     [theme.breakpoints.up("md")]: {
         height: "150px",
         borderRadius: "0 0 48px 48px",
@@ -2531,10 +2029,8 @@ const FileListContainer = styled(Box)(({ theme }) => ({
     flexDirection: "column",
     paddingLeft: "8px",
     paddingRight: "8px",
-    paddingTop: "0px",
     paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 16px)",
     [theme.breakpoints.up("md")]: {
-        paddingTop: "0px",
         paddingLeft: "16px",
         paddingRight: "16px",
         paddingBottom: "18px",
@@ -2583,9 +2079,6 @@ const EmptyStateContainer = styled(Box)(({ theme }) => ({
     position: "relative",
     display: "flex",
     flexDirection: "column",
-    alignItems: "stretch",
-    justifyContent: "flex-start",
-    paddingTop: 0,
     paddingBottom: theme.spacing(4),
     color: theme.vars.palette.text.secondary,
     overflow: "auto",

--- a/web/apps/photos/src/components/Collections/CollectionMapDialog.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionMapDialog.tsx
@@ -311,7 +311,8 @@ const buildMapIndexPoints = async (files: EnteFile[]) => {
     let latestFileId: number | undefined;
 
     for (let index = 0; index < files.length; index += 1) {
-        const file = files[index]!;
+        const file = files[index];
+        if (!file) continue;
         const loc = fileLocation(file);
         if (!loc) continue;
 

--- a/web/apps/photos/src/components/Collections/CollectionMapDialog.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionMapDialog.tsx
@@ -1305,20 +1305,30 @@ function CollectionSidebar({
         (collectionSummary.coverFile &&
             thumbByFileID.get(collectionSummary.coverFile.id)) ||
         (latestFileId ? thumbByFileID.get(latestFileId) : undefined);
-    const coverHeader = shouldShowCover
-        ? {
-              component: (
-                  <MapCover
-                      name={collectionSummary.name}
-                      coverImageUrl={coverImageUrl}
-                      totalCount={collectionSummary.fileCount}
-                      onClose={onClose}
-                  />
-              ),
-              height: COVER_HEADER_HEIGHT,
-              extendToInlineEdges: true,
-          }
-        : undefined;
+    const coverHeader = useMemo(
+        () =>
+            shouldShowCover
+                ? {
+                      component: (
+                          <MapCover
+                              name={collectionSummary.name}
+                              coverImageUrl={coverImageUrl}
+                              totalCount={collectionSummary.fileCount}
+                              onClose={onClose}
+                          />
+                      ),
+                      height: COVER_HEADER_HEIGHT,
+                      extendToInlineEdges: true,
+                  }
+                : undefined,
+        [
+            shouldShowCover,
+            collectionSummary.name,
+            collectionSummary.fileCount,
+            coverImageUrl,
+            onClose,
+        ],
+    );
 
     const showStickyHeader =
         !shouldShowCover ||

--- a/web/apps/photos/src/components/Collections/CollectionMapDialog.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionMapDialog.tsx
@@ -1,4 +1,5 @@
 import type { RemotePullOpts } from "@/components/gallery";
+import type { SelectedState } from "@/utils/file";
 import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
@@ -1301,6 +1302,17 @@ function CollectionSidebar({
     const isDarkMode = theme.palette.mode === "dark";
     const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
+    const emptySelected = useMemo<SelectedState>(
+        () => ({
+            ownCount: 0,
+            count: 0,
+            context: undefined,
+            collectionID: collectionSummary.id,
+        }),
+        [collectionSummary.id],
+    );
+    const noOpSetSelected = useCallback(() => undefined, []);
+
     const coverImageUrl =
         (collectionSummary.coverFile &&
             thumbByFileID.get(collectionSummary.coverFile.id)) ||
@@ -1406,13 +1418,8 @@ function CollectionSidebar({
                             enableImageEditing={false}
                             enableDownload={true}
                             activeCollectionID={collectionSummary.id}
-                            selected={{
-                                ownCount: 0,
-                                count: 0,
-                                context: undefined,
-                                collectionID: collectionSummary.id,
-                            }}
-                            setSelected={() => undefined}
+                            selected={emptySelected}
+                            setSelected={noOpSetSelected}
                             onSetOpenFileViewer={onSetOpenFileViewer}
                             listBorderRadius={isMobile ? "0" : "0 0 32px 32px"}
                             header={coverHeader}

--- a/web/apps/photos/src/components/Collections/GalleryBarAndListHeader.tsx
+++ b/web/apps/photos/src/components/Collections/GalleryBarAndListHeader.tsx
@@ -63,20 +63,11 @@ type GalleryBarAndListHeaderProps = Omit<
     canCreateAlbum: boolean;
 } & Pick<
         CollectionHeaderProps,
-        | "files"
-        | "mapFileSource"
         | "onRemotePull"
         | "onAddSaveGroup"
-        | "onMarkTempDeleted"
-        | "onAddFileToCollection"
-        | "onRemoteFilesPull"
-        | "onVisualFeedback"
-        | "fileNormalCollectionIDs"
-        | "collectionNameByID"
-        | "onSelectCollection"
-        | "onSelectPerson"
         | "canSetAlbumCover"
         | "onSetAlbumCover"
+        | "onShowMap"
     > &
     Pick<
         CollectionShareProps,
@@ -97,12 +88,11 @@ export const GalleryBarAndListHeader: React.FC<
     setActiveCollectionID,
     setBlockingLoad,
     people,
+    onSelectPerson,
     allPeople,
     saveGroups,
     canCreateAlbum,
     hasActiveFileSelection,
-    files,
-    mapFileSource,
     activePerson,
     emailByUserID,
     shareSuggestionEmails,
@@ -110,14 +100,7 @@ export const GalleryBarAndListHeader: React.FC<
     canSetAlbumCover,
     onSetAlbumCover,
     onAddSaveGroup,
-    onMarkTempDeleted,
-    onAddFileToCollection,
-    onRemoteFilesPull,
-    onVisualFeedback,
-    fileNormalCollectionIDs,
-    collectionNameByID,
-    onSelectCollection,
-    onSelectPerson,
+    onShowMap,
     setFileListHeader,
 }) => {
     const { show: showAllAlbums, props: allAlbumsVisibilityProps } =
@@ -197,21 +180,11 @@ export const GalleryBarAndListHeader: React.FC<
                 <CollectionHeader
                     {...{
                         activeCollection,
-                        files,
-                        mapFileSource,
                         setActiveCollectionID,
                         isActiveCollectionDownloadInProgress,
                         onRemotePull,
                         onAddSaveGroup,
-                        onMarkTempDeleted,
-                        onAddFileToCollection,
-                        onRemoteFilesPull,
-                        onVisualFeedback,
-                        fileNormalCollectionIDs,
-                        collectionNameByID,
-                        emailByUserID,
-                        onSelectCollection,
-                        onSelectPerson,
+                        onShowMap,
                     }}
                     collectionSummary={collectionSummary}
                     onCollectionShare={openCollectionShare}
@@ -246,8 +219,6 @@ export const GalleryBarAndListHeader: React.FC<
         activeCollection,
         activeCollectionID,
         isActiveCollectionDownloadInProgress,
-        files,
-        mapFileSource,
         activePerson,
         showCollectionShare,
         openCollectionShare,
@@ -256,15 +227,7 @@ export const GalleryBarAndListHeader: React.FC<
         hasActiveFileSelection,
         onRemotePull,
         onAddSaveGroup,
-        onMarkTempDeleted,
-        onAddFileToCollection,
-        onRemoteFilesPull,
-        onVisualFeedback,
-        fileNormalCollectionIDs,
-        collectionNameByID,
-        emailByUserID,
-        onSelectCollection,
-        onSelectPerson,
+        onShowMap,
         canSetAlbumCover,
         onSetAlbumCover,
         // TODO: Cluster

--- a/web/apps/photos/src/components/FileListWithViewer.tsx
+++ b/web/apps/photos/src/components/FileListWithViewer.tsx
@@ -1,12 +1,9 @@
-import { CollectionMapDialog } from "@/components/Collections/CollectionMapDialog";
 import type { RemotePullOpts } from "@/components/gallery";
 import { downloadAndSaveFiles } from "@/services/save";
 import { uploadManager } from "@/services/upload-manager";
 import { fileTimelineDateString } from "@/utils/file";
 import { IconButton, Tooltip, styled } from "@mui/material";
 import { useColorScheme, useTheme } from "@mui/material/styles";
-import { useModalVisibility } from "ente-base/components/utils/modal";
-import { useBaseContext } from "ente-base/context";
 import type { AddSaveGroup } from "ente-gallery/components/utils/save-groups";
 import {
     FileViewer,
@@ -16,11 +13,9 @@ import {
 import type { Collection } from "ente-media/collection";
 import type { EnteFile } from "ente-media/file";
 import { fileFileName } from "ente-media/file-metadata";
-import { useSettingsSnapshot } from "ente-new/photos/components/utils/use-snapshot";
 import { moveToTrash } from "ente-new/photos/services/collection";
 import type { CollectionSummary } from "ente-new/photos/services/collection-summary";
 import { PseudoCollectionID } from "ente-new/photos/services/collection-summary";
-import { updateMapEnabled } from "ente-new/photos/services/settings";
 import { usePhotosAppContext } from "ente-new/photos/types/context";
 import { t } from "i18next";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -33,21 +28,13 @@ import {
 
 export type FileListWithViewerProps = {
     files: EnteFile[];
-    mapFileSource?: {
-        collectionFiles: EnteFile[];
-        favoriteFileIDs: Set<number>;
-        hiddenFileIDs: Set<number>;
-        archivedFileIDs: Set<number>;
-        tempDeletedFileIDs: Set<number>;
-        tempHiddenFileIDs: Set<number>;
-    };
+    onShowMap?: () => void;
     enableDownload?: boolean;
     enableImageEditing?: boolean;
     onMarkTempDeleted?: (files: EnteFile[]) => void;
     onSetOpenFileViewer?: (open: boolean) => void;
     onRemotePull: (opts?: RemotePullOpts) => Promise<void>;
     activeCollectionSummary?: CollectionSummary;
-    activeCollection?: Collection;
     pendingFileIndex?: number;
     pendingFileSidebar?: FileViewerInitialSidebar;
     pendingHighlightCommentID?: string;
@@ -118,7 +105,6 @@ export const FileListWithViewer: React.FC<FileListWithViewerProps> = ({
     activeCollectionID,
     activePersonID,
     activeCollectionSummary,
-    activeCollection,
     favoriteFileIDs,
     emailByUserID,
     listBorderRadius,
@@ -154,7 +140,7 @@ export const FileListWithViewer: React.FC<FileListWithViewerProps> = ({
     pendingFileSidebar,
     pendingHighlightCommentID,
     onPendingNavigationConsumed,
-    mapFileSource,
+    onShowMap,
 }) => {
     const [openFileViewer, setOpenFileViewer] = useState(false);
     const [currentIndex, setCurrentIndex] = useState(0);
@@ -164,11 +150,7 @@ export const FileListWithViewer: React.FC<FileListWithViewerProps> = ({
     const [highlightCommentID, setHighlightCommentID] = useState<
         string | undefined
     >(undefined);
-    const { show: showMapDialog, props: mapDialogVisibilityProps } =
-        useModalVisibility();
-    const { onGenericError } = useBaseContext();
     const { showNotification } = usePhotosAppContext();
-    const { mapEnabled } = useSettingsSnapshot();
     const { mode: colorSchemeMode, systemMode } = useColorScheme();
     const theme = useTheme();
     const resolvedMode =
@@ -259,22 +241,10 @@ export const FileListWithViewer: React.FC<FileListWithViewerProps> = ({
     }, [enableImageEditing, showNotification]);
 
     const shouldShowMapButton =
+        !!onShowMap &&
         modePlus !== "search" &&
         activeCollectionSummary?.type === "all" &&
         (activeCollectionSummary.fileCount > 0 || files.length > 0);
-
-    const handleShowMap = useCallback(async () => {
-        if (!activeCollectionSummary) return;
-        if (!mapEnabled) {
-            try {
-                await updateMapEnabled(true);
-            } catch (e) {
-                onGenericError(e);
-                return;
-            }
-        }
-        showMapDialog();
-    }, [activeCollectionSummary, mapEnabled, onGenericError, showMapDialog]);
 
     const headerWithMap = useMemo(() => {
         if (!shouldShowMapButton || !header) return header;
@@ -288,7 +258,7 @@ export const FileListWithViewer: React.FC<FileListWithViewerProps> = ({
                             className="map-button"
                             size="small"
                             aria-label={t("map")}
-                            onClick={handleShowMap}
+                            onClick={onShowMap}
                         >
                             <MapIcon
                                 src="/images/gallery-globe/globe.svg"
@@ -301,7 +271,7 @@ export const FileListWithViewer: React.FC<FileListWithViewerProps> = ({
                 </HeaderWithMap>
             ),
         };
-    }, [header, handleShowMap, isDarkMode, shouldShowMapButton]);
+    }, [header, isDarkMode, onShowMap, shouldShowMapButton]);
 
     return (
         <Container>
@@ -376,28 +346,6 @@ export const FileListWithViewer: React.FC<FileListWithViewerProps> = ({
                 onAddFileToCollection={onAddFileToCollection}
                 activeCollectionID={activeCollectionID}
             />
-            {shouldShowMapButton && (
-                <CollectionMapDialog
-                    {...mapDialogVisibilityProps}
-                    collectionSummary={activeCollectionSummary}
-                    activeCollection={activeCollection}
-                    files={files}
-                    mapFileSource={mapFileSource}
-                    onRemotePull={onRemotePull}
-                    {...{
-                        onAddSaveGroup,
-                        onMarkTempDeleted,
-                        onAddFileToCollection,
-                        onRemoteFilesPull,
-                        onVisualFeedback,
-                        fileNormalCollectionIDs,
-                        collectionNameByID,
-                        emailByUserID,
-                        onSelectCollection,
-                        onSelectPerson,
-                    }}
-                />
-            )}
         </Container>
     );
 };

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -8,6 +8,7 @@ import {
     CollectionSelector,
     type CollectionSelectorAttributes,
 } from "@/components/CollectionSelector";
+import { CollectionMapDialog } from "@/components/Collections/CollectionMapDialog";
 import { GalleryBarAndListHeader } from "@/components/Collections/GalleryBarAndListHeader";
 import { PickCoverPhotoDialog } from "@/components/Collections/PickCoverPhotoDialog";
 import { Export } from "@/components/Export";
@@ -153,7 +154,10 @@ import type {
     SearchOption,
     SidebarActionID,
 } from "ente-new/photos/services/search/types";
-import { initSettings } from "ente-new/photos/services/settings";
+import {
+    initSettings,
+    updateMapEnabled,
+} from "ente-new/photos/services/settings";
 import {
     redirectToCustomerPortal,
     savedUserDetailsOrTriggerPull,
@@ -224,7 +228,7 @@ const Page: React.FC = () => {
     const [collectionSelectorAttributes, setCollectionSelectorAttributes] =
         useState<CollectionSelectorAttributes | undefined>();
 
-    const { customDomain } = useSettingsSnapshot();
+    const { customDomain, mapEnabled } = useSettingsSnapshot();
     const userDetails = useUserDetailsSnapshot();
     const peopleState = usePeopleStateSnapshot();
 
@@ -281,6 +285,22 @@ const Page: React.FC = () => {
         show: showPickCoverPhotoDialog,
         props: pickCoverPhotoDialogVisibilityProps,
     } = useModalVisibility();
+    const { show: showCollectionMap, props: collectionMapVisibilityProps } =
+        useModalVisibility();
+
+    const handleShowCollectionMap = useCallback(() => {
+        void (async () => {
+            if (!mapEnabled) {
+                try {
+                    await updateMapEnabled(true);
+                } catch (e) {
+                    onGenericError(e);
+                    return;
+                }
+            }
+            showCollectionMap();
+        })();
+    }, [mapEnabled, onGenericError, showCollectionMap]);
 
     const [addToAlbumProgress, setAddToAlbumProgress] = useState<{
         open: boolean;
@@ -1907,24 +1927,14 @@ const Page: React.FC = () => {
                     // component need to be updated.
                     activeCollection: activeCollection!,
                     activeCollectionID: activeCollectionID!,
-                    files: activeCollection
-                        ? activeCollectionFiles
-                        : filteredFiles,
-                    mapFileSource,
                     activePerson,
                     setFileListHeader,
                     saveGroups,
                     canCreateAlbum: !isInArchiveSection,
                     onAddSaveGroup,
-                    onMarkTempDeleted: handleMarkTempDeleted,
-                    onAddFileToCollection: handleAddSingleFileToCollection,
-                    onRemoteFilesPull: remoteFilesPull,
-                    onVisualFeedback: handleVisualFeedback,
-                    fileNormalCollectionIDs,
-                    collectionNameByID,
-                    onSelectCollection: handleSelectCollection,
                     canSetAlbumCover: isOwnedAlbumEligibleForCover,
                     onSetAlbumCover: handleOpenPickCoverPhotoDialog,
+                    onShowMap: handleShowCollectionMap,
                 }}
                 mode={barMode}
                 shouldHide={isInSearchMode}
@@ -2017,7 +2027,7 @@ const Page: React.FC = () => {
                     footer={fileListFooter}
                     user={user}
                     files={filteredFiles}
-                    mapFileSource={mapFileSource}
+                    onShowMap={handleShowCollectionMap}
                     enableDownload={true}
                     disableGrouping={state.searchSuggestion?.type == "clip"}
                     enableSelect={true}
@@ -2026,7 +2036,6 @@ const Page: React.FC = () => {
                     // TODO: Incorrect assertion, need to update the type
                     activeCollectionID={activeCollectionID!}
                     activeCollectionSummary={activeCollectionSummary}
-                    activeCollection={activeCollection}
                     activePersonID={activePerson?.id}
                     isInIncomingSharedCollection={activeCollectionSummary?.attributes.has(
                         "sharedIncoming",
@@ -2068,6 +2077,27 @@ const Page: React.FC = () => {
                     onPendingNavigationConsumed={
                         handlePendingNavigationConsumed
                     }
+                />
+            )}
+            {activeCollectionSummary && (
+                <CollectionMapDialog
+                    {...collectionMapVisibilityProps}
+                    collectionSummary={activeCollectionSummary}
+                    files={
+                        activeCollection ? activeCollectionFiles : filteredFiles
+                    }
+                    mapFileSource={mapFileSource}
+                    onRemotePull={remotePull}
+                    onAddSaveGroup={onAddSaveGroup}
+                    onMarkTempDeleted={handleMarkTempDeleted}
+                    onAddFileToCollection={handleAddSingleFileToCollection}
+                    onRemoteFilesPull={remoteFilesPull}
+                    onVisualFeedback={handleVisualFeedback}
+                    fileNormalCollectionIDs={fileNormalCollectionIDs}
+                    collectionNameByID={collectionNameByID}
+                    emailByUserID={state.emailByUserID}
+                    onSelectCollection={handleSelectCollection}
+                    onSelectPerson={handleSelectPerson}
                 />
             )}
             {activeCollection && (

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -287,6 +287,7 @@ const Page: React.FC = () => {
     } = useModalVisibility();
     const { show: showCollectionMap, props: collectionMapVisibilityProps } =
         useModalVisibility();
+    const closeCollectionMap = collectionMapVisibilityProps.onClose;
 
     const handleShowCollectionMap = useCallback(() => {
         void (async () => {
@@ -621,6 +622,15 @@ const Page: React.FC = () => {
         const href = `/gallery${collectionURL}`;
         void router.push(href, undefined, { shallow: true });
     }, [activeCollectionID, router.isReady]);
+
+    // The map dialog is only mounted when there is an active collection
+    // summary, and MUI only invokes onClose for escape / backdrop dismissal,
+    // so if the user navigates somewhere without one (e.g. to a person) while
+    // the map is open, the open flag would stay latched and the map would
+    // reopen on the next visit to an albums view unless we reset it here.
+    useEffect(() => {
+        if (!activeCollectionSummary) closeCollectionMap();
+    }, [activeCollectionSummary, closeCollectionMap]);
 
     useEffect(() => {
         if (router.isReady && haveMasterKeyInSession()) {
@@ -1468,18 +1478,26 @@ const Page: React.FC = () => {
         [],
     );
 
+    // These can be invoked from the file viewer hosted by the map dialog, so
+    // close the map (if open) to land the user in the gallery grid instead of
+    // silently swapping the contents of the still open map.
     const handleSelectCollection = useCallback(
-        (collectionID: number) =>
+        (collectionID: number) => {
+            closeCollectionMap();
             dispatch({
                 type: "showCollectionSummary",
                 collectionSummaryID: collectionID,
-            }),
-        [],
+            });
+        },
+        [closeCollectionMap],
     );
 
     const handleSelectPerson = useCallback(
-        (personID: string) => dispatch({ type: "showPerson", personID }),
-        [],
+        (personID: string) => {
+            closeCollectionMap();
+            dispatch({ type: "showPerson", personID });
+        },
+        [closeCollectionMap],
     );
 
     const handleOpenCollectionSelector = useCallback(

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -623,11 +623,6 @@ const Page: React.FC = () => {
         void router.push(href, undefined, { shallow: true });
     }, [activeCollectionID, router.isReady]);
 
-    // The map dialog is only mounted when there is an active collection
-    // summary, and MUI only invokes onClose for escape / backdrop dismissal,
-    // so if the user navigates somewhere without one (e.g. to a person) while
-    // the map is open, the open flag would stay latched and the map would
-    // reopen on the next visit to an albums view unless we reset it here.
     useEffect(() => {
         if (!activeCollectionSummary) closeCollectionMap();
     }, [activeCollectionSummary, closeCollectionMap]);
@@ -1478,9 +1473,6 @@ const Page: React.FC = () => {
         [],
     );
 
-    // These can be invoked from the file viewer hosted by the map dialog, so
-    // close the map (if open) to land the user in the gallery grid instead of
-    // silently swapping the contents of the still open map.
     const handleSelectCollection = useCallback(
         (collectionID: number) => {
             closeCollectionMap();


### PR DESCRIPTION
## Description

This PR refactors CollectionMapDialog so that `gallery.tsx` is the single consumer of the components, removing the prop drilling in favour of a single trigger function. Specifically, it:

* Uses parent-provided map and favorite data, removing redundant IndexedDB reads and fallback discovery.
* Stores visible file IDs instead of larger placeholder photo objects, reducing state and transformation overhead.
* Removes the intermediate MapLayout, useVisiblePhotos, unnecessary memoization, and wrapper callbacks.
* Uses the official Supercluster and React-Leaflet types instead of maintaining extensive custom type definitions.
* Consolidates point and cluster marker generation into one function, and simplifies equivalent-file selection, sidebar rendering, and styling.

