### PR TITLE
[mobile] Add shared PIN input component

### DIFF
--- a/mobile/apps/photos/lib/ui/account/ott_verification_page.dart
+++ b/mobile/apps/photos/lib/ui/account/ott_verification_page.dart
@@ -2,7 +2,6 @@ import "package:ente_components/ente_components.dart";
 import "package:ente_strings/ente_strings.dart";
 import 'package:flutter/material.dart';
 import 'package:photos/services/account/user_service.dart';
-import "package:pinput/pinput.dart";
 
 class OTTVerificationPage extends StatefulWidget {
   final String email;
@@ -108,31 +107,6 @@ class _OTTVerificationPageState extends State<OTTVerificationPage> {
 
   Widget _getBody() {
     final colors = context.componentColors;
-    final defaultPinTheme = PinTheme(
-      height: 52,
-      width: 48,
-      textStyle: TextStyles.body.copyWith(color: colors.textBase),
-      decoration: BoxDecoration(
-        border: Border.all(color: colors.strokeFaint),
-        borderRadius: BorderRadius.circular(20),
-      ),
-    );
-
-    final focusedPinTheme = defaultPinTheme.copyWith(
-      decoration: BoxDecoration(
-        border: Border.all(color: colors.primary, width: 2),
-        borderRadius: BorderRadius.circular(20),
-      ),
-    );
-
-    final submittedPinTheme = defaultPinTheme.copyWith(
-      textStyle: TextStyles.h1.copyWith(color: colors.primary),
-      decoration: BoxDecoration(
-        color: colors.primaryLight,
-        border: Border.all(color: colors.primary, width: 2),
-        borderRadius: BorderRadius.circular(20),
-      ),
-    );
 
     return SafeArea(
       child: Padding(
@@ -156,15 +130,10 @@ class _OTTVerificationPageState extends State<OTTVerificationPage> {
             ),
             const SizedBox(height: 32),
             Center(
-              child: Pinput(
+              child: PinInputComponent(
                 length: 6,
                 controller: _pinController,
                 autofocus: true,
-                defaultPinTheme: defaultPinTheme,
-                focusedPinTheme: focusedPinTheme,
-                submittedPinTheme: submittedPinTheme,
-                followingPinTheme: defaultPinTheme,
-                keyboardType: TextInputType.number,
                 onChanged: (String pin) {
                   setState(() {
                     _code = pin;

--- a/mobile/apps/photos/lib/ui/account/ott_verification_page.dart
+++ b/mobile/apps/photos/lib/ui/account/ott_verification_page.dart
@@ -134,6 +134,7 @@ class _OTTVerificationPageState extends State<OTTVerificationPage> {
                 length: 6,
                 controller: _pinController,
                 autofocus: true,
+                autofillHints: const [AutofillHints.oneTimeCode],
                 onChanged: (String pin) {
                   setState(() {
                     _code = pin;

--- a/mobile/packages/accounts/lib/pages/ott_verification_page.dart
+++ b/mobile/packages/accounts/lib/pages/ott_verification_page.dart
@@ -172,6 +172,7 @@ class _OTTVerificationPageState extends State<OTTVerificationPage> {
                 length: 6,
                 controller: _pinController,
                 autofocus: true,
+                autofillHints: const [AutofillHints.oneTimeCode],
                 onCompleted: (value) {
                   if (value.length == 6) {
                     onPressed();

--- a/mobile/packages/accounts/lib/pages/ott_verification_page.dart
+++ b/mobile/packages/accounts/lib/pages/ott_verification_page.dart
@@ -1,11 +1,11 @@
 import 'package:dots_indicator/dots_indicator.dart';
 import 'package:ente_accounts/ente_accounts.dart';
+import 'package:ente_components/ente_components.dart';
 import 'package:ente_strings/ente_strings.dart';
 import 'package:ente_ui/components/buttons/dynamic_fab.dart';
 import 'package:ente_ui/theme/ente_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:pinput/pinput.dart';
 
 class OTTVerificationPage extends StatefulWidget {
   final String email;
@@ -146,33 +146,6 @@ class _OTTVerificationPageState extends State<OTTVerificationPage> {
     final colorScheme = getEnteColorScheme(context);
     final textTheme = getEnteTextTheme(context);
 
-    final defaultPinTheme = PinTheme(
-      height: 48,
-      width: 48,
-      decoration: BoxDecoration(
-        color: colorScheme.backdropBase,
-        border: Border.all(color: colorScheme.strokeFaint, width: 1.75),
-        borderRadius: BorderRadius.circular(18),
-      ),
-    );
-
-    final focusedPinTheme = defaultPinTheme.copyWith(
-      decoration: BoxDecoration(
-        color: colorScheme.backdropBase,
-        border: Border.all(color: colorScheme.primary700, width: 1.75),
-        borderRadius: BorderRadius.circular(18),
-      ),
-    );
-
-    final submittedPinTheme = defaultPinTheme.copyWith(
-      textStyle: textTheme.h3Bold.copyWith(color: colorScheme.primary700),
-      decoration: BoxDecoration(
-        color: colorScheme.backdropBase,
-        border: Border.all(color: colorScheme.strokeFaint, width: 1.75),
-        borderRadius: BorderRadius.circular(18),
-      ),
-    );
-
     return SafeArea(
       child: SingleChildScrollView(
         child: Padding(
@@ -195,15 +168,10 @@ class _OTTVerificationPageState extends State<OTTVerificationPage> {
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 32),
-              Pinput(
+              PinInputComponent(
                 length: 6,
                 controller: _pinController,
                 autofocus: true,
-                defaultPinTheme: defaultPinTheme,
-                focusedPinTheme: focusedPinTheme,
-                submittedPinTheme: submittedPinTheme,
-                showCursor: false,
-                keyboardType: TextInputType.number,
                 onCompleted: (value) {
                   if (value.length == 6) {
                     onPressed();

--- a/mobile/packages/ente_components/example/lib/main.dart
+++ b/mobile/packages/ente_components/example/lib/main.dart
@@ -282,6 +282,12 @@ class _CatalogHomeState extends State<CatalogHome> {
         previewBuilder: (_) => const _TextInputPreview(),
       ),
       CatalogSection(
+        title: 'PIN input',
+        icon: HugeIcons.strokeRoundedLockPassword,
+        components: const ['Six-digit OTP', 'Obscured PIN', 'Error state'],
+        previewBuilder: (_) => const _PinInputPreview(),
+      ),
+      CatalogSection(
         title: 'Selection controls',
         icon: HugeIcons.strokeRoundedSlidersHorizontal,
         components: const ['Checkbox', 'Radio', 'Switch', 'Slider', 'Stepper'],
@@ -2445,6 +2451,77 @@ class _TextInputPreviewIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return _CatalogHugeIcon(icon, color: context.componentColors.textLighter);
+  }
+}
+
+class _PinInputPreview extends StatefulWidget {
+  const _PinInputPreview();
+
+  @override
+  State<_PinInputPreview> createState() => _PinInputPreviewState();
+}
+
+class _PinInputPreviewState extends State<_PinInputPreview> {
+  late final TextEditingController _otpController;
+  late final TextEditingController _pinController;
+  late final TextEditingController _errorController;
+
+  @override
+  void initState() {
+    super.initState();
+    _otpController = TextEditingController(text: '888');
+    _pinController = TextEditingController(text: '12');
+    _errorController = TextEditingController(text: '8051');
+  }
+
+  @override
+  void dispose() {
+    _otpController.dispose();
+    _pinController.dispose();
+    _errorController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _CatalogPreviewList(
+      children: [
+        _CatalogPreviewGroup(
+          title: 'Six-digit OTP',
+          child: Center(
+            child: PinInputComponent(
+              controller: _otpController,
+              autofocus: true,
+              autofillHints: const [AutofillHints.oneTimeCode],
+              semanticLabel: 'Six-digit one-time code',
+            ),
+          ),
+        ),
+        _CatalogPreviewGroup(
+          title: 'Obscured PIN',
+          child: Center(
+            child: PinInputComponent(
+              length: 4,
+              controller: _pinController,
+              obscureText: true,
+              semanticLabel: 'Four-digit PIN',
+            ),
+          ),
+        ),
+        _CatalogPreviewGroup(
+          title: 'Error state',
+          child: Center(
+            child: PinInputComponent(
+              length: 4,
+              controller: _errorController,
+              obscureText: true,
+              isError: true,
+              semanticLabel: 'Incorrect four-digit PIN',
+            ),
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/mobile/packages/ente_components/lib/components/pin_input_component.dart
+++ b/mobile/packages/ente_components/lib/components/pin_input_component.dart
@@ -98,12 +98,30 @@ class _PinInputComponentState extends State<PinInputComponent> {
   }
 
   void _synchronizeController() {
-    final sanitizedText = _sanitizeValue(widget.controller.text);
-    _lastControllerText = sanitizedText;
+    final controller = widget.controller;
+    final controllerText = controller.text;
+    final sanitizedText = _sanitizeValue(controllerText);
+    _lastControllerText = controllerText;
     _value = sanitizedText;
-    if (widget.controller.text != sanitizedText) {
-      _replaceControllerText(sanitizedText);
+    if (controllerText == sanitizedText) {
+      return;
     }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || widget.controller != controller) {
+        return;
+      }
+      final currentText = controller.text;
+      final sanitizedCurrentText = _sanitizeValue(currentText);
+      if (currentText == sanitizedCurrentText) {
+        return;
+      }
+      _lastControllerText = sanitizedCurrentText;
+      if (_value != sanitizedCurrentText) {
+        setState(() => _value = sanitizedCurrentText);
+      }
+      _replaceControllerText(sanitizedCurrentText);
+    });
   }
 
   void _handleControllerChanged() {
@@ -121,6 +139,9 @@ class _PinInputComponentState extends State<PinInputComponent> {
       setState(() => _value = controllerText);
     }
     widget.onChanged?.call(controllerText);
+    if (widget.controller.text != controllerText) {
+      return;
+    }
 
     if (controllerText.length != widget.length) {
       _lastCompletedValue = null;
@@ -221,6 +242,7 @@ class _PinInputComponentState extends State<PinInputComponent> {
       autofillHints: widget.autofillHints,
       autocorrect: false,
       enableSuggestions: false,
+      enableIMEPersonalizedLearning: false,
       obscureText: widget.obscureText,
       obscuringCharacter: widget.obscuringCharacter,
       inputFormatters: [

--- a/mobile/packages/ente_components/lib/components/pin_input_component.dart
+++ b/mobile/packages/ente_components/lib/components/pin_input_component.dart
@@ -1,0 +1,338 @@
+import 'package:ente_components/theme/colors.dart';
+import 'package:ente_components/theme/motion.dart';
+import 'package:ente_components/theme/radii.dart';
+import 'package:ente_components/theme/text_styles.dart';
+import 'package:ente_components/theme/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// A fixed-length numeric input rendered as individual code boxes.
+///
+/// The caller owns [controller]; the component manages its focus internally.
+/// Set [useNativeKeyboard] to false when a caller-managed keypad updates the
+/// controller directly.
+///
+/// Figma:
+/// https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=2275-11846&m=dev
+/// https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=7634-53618&m=dev
+class PinInputComponent extends StatefulWidget {
+  const PinInputComponent({
+    super.key,
+    required this.controller,
+    this.length = 6,
+    this.autofocus = false,
+    this.useNativeKeyboard = true,
+    this.obscureText = false,
+    this.obscuringCharacter = '•',
+    this.isError = false,
+    this.isDisabled = false,
+    this.autofillHints,
+    this.semanticLabel,
+    this.onChanged,
+    this.onCompleted,
+  }) : assert(length > 0),
+       assert(obscuringCharacter.length == 1);
+
+  final int length;
+  final TextEditingController controller;
+  final bool autofocus;
+  final bool useNativeKeyboard;
+  final bool obscureText;
+  final String obscuringCharacter;
+  final bool isError;
+  final bool isDisabled;
+  final Iterable<String>? autofillHints;
+  final String? semanticLabel;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onCompleted;
+
+  @override
+  State<PinInputComponent> createState() => _PinInputComponentState();
+}
+
+class _PinInputComponentState extends State<PinInputComponent> {
+  static const _boxWidth = 49.0;
+  static const _boxHeight = 52.0;
+  static const _boxGap = 6.0;
+
+  final FocusNode _focusNode = FocusNode();
+  String _value = '';
+  String _lastControllerText = '';
+  String? _lastCompletedValue;
+
+  @override
+  void initState() {
+    super.initState();
+    _synchronizeController();
+    widget.controller.addListener(_handleControllerChanged);
+    _focusNode.addListener(_handleFocusChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant PinInputComponent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_handleControllerChanged);
+      _synchronizeController();
+      _lastCompletedValue = null;
+      widget.controller.addListener(_handleControllerChanged);
+    } else if (oldWidget.length != widget.length) {
+      _synchronizeController();
+      _lastCompletedValue = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_handleControllerChanged);
+    _focusNode.removeListener(_handleFocusChanged);
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  String _visibleValue(String value) {
+    if (value.length <= widget.length) {
+      return value;
+    }
+    return value.substring(0, widget.length);
+  }
+
+  void _synchronizeController() {
+    final sanitizedText = _sanitizeValue(widget.controller.text);
+    _lastControllerText = sanitizedText;
+    _value = sanitizedText;
+    if (widget.controller.text != sanitizedText) {
+      _replaceControllerText(sanitizedText);
+    }
+  }
+
+  void _handleControllerChanged() {
+    final controllerText = widget.controller.text;
+    if (_lastControllerText == controllerText) {
+      return;
+    }
+    final sanitizedText = _sanitizeValue(controllerText);
+    if (sanitizedText != controllerText) {
+      _replaceControllerText(sanitizedText);
+      return;
+    }
+    _lastControllerText = controllerText;
+    if (_value != controllerText && mounted) {
+      setState(() => _value = controllerText);
+    }
+    widget.onChanged?.call(controllerText);
+
+    if (controllerText.length != widget.length) {
+      _lastCompletedValue = null;
+      return;
+    }
+    if (_lastCompletedValue == controllerText) {
+      return;
+    }
+    _lastCompletedValue = controllerText;
+    widget.onCompleted?.call(controllerText);
+  }
+
+  String _sanitizeValue(String value) {
+    final digits = value.replaceAll(RegExp('[^0-9]'), '');
+    return _visibleValue(digits);
+  }
+
+  void _replaceControllerText(String value) {
+    widget.controller.value = TextEditingValue(
+      text: value,
+      selection: TextSelection.collapsed(offset: value.length),
+    );
+  }
+
+  void _handleFocusChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void _moveSelectionToEnd() {
+    if (widget.isDisabled) {
+      return;
+    }
+    widget.controller.selection = TextSelection.collapsed(
+      offset: widget.controller.text.length,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final desiredWidth =
+        (_boxWidth * widget.length) + (_boxGap * (widget.length - 1));
+
+    return SizedBox(
+      height: _boxHeight,
+      width: desiredWidth,
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: SizedBox(
+          width: desiredWidth,
+          height: _boxHeight,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              ExcludeSemantics(child: _buildBoxes(context)),
+              _buildTextField(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBoxes(BuildContext context) {
+    final colors = context.componentColors;
+    return Row(
+      children: [
+        for (var index = 0; index < widget.length; index++) ...[
+          _PinInputBox(
+            character: index < _value.length ? _value[index] : null,
+            isFocused:
+                _focusNode.hasFocus &&
+                _value.length < widget.length &&
+                index == _value.length,
+            obscureText: widget.obscureText,
+            obscuringCharacter: widget.obscuringCharacter,
+            isError: widget.isError,
+            isDisabled: widget.isDisabled,
+            colors: colors,
+          ),
+          if (index != widget.length - 1) const SizedBox(width: _boxGap),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildTextField() {
+    Widget field = TextField(
+      controller: widget.controller,
+      focusNode: _focusNode,
+      autofocus: widget.autofocus,
+      enabled: !widget.isDisabled,
+      readOnly: !widget.useNativeKeyboard,
+      showCursor: false,
+      keyboardType: TextInputType.number,
+      textInputAction: TextInputAction.done,
+      autofillHints: widget.autofillHints,
+      autocorrect: false,
+      enableSuggestions: false,
+      obscureText: widget.obscureText,
+      obscuringCharacter: widget.obscuringCharacter,
+      inputFormatters: [
+        FilteringTextInputFormatter.digitsOnly,
+        LengthLimitingTextInputFormatter(widget.length),
+      ],
+      style: const TextStyle(color: Colors.transparent),
+      cursorColor: Colors.transparent,
+      decoration: const InputDecoration(
+        border: InputBorder.none,
+        enabledBorder: InputBorder.none,
+        focusedBorder: InputBorder.none,
+        disabledBorder: InputBorder.none,
+        contentPadding: EdgeInsets.zero,
+        counterText: '',
+      ),
+      onTap: _moveSelectionToEnd,
+    );
+
+    if (widget.semanticLabel != null) {
+      field = Semantics(label: widget.semanticLabel, child: field);
+    }
+    return field;
+  }
+}
+
+class _PinInputBox extends StatelessWidget {
+  const _PinInputBox({
+    required this.character,
+    required this.isFocused,
+    required this.obscureText,
+    required this.obscuringCharacter,
+    required this.isError,
+    required this.isDisabled,
+    required this.colors,
+  });
+
+  final String? character;
+  final bool isFocused;
+  final bool obscureText;
+  final String obscuringCharacter;
+  final bool isError;
+  final bool isDisabled;
+  final ColorTokens colors;
+
+  bool get _isFilled => character != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderColor = switch ((isDisabled, isError, isFocused, _isFilled)) {
+      (true, _, _, _) => colors.strokeFaint,
+      (_, true, _, _) => colors.warning,
+      (_, _, true, _) || (_, _, _, true) => colors.primary,
+      _ => colors.strokeDark,
+    };
+    final borderWidth = isError || isFocused || _isFilled ? 2.0 : 1.0;
+    final backgroundColor = switch ((isDisabled, _isFilled)) {
+      (true, _) => colors.fillDark,
+      (_, true) when !isError => colors.primaryLight,
+      _ => colors.fillLight,
+    };
+    final textColor = switch ((isDisabled, isError)) {
+      (true, _) => colors.textLight,
+      (_, true) => colors.warning,
+      _ => colors.primary,
+    };
+
+    return AnimatedContainer(
+      duration: Motion.quick,
+      curve: Curves.easeOut,
+      width: _PinInputComponentState._boxWidth,
+      height: _PinInputComponentState._boxHeight,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        border: Border.all(color: borderColor, width: borderWidth),
+        borderRadius: BorderRadius.circular(Radii.lg),
+      ),
+      child: AnimatedSwitcher(
+        duration: Motion.quick,
+        switchInCurve: Curves.easeOut,
+        switchOutCurve: Curves.easeIn,
+        transitionBuilder: (child, animation) {
+          return FadeTransition(
+            opacity: animation,
+            child: ScaleTransition(
+              scale: Tween<double>(begin: 0.9, end: 1).animate(animation),
+              child: child,
+            ),
+          );
+        },
+        child: _buildCharacter(textColor),
+      ),
+    );
+  }
+
+  Widget? _buildCharacter(Color color) {
+    if (character == null) {
+      return null;
+    }
+    if (obscureText && obscuringCharacter == '•') {
+      return Container(
+        key: ValueKey(character),
+        width: 8,
+        height: 8,
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+      );
+    }
+    return Text(
+      obscureText ? obscuringCharacter : character!,
+      key: ValueKey(character),
+      style: TextStyles.h1.copyWith(color: color),
+    );
+  }
+}

--- a/mobile/packages/ente_components/lib/components/pin_input_component.dart
+++ b/mobile/packages/ente_components/lib/components/pin_input_component.dart
@@ -22,6 +22,7 @@ class PinInputComponent extends StatefulWidget {
     this.length = 6,
     this.autofocus = false,
     this.useNativeKeyboard = true,
+    this.closeKeyboardWhenCompleted = true,
     this.obscureText = false,
     this.obscuringCharacter = '•',
     this.isError = false,
@@ -37,6 +38,7 @@ class PinInputComponent extends StatefulWidget {
   final TextEditingController controller;
   final bool autofocus;
   final bool useNativeKeyboard;
+  final bool closeKeyboardWhenCompleted;
   final bool obscureText;
   final String obscuringCharacter;
   final bool isError;
@@ -152,6 +154,9 @@ class _PinInputComponentState extends State<PinInputComponent> {
     }
     _lastCompletedValue = controllerText;
     widget.onCompleted?.call(controllerText);
+    if (widget.closeKeyboardWhenCompleted && mounted) {
+      _focusNode.unfocus();
+    }
   }
 
   String _sanitizeValue(String value) {

--- a/mobile/packages/ente_components/lib/components/pin_input_component.dart
+++ b/mobile/packages/ente_components/lib/components/pin_input_component.dart
@@ -245,6 +245,7 @@ class _PinInputComponentState extends State<PinInputComponent> {
       enableIMEPersonalizedLearning: false,
       obscureText: widget.obscureText,
       obscuringCharacter: widget.obscuringCharacter,
+      maxLength: widget.length,
       inputFormatters: [
         FilteringTextInputFormatter.digitsOnly,
         LengthLimitingTextInputFormatter(widget.length),

--- a/mobile/packages/ente_components/lib/ente_components.dart
+++ b/mobile/packages/ente_components/lib/ente_components.dart
@@ -12,6 +12,7 @@ export 'components/ente_app_icon.dart';
 export 'components/filter_chip_component.dart';
 export 'components/menu_component.dart';
 export 'components/menu_group_component.dart';
+export 'components/pin_input_component.dart';
 export 'components/popup_menu_component.dart';
 export 'components/selection_controls/checkbox_component.dart';
 export 'components/selection_controls/labeled_control_component.dart';

--- a/mobile/packages/lock_screen/lib/ui/lock_screen_pin_input.dart
+++ b/mobile/packages/lock_screen/lib/ui/lock_screen_pin_input.dart
@@ -1,6 +1,5 @@
 import "package:ente_components/ente_components.dart";
 import "package:flutter/material.dart";
-import "package:pinput/pinput.dart";
 
 class LockScreenPinInput extends StatelessWidget {
   const LockScreenPinInput({
@@ -20,18 +19,6 @@ class LockScreenPinInput extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorTheme = context.componentColors;
-    final pinPutDecoration = PinTheme(
-      height: 48,
-      width: 48,
-      padding: const EdgeInsets.only(top: 6.0),
-      decoration: BoxDecoration(
-        color: colorTheme.backgroundBase,
-        border: Border.all(color: colorTheme.strokeDark, width: 1),
-        borderRadius: BorderRadius.circular(15.0),
-      ),
-    );
-
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24.0),
@@ -43,48 +30,13 @@ class LockScreenPinInput extends StatelessWidget {
             const SizedBox(height: 24),
             Text(title, style: TextStyles.bodyBold),
             const Padding(padding: EdgeInsets.all(12)),
-            Pinput(
+            PinInputComponent(
               length: 4,
-              showCursor: false,
-              useNativeKeyboard: useNativeKeyboard,
               controller: controller,
               autofocus: true,
-              defaultPinTheme: pinPutDecoration.copyWith(
-                textStyle: TextStyles.h2,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(15.0),
-                  border: Border.all(color: colorTheme.strokeDark),
-                ),
-              ),
-              submittedPinTheme: pinPutDecoration.copyWith(
-                textStyle: TextStyles.h2.copyWith(color: colorTheme.primary),
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(15.0),
-                  border: Border.all(color: colorTheme.primary),
-                ),
-              ),
-              followingPinTheme: pinPutDecoration.copyWith(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(15.0),
-                  border: Border.all(color: colorTheme.strokeDark),
-                ),
-              ),
-              focusedPinTheme: pinPutDecoration.copyWith(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(15.0),
-                  border: Border.all(color: colorTheme.fillBase),
-                ),
-              ),
-              errorPinTheme: pinPutDecoration.copyWith(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(15.0),
-                  border: Border.all(color: colorTheme.warning),
-                ),
-              ),
-              forceErrorState: forceErrorState,
+              useNativeKeyboard: useNativeKeyboard,
               obscureText: true,
-              obscuringCharacter: '*',
-              errorText: '',
+              isError: forceErrorState,
               onCompleted: onCompleted,
             ),
           ],

--- a/mobile/packages/lock_screen/pubspec.yaml
+++ b/mobile/packages/lock_screen/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   local_auth_linux:
     path: ../local_auth_linux
   logging: 1.3.0
-  pinput: 5.0.2
   shared_preferences: 2.5.3
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add a shared PIN input component to Ente Components
- migrate Photos and shared email verification plus app-lock PIN entry
- preserve one-time-code autofill and keyboard dismissal on completion
- remove the lock-screen package's direct Pinput dependency

## Verification
- flutter analyze --no-pub: Ente Components, Lock Screen, Accounts, Auth, Locker, Photos
- flutter test --no-pub: Ente Components and Lock Screen
- git diff --check