### PR TITLE
[mobile][photos] Serialize foreground and background ML

### DIFF
--- a/mobile/apps/photos/ios/Podfile.lock
+++ b/mobile/apps/photos/ios/Podfile.lock
@@ -456,7 +456,7 @@ SPEC CHECKSUMS:
   ente_cast: a25feb3127397e5fc6aff03a12120916707757d4
   ente_mail: 90753dd584f49ee092759a32d4143ca51db69641
   ente_panorama_viewer: 87bb22e7868c3005314f80c05ee0787aa07edcd8
-  ente_photos_platform: 9a5d62b4008563bdfefe6a42cc4297c5c19bf70c
+  ente_photos_platform: 2dff4c0778eae769b133dd0ae3260eafec0011d4
   ente_photos_rust: 2db1f31cbe3f13ef0f52909a52b1f885b880a6ec
   ente_qr: 86beaf5d2644705db9b565b32dd8b82c05fb36af
   ente_rust: d0197ebd5460e8f67576579452b073d698404abe

--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -8,6 +8,7 @@ import 'package:ente_account_deletion/account_deletion.dart';
 import 'package:ente_contacts/contacts.dart';
 import "package:ente_crypto/ente_crypto.dart";
 import 'package:ente_lock_screen/lock_screen_host.dart';
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import 'package:ente_pure_utils/ente_pure_utils.dart';
 import "package:flutter/services.dart";
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -43,9 +44,12 @@ import 'package:photos/services/favorites_service.dart';
 import "package:photos/services/home_widget_service.dart";
 import 'package:photos/services/ignored_files_service.dart';
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
+import "package:photos/services/machine_learning/ml_service.dart";
 import "package:photos/services/machine_learning/similar_images_service.dart";
 import "package:photos/services/memory_share_service.dart";
 import "package:photos/services/notification_service.dart";
+import "package:photos/services/process_activity_service.dart";
 import 'package:photos/services/search_service.dart';
 import 'package:photos/services/sync/sync_service.dart';
 import 'package:photos/services/video_preview_service.dart';
@@ -193,6 +197,21 @@ class Configuration implements LockScreenHost, AccountDeletionHost {
 
   @override
   Future<void> logout({bool autoLogout = false}) async {
+    MLService.instance.pauseIndexingAndClustering();
+    final completed = await MlProcessLock.instance.runExclusive(
+      origin: ProcessActivityService.instance.isBackgroundProcess
+          ? MlProcessLockOrigin.background
+          : MlProcessLockOrigin.foreground,
+      operation: MlProcessOperation.vectorMaintenance,
+      retryFor: const Duration(seconds: 30),
+      body: () => _logoutWithMlPermit(autoLogout: autoLogout),
+    );
+    if (!completed) {
+      throw StateError("ML is busy; logout did not start");
+    }
+  }
+
+  Future<void> _logoutWithMlPermit({required bool autoLogout}) async {
     _logger.info("Logging out, autoLogout: $autoLogout");
     if (!autoLogout) {
       if (flagService.stopStreamProcess) {

--- a/mobile/apps/photos/lib/db/ml/clip_vector_db.dart
+++ b/mobile/apps/photos/lib/db/ml/clip_vector_db.dart
@@ -6,6 +6,7 @@ import "package:logging/logging.dart";
 import "package:path/path.dart";
 import "package:path_provider/path_provider.dart";
 import "package:photos/models/ml/vector.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/services/machine_learning/semantic_search/query_result.dart";
 import "package:photos/src/rust/api/usearch_api.dart";
 import "package:shared_preferences/shared_preferences.dart";
@@ -111,6 +112,9 @@ class ClipVectorDB {
   Future<void> _runWriteOperation(
     Future<void> Function(VectorDb db) operation,
   ) async {
+    await MlProcessLock.instance.debugLogUnpermittedVectorMutation(
+      _databaseName,
+    );
     final db = await _vectorDB;
     await _writeLock.synchronized(() async {
       await operation(db);
@@ -407,6 +411,9 @@ class ClipVectorDB {
   }
 
   Future<void> deleteIndex() async {
+    await MlProcessLock.instance.debugLogUnpermittedVectorMutation(
+      "$_databaseName.deleteIndex",
+    );
     await invalidateMigrationState();
     final db = await _vectorDB;
     try {
@@ -422,6 +429,9 @@ class ClipVectorDB {
   }
 
   Future<void> deleteIndexFile() async {
+    await MlProcessLock.instance.debugLogUnpermittedVectorMutation(
+      "$_databaseName.deleteIndexFile",
+    );
     await _writeLock.synchronized(() async {
       try {
         final documentsDirectory = await getApplicationDocumentsDirectory();

--- a/mobile/apps/photos/lib/db/ml/cluster_centroid_vector_db.dart
+++ b/mobile/apps/photos/lib/db/ml/cluster_centroid_vector_db.dart
@@ -5,6 +5,7 @@ import "package:flutter_rust_bridge/flutter_rust_bridge.dart" show Uint64List;
 import "package:logging/logging.dart";
 import "package:path/path.dart";
 import "package:path_provider/path_provider.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/src/rust/api/usearch_api.dart";
 import "package:shared_preferences/shared_preferences.dart";
 import "package:synchronized/synchronized.dart";
@@ -124,6 +125,9 @@ class ClusterCentroidVectorDB {
   Future<void> _runWriteOperation(
     Future<void> Function(VectorDb db) operation,
   ) async {
+    await MlProcessLock.instance.debugLogUnpermittedVectorMutation(
+      _databaseName,
+    );
     final db = await _vectorDB;
     await _writeLock.synchronized(() async {
       await operation(db);
@@ -403,6 +407,9 @@ class ClusterCentroidVectorDB {
   }
 
   Future<void> deleteIndex() async {
+    await MlProcessLock.instance.debugLogUnpermittedVectorMutation(
+      "$_databaseName.deleteIndex",
+    );
     await invalidateMigrationState();
     final db = await _vectorDB;
     try {
@@ -418,6 +425,9 @@ class ClusterCentroidVectorDB {
   }
 
   Future<void> deleteIndexFile() async {
+    await MlProcessLock.instance.debugLogUnpermittedVectorMutation(
+      "$_databaseName.deleteIndexFile",
+    );
     await _writeLock.synchronized(() async {
       try {
         final documentsDirectory = await getApplicationDocumentsDirectory();

--- a/mobile/apps/photos/lib/db/ml/db.dart
+++ b/mobile/apps/photos/lib/db/ml/db.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import "dart:math";
 
 import "package:collection/collection.dart";
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/foundation.dart";
 import 'package:logging/logging.dart';
@@ -27,7 +28,9 @@ import "package:photos/service_locator.dart";
 import "package:photos/services/machine_learning/compute_controller.dart";
 import "package:photos/services/machine_learning/face_ml/face_clustering/face_db_info_for_clustering.dart";
 import 'package:photos/services/machine_learning/face_ml/face_filtering/face_filtering_constants.dart';
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/services/machine_learning/ml_result.dart";
+import "package:photos/services/process_activity_service.dart";
 import "package:photos/utils/ml_util.dart";
 import 'package:sqlite_async/sqlite_async.dart';
 import "package:synchronized/synchronized.dart";
@@ -1985,7 +1988,26 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
         await Future.delayed(idlePollDelay);
       }
       _logger.info("Starting ClusterCentroidVectorDB rebuild from SQLite");
-      await checkMigrateFillClusterCentroidVectorDB(force: true);
+      if (ProcessActivityService.instance.isBackgroundProcess &&
+          await ProcessActivityService.instance.isForegroundRecentlyActive()) {
+        _logger.info(
+          "Deferring ClusterCentroidVectorDB rebuild while foreground is active",
+        );
+        return;
+      }
+      final rebuilt = await MlProcessLock.instance.runExclusive(
+        origin: ProcessActivityService.instance.isBackgroundProcess
+            ? MlProcessLockOrigin.background
+            : MlProcessLockOrigin.foreground,
+        operation: MlProcessOperation.vectorMaintenance,
+        body: () => checkMigrateFillClusterCentroidVectorDB(force: true),
+      );
+      if (!rebuilt) {
+        _logger.info(
+          "Deferring ClusterCentroidVectorDB rebuild while another ML operation is active",
+        );
+        return;
+      }
       _logger.info("ClusterCentroidVectorDB rebuild from SQLite completed");
     } catch (e, s) {
       _logger.severe(
@@ -2406,7 +2428,26 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
         await Future.delayed(idlePollDelay);
       }
       _logger.info("Starting ClipVectorDB rebuild from SQLite");
-      await checkMigrateFillClipVectorDB(force: true);
+      if (ProcessActivityService.instance.isBackgroundProcess &&
+          await ProcessActivityService.instance.isForegroundRecentlyActive()) {
+        _logger.info(
+          "Deferring ClipVectorDB rebuild while foreground is active",
+        );
+        return;
+      }
+      final rebuilt = await MlProcessLock.instance.runExclusive(
+        origin: ProcessActivityService.instance.isBackgroundProcess
+            ? MlProcessLockOrigin.background
+            : MlProcessLockOrigin.foreground,
+        operation: MlProcessOperation.vectorMaintenance,
+        body: () => checkMigrateFillClipVectorDB(force: true),
+      );
+      if (!rebuilt) {
+        _logger.info(
+          "Deferring ClipVectorDB rebuild while another ML operation is active",
+        );
+        return;
+      }
       _logger.info("ClipVectorDB rebuild from SQLite completed");
     } catch (e, s) {
       _logger.severe("ClipVectorDB rebuild from SQLite failed", e, s);

--- a/mobile/apps/photos/lib/db/ml/pet_vector_db.dart
+++ b/mobile/apps/photos/lib/db/ml/pet_vector_db.dart
@@ -8,6 +8,7 @@ import "package:path/path.dart";
 import "package:path_provider/path_provider.dart";
 import "package:photos/db/ml/clip_vector_db.dart" show VectorDbStats;
 import "package:photos/db/ml/schema.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/src/rust/api/usearch_api.dart";
 import "package:sqlite_async/sqlite_async.dart";
 import "package:synchronized/synchronized.dart";
@@ -239,6 +240,9 @@ class PetVectorDB {
   Future<void> _runWriteOperation(
     Future<void> Function(VectorDb db) operation,
   ) async {
+    await MlProcessLock.instance.debugLogUnpermittedVectorMutation(
+      _databaseName,
+    );
     final db = await _vectorDB;
     await _writeLock.synchronized(() async {
       await operation(db);
@@ -363,6 +367,9 @@ class PetVectorDB {
   }
 
   Future<void> deleteIndex() async {
+    await MlProcessLock.instance.debugLogUnpermittedVectorMutation(
+      "$_databaseName.deleteIndex",
+    );
     final db = await _vectorDB;
     try {
       await _writeLock.synchronized(() async {
@@ -376,6 +383,9 @@ class PetVectorDB {
   }
 
   Future<void> deleteIndexFile() async {
+    await MlProcessLock.instance.debugLogUnpermittedVectorMutation(
+      "$_databaseName.deleteIndexFile",
+    );
     await _writeLock.synchronized(() async {
       try {
         final documentsDirectory = await getApplicationDocumentsDirectory();

--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -46,12 +46,14 @@ import 'package:photos/services/collections_service.dart';
 import 'package:photos/services/favorites_service.dart';
 import 'package:photos/services/home_widget_service.dart';
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
+import 'package:photos/services/machine_learning/ml_run_control.dart';
 import 'package:photos/services/machine_learning/ml_service.dart';
 import 'package:photos/services/machine_learning/semantic_search/semantic_search_service.dart';
 import 'package:photos/services/memory_lane/memory_lane_service.dart';
 import 'package:photos/services/memory_share_service.dart';
 import "package:photos/services/notification_service.dart";
 import "package:photos/services/photos_contacts_service.dart";
+import 'package:photos/services/process_activity_service.dart';
 import 'package:photos/services/push_service.dart';
 import 'package:photos/services/search_service.dart';
 import 'package:photos/services/social_notification_coordinator.dart';
@@ -70,15 +72,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 final _logger = Logger("main");
 
-const kLastBGTaskHeartBeatTime = "bg_task_hb_time";
-const kLastFGTaskHeartBeatTime = "fg_task_hb_time";
-const kHeartBeatFrequency = Duration(seconds: 1);
 const kFGSyncFrequency = Duration(minutes: 5);
 const kFGHomeWidgetSyncFrequency = Duration(minutes: 15);
 const kBGTaskTimeout = Duration(seconds: 28);
 const kBGPushTimeout = Duration(seconds: 28);
-const kFGTaskDeathTimeoutInMicroseconds = 5000000;
-bool isProcessBg = true;
+bool get isProcessBg => ProcessActivityService.instance.isBackgroundProcess;
+set isProcessBg(bool value) =>
+    ProcessActivityService.instance.isBackgroundProcess = value;
 bool _stopHearBeat = false;
 bool _isSyncInitialized = false;
 bool _isRustInitialized = false;
@@ -241,11 +241,13 @@ Future<void> runBackgroundTask(
   String taskId,
   TimeLogger tlog, {
   String mode = 'normal',
+  MlRunControl? runControl,
 }) async {
   // Check if foreground is recently active to avoid conflicts
-  final isRunningInFG = await _isRunningInForeground();
+  final isRunningInFG = await ProcessActivityService.instance
+      .isForegroundRecentlyActive();
 
-  // If FG was active in last 30 seconds, skip BG work
+  // If FG was active in the last five seconds, skip BG work.
   if (isRunningInFG) {
     _logger.info(
       "[BG TASK] Foreground recently active, skipping background work",
@@ -259,10 +261,14 @@ Future<void> runBackgroundTask(
 
   // Mark BG as active
 
-  await _runMinimally(taskId, tlog);
+  await _runMinimally(taskId, tlog, runControl: runControl);
 }
 
-Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
+Future<void> _runMinimally(
+  String taskId,
+  TimeLogger tlog, {
+  MlRunControl? runControl,
+}) async {
   try {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     final SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -344,24 +350,13 @@ Future<void> _runMinimally(String taskId, TimeLogger tlog) async {
     if ((isLocalGalleryMode || flagService.enableMLInBackground) &&
         hasGrantedMLConsent) {
       await controller.init();
-      final canRunML = controller.requestCompute(ml: true);
-      if (!canRunML) {
-        _logger.info(
-          "[BG TASK] skipping ML, compute requirements not satisfied",
-        );
-      } else {
-        bool mlRunStarted = false;
-        try {
-          await MLService.instance.init();
-          PersonService.init(entityService, MLDataDB.instance, prefs);
-          mlRunStarted = true;
-          await MLService.instance.runAllML(force: false);
-        } finally {
-          if (!mlRunStarted) {
-            controller.releaseCompute(ml: true);
-          }
-        }
-      }
+      await MLService.instance.init();
+      PersonService.init(entityService, MLDataDB.instance, prefs);
+      final disposition = await MLService.instance.runAllML(
+        force: false,
+        runControl: runControl,
+      );
+      _logger.info("[BG TASK] ML finished with ${disposition.name}");
     }
     _logger.info("[BG TASK] smart albums sync");
     await smartAlbumsService.syncSmartAlbums();
@@ -656,10 +651,12 @@ Future<void> _scheduleHeartBeat(
   bool isBackground,
 ) async {
   await prefs.setInt(
-    isBackground ? kLastBGTaskHeartBeatTime : kLastFGTaskHeartBeatTime,
+    isBackground
+        ? lastBackgroundTaskHeartbeatKey
+        : lastForegroundTaskHeartbeatKey,
     DateTime.now().microsecondsSinceEpoch,
   );
-  Future.delayed(kHeartBeatFrequency, () async {
+  Future.delayed(processHeartbeatFrequency, () async {
     // ignore: unawaited_futures
     _scheduleHeartBeat(prefs, isBackground);
   });
@@ -685,19 +682,9 @@ Future<void> _scheduleFGSync(String caller) async {
   });
 }
 
-Future<bool> _isRunningInForeground() async {
-  final prefs = await SharedPreferences.getInstance();
-  await prefs.reload();
-  final currentTime = DateTime.now().microsecondsSinceEpoch;
-  final lastFGHeartBeatTime = DateTime.fromMicrosecondsSinceEpoch(
-    prefs.getInt(kLastFGTaskHeartBeatTime) ?? 0,
-  );
-  return lastFGHeartBeatTime.microsecondsSinceEpoch >
-      (currentTime - kFGTaskDeathTimeoutInMicroseconds);
-}
-
 Future<void> _handleBackgroundPush(Object message) async {
-  final bool isRunningInFG = await _isRunningInForeground(); // hb
+  final bool isRunningInFG = await ProcessActivityService.instance
+      .isForegroundRecentlyActive();
   final bool isInForeground = AppLifecycleService.instance.isForeground;
   if (isRunningInFG) {
     _logger.info(
@@ -716,7 +703,7 @@ Future<void> _handleBackgroundPush(Object message) async {
       // Mark BG as active before starting
       final prefs = await SharedPreferences.getInstance();
       await prefs.setInt(
-        kLastBGTaskHeartBeatTime,
+        lastBackgroundTaskHeartbeatKey,
         DateTime.now().microsecondsSinceEpoch,
       );
 
@@ -733,9 +720,11 @@ Future<void> _handleBackgroundPush(Object message) async {
 }
 
 Future<void> _logFGHeartBeatInfo(SharedPreferences prefs) async {
-  final bool isRunningInFG = await _isRunningInForeground();
+  final bool isRunningInFG = await ProcessActivityService.instance
+      .isForegroundRecentlyActive();
   await prefs.reload();
-  final lastFGTaskHeartBeatTime = prefs.getInt(kLastFGTaskHeartBeatTime) ?? 0;
+  final lastFGTaskHeartBeatTime =
+      prefs.getInt(lastForegroundTaskHeartbeatKey) ?? 0;
   final String lastRun = lastFGTaskHeartBeatTime == 0
       ? 'never'
       : DateTime.fromMicrosecondsSinceEpoch(lastFGTaskHeartBeatTime).toString();

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -20,7 +20,7 @@ import "package:photos/events/file_uploaded_event.dart";
 import 'package:photos/events/files_updated_event.dart';
 import 'package:photos/events/local_photos_updated_event.dart';
 import "package:photos/gateways/files/file_upload_gateway.dart";
-import "package:photos/main.dart" show isProcessBg, kLastBGTaskHeartBeatTime;
+import "package:photos/main.dart" show isProcessBg;
 import "package:photos/models/backup/backup_item.dart";
 import 'package:photos/models/file/file.dart';
 import 'package:photos/models/file/file_type.dart';
@@ -38,6 +38,7 @@ import "package:photos/service_locator.dart";
 import "package:photos/services/account/user_service.dart";
 import 'package:photos/services/collections_service.dart';
 import 'package:photos/services/file_magic_service.dart';
+import "package:photos/services/process_activity_service.dart";
 import 'package:photos/services/sync/local_sync_service.dart';
 import 'package:photos/services/sync/sync_service.dart';
 import "package:photos/utils/device_storage_error.dart";
@@ -106,7 +107,7 @@ class FileUploader {
     if (!isBackground) {
       await _prefs.reload();
       final lastBGTaskHeartBeatTime =
-          _prefs.getInt(kLastBGTaskHeartBeatTime) ?? 0;
+          _prefs.getInt(lastBackgroundTaskHeartbeatKey) ?? 0;
       final isBGTaskDead =
           lastBGTaskHeartBeatTime < (currentTime - kBGTaskDeathTimeout);
       if (isBGTaskDead) {

--- a/mobile/apps/photos/lib/services/machine_learning/face_ml/feedback/cluster_feedback.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/face_ml/feedback/cluster_feedback.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as dev show log;
 import "dart:math" show Random, min;
 
 import "package:computer/computer.dart";
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
@@ -20,6 +21,7 @@ import "package:photos/service_locator.dart";
 import "package:photos/services/machine_learning/face_ml/face_clustering/face_clustering_service.dart";
 import "package:photos/services/machine_learning/face_ml/face_filtering/face_filtering_constants.dart";
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/services/machine_learning/ml_result.dart";
 import "package:photos/services/search_service.dart";
 
@@ -1507,8 +1509,18 @@ class ClusterFeedbackService<T> {
       if (!flagService.usearchForSuggestions) return;
       if (!flagService.hasGrantedMLConsent) return;
       if (!await _clusterCentroidVectorDB.checkIfMigrationDone()) {
-        await _mlDataDBForCentroidVectorDb
-            .checkMigrateFillClusterCentroidVectorDB();
+        final migrated = await MlProcessLock.instance.runExclusive(
+          origin: MlProcessLockOrigin.foreground,
+          operation: MlProcessOperation.vectorMaintenance,
+          body: _mlDataDBForCentroidVectorDb
+              .checkMigrateFillClusterCentroidVectorDB,
+        );
+        if (!migrated) {
+          _logger.info(
+            "Skipping centroid vector migration while another ML operation is active",
+          );
+          return;
+        }
       }
       if (await _clusterCentroidVectorDB.checkIfMigrationDone()) {
         await _clusterCentroidVectorDB.warmupApproxSearch();

--- a/mobile/apps/photos/lib/services/machine_learning/ml_process_lock.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_process_lock.dart
@@ -1,0 +1,196 @@
+import "dart:async" show Zone, runZoned;
+
+import "package:ente_photos_platform/ente_photos_platform.dart";
+import "package:flutter/foundation.dart" show kDebugMode;
+import "package:logging/logging.dart";
+import "package:uuid/uuid.dart";
+
+enum MlProcessOperation {
+  fullRun,
+  indexing,
+  clustering,
+  startupRemoteHydration,
+  vectorMaintenance,
+}
+
+class MlPermitAttempt {
+  const MlPermitAttempt._({this.permit, this.holder});
+
+  factory MlPermitAttempt.acquired(MlProcessPermit permit) =>
+      MlPermitAttempt._(permit: permit);
+
+  factory MlPermitAttempt.denied(MlProcessLockState holder) =>
+      MlPermitAttempt._(holder: holder);
+
+  final MlProcessPermit? permit;
+  final MlProcessLockState? holder;
+
+  bool get acquired => permit != null;
+}
+
+class MlProcessPermit {
+  MlProcessPermit._({
+    required String token,
+    required this.origin,
+    required this.operation,
+    required MlProcessLockClient client,
+    required Logger logger,
+    required void Function(String) onReleased,
+  }) : _token = token,
+       _client = client,
+       _logger = logger,
+       _onReleased = onReleased;
+
+  final String _token;
+  final MlProcessLockOrigin origin;
+  final MlProcessOperation operation;
+  final MlProcessLockClient _client;
+  final Logger _logger;
+  final void Function(String) _onReleased;
+  bool _released = false;
+
+  Future<T> run<T>(Future<T> Function() body) {
+    if (_released) {
+      throw StateError("Cannot run work with a released ML process permit");
+    }
+    return runZoned(
+      body,
+      zoneValues: {MlProcessLock._permitTokenZoneKey: _token},
+    );
+  }
+
+  Future<void> release() async {
+    if (_released) return;
+    _released = true;
+    try {
+      final released = await _client.release(_token);
+      if (!released) {
+        _logger.warning(
+          "ML process permit release was rejected for ${origin.name}/${operation.name}",
+        );
+        return;
+      }
+      _logger.info(
+        "Released ML process permit for ${origin.name}/${operation.name}",
+      );
+    } finally {
+      _onReleased(_token);
+    }
+  }
+}
+
+class MlProcessLock {
+  MlProcessLock({MlProcessLockClient? client, Uuid? uuid})
+    : _client = client ?? MlProcessLockClient.instance,
+      _uuid = uuid ?? const Uuid();
+
+  static final instance = MlProcessLock();
+
+  final _logger = Logger("MlProcessLock");
+  final MlProcessLockClient _client;
+  final Uuid _uuid;
+  final Set<String> _activeLocalTokens = {};
+  static final _permitTokenZoneKey = Object();
+
+  String newOperationToken() => _uuid.v4();
+
+  Future<void> debugLogUnpermittedVectorMutation(String mutation) async {
+    if (!kDebugMode) return;
+    final zoneToken = Zone.current[_permitTokenZoneKey];
+    if (zoneToken is String && _activeLocalTokens.contains(zoneToken)) return;
+    try {
+      final holder = await _client.state();
+      if (holder != null) {
+        _logger.warning(
+          "Unpermitted vector mutation $mutation while "
+          "${holder.origin.name}/${holder.operation} owns the ML permit",
+        );
+      }
+    } catch (e, s) {
+      _logger.warning("Failed to inspect ML permit for $mutation", e, s);
+    }
+  }
+
+  Future<bool> runExclusive({
+    required MlProcessLockOrigin origin,
+    required MlProcessOperation operation,
+    required Future<void> Function() body,
+    Duration retryFor = Duration.zero,
+    Duration retryInterval = const Duration(seconds: 5),
+    bool Function()? shouldContinueWaiting,
+  }) async {
+    final token = newOperationToken();
+    final deadline = DateTime.now().add(retryFor);
+    while (true) {
+      final attempt = await tryAcquire(
+        origin: origin,
+        operation: operation,
+        token: token,
+      );
+      final permit = attempt.permit;
+      if (permit != null) {
+        try {
+          await permit.run(body);
+        } finally {
+          await permit.release();
+        }
+        return true;
+      }
+      if (retryFor == Duration.zero ||
+          DateTime.now().add(retryInterval).isAfter(deadline) ||
+          shouldContinueWaiting?.call() == false) {
+        if (retryFor != Duration.zero) {
+          _logger.warning(
+            "Timed out waiting for ${origin.name}/${operation.name} ML process permit",
+          );
+        }
+        return false;
+      }
+      await Future<void>.delayed(retryInterval);
+    }
+  }
+
+  Future<MlPermitAttempt> tryAcquire({
+    required MlProcessLockOrigin origin,
+    required MlProcessOperation operation,
+    String? token,
+  }) async {
+    final operationToken = token ?? newOperationToken();
+    try {
+      final result = await _client.tryAcquire(
+        token: operationToken,
+        origin: origin,
+        operation: operation.name,
+      );
+      if (!result.acquired) {
+        _logger.info(
+          "Denied ML process permit for ${origin.name}/${operation.name}; "
+          "held by ${result.holder.origin.name}/${result.holder.operation} "
+          "for ${result.holder.heldDuration.inMilliseconds}ms",
+        );
+        return MlPermitAttempt.denied(result.holder);
+      }
+      _logger.info(
+        "Acquired ML process permit for ${origin.name}/${operation.name}",
+      );
+      _activeLocalTokens.add(operationToken);
+      return MlPermitAttempt.acquired(
+        MlProcessPermit._(
+          token: operationToken,
+          origin: origin,
+          operation: operation,
+          client: _client,
+          logger: _logger,
+          onReleased: _activeLocalTokens.remove,
+        ),
+      );
+    } catch (e, s) {
+      _logger.severe(
+        "Failed to acquire ML process permit for ${origin.name}/${operation.name}; denying operation",
+        e,
+        s,
+      );
+      rethrow;
+    }
+  }
+}

--- a/mobile/apps/photos/lib/services/machine_learning/ml_run_control.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_run_control.dart
@@ -1,0 +1,27 @@
+enum MlStopReason { foregroundActive, backgroundDeadline, controller, manual }
+
+class MlRunControl {
+  final _stopListeners = <void Function(MlStopReason)>{};
+
+  MlStopReason? _stopReason;
+
+  bool get stopRequested => _stopReason != null;
+  MlStopReason? get stopReason => _stopReason;
+
+  void requestStop(MlStopReason reason) {
+    if (_stopReason != null) return;
+    _stopReason = reason;
+    for (final listener in List.of(_stopListeners)) {
+      listener(reason);
+    }
+  }
+
+  void Function() addStopListener(void Function(MlStopReason) listener) {
+    _stopListeners.add(listener);
+    final reason = _stopReason;
+    if (reason != null) {
+      listener(reason);
+    }
+    return () => _stopListeners.remove(listener);
+  }
+}

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -4,6 +4,7 @@ import "dart:io" show File, Platform;
 import "dart:math" show min;
 import "dart:typed_data" show Uint8List;
 
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import "package:flutter/foundation.dart" show kDebugMode;
 import "package:logging/logging.dart";
 import "package:photos/core/event_bus.dart";
@@ -28,14 +29,19 @@ import "package:photos/services/machine_learning/face_ml/face_detection/detectio
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
 import "package:photos/services/machine_learning/ml_indexing_isolate.dart";
 import "package:photos/services/machine_learning/ml_model_download_service.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/services/machine_learning/ml_result.dart";
+import "package:photos/services/machine_learning/ml_run_control.dart";
 import "package:photos/services/machine_learning/semantic_search/semantic_search_service.dart";
+import "package:photos/services/process_activity_service.dart";
 import "package:photos/services/search_service.dart";
 import "package:photos/services/video_preview_service.dart";
 import "package:photos/utils/isolate/isolate_operations.dart";
 import "package:photos/utils/ml_util.dart";
 import "package:photos/utils/network_util.dart";
 import "package:photos/utils/ram_check_util.dart";
+
+enum MlRunDisposition { completed, denied, stopped, failed }
 
 class MLService {
   final _logger = Logger("MLService");
@@ -64,8 +70,13 @@ class MLService {
   bool _isRunningML = false;
   bool _shouldPauseIndexingAndClustering = false;
   Timer? _predownloadLocalModelsTimer;
+  Timer? _automaticRetryTimer;
+  MlRunControl? _activeRunControl;
 
   static const _kPredownloadLocalModelsDelay = Duration(seconds: 10);
+  static const _kPermitRetryInterval = Duration(seconds: 5);
+  static const _kPermitRetryTimeout = Duration(seconds: 30);
+  static const _kBackgroundForegroundPollInterval = Duration(seconds: 3);
 
   bool get isRunningML =>
       _isRunningML || memoriesCacheService.isUpdatingMemories;
@@ -77,9 +88,6 @@ class MLService {
         ? _kForceClusteringFaceCountLocalGallery
         : _kForceClusteringFaceCount;
   }
-
-  MLDataDB get _mlDataDB =>
-      isLocalGalleryMode ? MLDataDB.localGalleryInstance : MLDataDB.instance;
 
   MLDataDB _dbForMode(MLMode mode) {
     return mode == MLMode.localGallery
@@ -266,14 +274,38 @@ class MLService {
     required String reason,
     int? skipHydrationIfCandidateFileCountAtMost,
   }) async {
+    MlProcessPermit? permit;
     try {
-      await _hydrateRemoteEmbeddingsForOwnedFilesInternal(
-        reason: reason,
-        skipHydrationIfCandidateFileCountAtMost:
-            skipHydrationIfCandidateFileCountAtMost,
+      final attempt = await MlProcessLock.instance.tryAcquire(
+        origin: MlProcessLockOrigin.foreground,
+        operation: MlProcessOperation.startupRemoteHydration,
+      );
+      permit = attempt.permit;
+      if (permit == null) {
+        _logger.info(
+          "Skipping owned remote ML hydration ($reason): another ML operation is active",
+        );
+        return;
+      }
+      await permit.run(
+        () => _hydrateRemoteEmbeddingsForOwnedFilesInternal(
+          reason: reason,
+          skipHydrationIfCandidateFileCountAtMost:
+              skipHydrationIfCandidateFileCountAtMost,
+        ),
       );
     } catch (e, s) {
       _logger.warning("Owned remote ML hydration ($reason) failed", e, s);
+    } finally {
+      try {
+        await permit?.release();
+      } catch (e, s) {
+        _logger.severe(
+          "Failed to release owned remote ML hydration permit",
+          e,
+          s,
+        );
+      }
     }
   }
 
@@ -307,25 +339,6 @@ class MLService {
     );
   }
 
-  Future<void> _waitForOwnedRemoteHydrationIfRunning() async {
-    final existing = _ownedRemoteHydrationFuture;
-    if (existing == null) {
-      return;
-    }
-    _logger.info(
-      "Waiting for owned remote ML hydration to finish before indexing",
-    );
-    try {
-      await existing;
-    } catch (e, s) {
-      _logger.warning(
-        "Owned remote ML hydration failed while indexing was waiting, continuing",
-        e,
-        s,
-      );
-    }
-  }
-
   void _schedulePredownloadLocalModels() {
     if (isProcessBg || _predownloadLocalModelsTimer?.isActive == true) {
       return;
@@ -355,77 +368,187 @@ class MLService {
     await personFeedbackService.syncPersonFeedback();
   }
 
-  Future<void> runAllML({bool force = false}) async {
+  Future<MlRunDisposition> runAllML({
+    bool force = false,
+    MlRunControl? runControl,
+  }) {
+    return _runAllML(
+      force: force,
+      runControl: runControl,
+      scheduleAutomaticRetry: !force,
+    );
+  }
+
+  Future<MlRunDisposition> _runAllML({
+    required bool force,
+    required MlRunControl? runControl,
+    required bool scheduleAutomaticRetry,
+  }) async {
     if (_isRunningML) {
       _logger.info("runAllML called while already running, skipping");
-      return;
+      return MlRunDisposition.denied;
     }
+    final control = runControl ?? MlRunControl();
+    if (control.stopRequested) {
+      _logger.info(
+        "runAllML stopped before starting: ${control.stopReason?.name}",
+      );
+      return MlRunDisposition.stopped;
+    }
+
+    final MLMode mode = isLocalGalleryMode
+        ? MLMode.localGallery
+        : MLMode.enteGallery;
+    bool computeAcquired = false;
+    MlProcessPermit? permit;
+    void Function()? removeStopListener;
+    Timer? foregroundPollTimer;
+    bool foregroundPollRunning = false;
     try {
       if (!hasGrantedMLConsent) {
         _logger.info("runAllML called without ML consent, skipping");
-        return;
+        return MlRunDisposition.denied;
       }
-      final MLMode mode = isLocalGalleryMode
-          ? MLMode.localGallery
-          : MLMode.enteGallery;
       final mlDataDB = _dbForMode(mode);
       if (force) {
         _mlControllerStatus = true;
       }
-      if (!_canRunMLFunction(function: "AllML") && !force) return;
-      if (!force && !computeController.requestCompute(ml: true)) return;
-      _isRunningML = true;
-      await sync();
-      if (_hasModeChanged(mode)) {
-        _logger.info("App mode changed during ML run, stopping");
-        return;
+      if (!_canRunMLFunction(function: "AllML") && !force) {
+        return MlRunDisposition.denied;
+      }
+      if (!force) {
+        computeAcquired = computeController.requestCompute(ml: true);
+        if (!computeAcquired) return MlRunDisposition.denied;
+      }
+      final permitResult = await _acquireProcessPermit(
+        operation: MlProcessOperation.fullRun,
+        waitForExplicitAction: force && !isProcessBg,
+        mode: mode,
+      );
+      permit = permitResult.permit;
+      if (permit == null) {
+        if (!permitResult.failed &&
+            !isProcessBg &&
+            scheduleAutomaticRetry &&
+            !force) {
+          _scheduleAutomaticRetry(mode);
+        }
+        return permitResult.failed
+            ? MlRunDisposition.failed
+            : MlRunDisposition.denied;
       }
 
-      final int unclusteredFacesCount = await mlDataDB
-          .getUnclusteredFaceCount();
-      if (unclusteredFacesCount > _forceClusteringFaceCountForMode(mode)) {
-        _logger.info(
-          "There are $unclusteredFacesCount unclustered faces, doing clustering first",
-        );
-        await clusterAllImages();
-      }
-      if (_mlControllerStatus == true) {
+      return await permit.run(() async {
+        _isRunningML = true;
+        _activeRunControl = control;
+        removeStopListener = control.addStopListener(_onRunStopRequested);
+        if (isProcessBg) {
+          foregroundPollTimer = Timer.periodic(
+            _kBackgroundForegroundPollInterval,
+            (_) async {
+              if (foregroundPollRunning || control.stopRequested) return;
+              foregroundPollRunning = true;
+              try {
+                if (await ProcessActivityService.instance
+                    .isForegroundRecentlyActive()) {
+                  control.requestStop(MlStopReason.foregroundActive);
+                }
+              } catch (e, s) {
+                _logger.warning("Failed to poll foreground activity", e, s);
+              } finally {
+                foregroundPollRunning = false;
+              }
+            },
+          );
+        }
+        if (control.stopRequested) return MlRunDisposition.stopped;
+
+        await sync();
+        if (control.stopRequested) return MlRunDisposition.stopped;
         if (_hasModeChanged(mode)) {
           _logger.info("App mode changed during ML run, stopping");
-          return;
+          control.requestStop(MlStopReason.manual);
+          return MlRunDisposition.stopped;
         }
-        // Refresh discover/memories caches before indexing using the same
-        // path in foreground and background runs.
-        magicCacheService.updateCache(forced: force).ignore();
-        memoriesCacheService.updateCache(forced: force).ignore();
-      }
-      if (canFetch()) {
-        await fetchAndIndexAllImages(mode: mode);
-      }
-      if (_hasModeChanged(mode)) {
-        _logger.info("App mode changed during ML run, stopping");
-        return;
-      }
-      if ((await mlDataDB.getUnclusteredFaceCount()) > 0) {
-        await clusterAllImages();
-      }
-      if (_mlControllerStatus == true) {
+
+        final int unclusteredFacesCount = await mlDataDB
+            .getUnclusteredFaceCount();
+        if (!control.stopRequested &&
+            unclusteredFacesCount > _forceClusteringFaceCountForMode(mode)) {
+          _logger.info(
+            "There are $unclusteredFacesCount unclustered faces, doing clustering first",
+          );
+          await _clusterAllImages(runControl: control, mode: mode);
+        }
+        if (control.stopRequested) return MlRunDisposition.stopped;
+        if (_mlControllerStatus == true) {
+          if (_hasModeChanged(mode)) {
+            _logger.info("App mode changed during ML run, stopping");
+            control.requestStop(MlStopReason.manual);
+            return MlRunDisposition.stopped;
+          }
+          // Refresh discover/memories caches before indexing using the same
+          // path in foreground and background runs.
+          magicCacheService.updateCache(forced: force).ignore();
+          memoriesCacheService.updateCache(forced: force).ignore();
+        }
+        if (!control.stopRequested && canFetch()) {
+          await _fetchAndIndexAllImages(mode: mode, runControl: control);
+        }
+        if (control.stopRequested) return MlRunDisposition.stopped;
         if (_hasModeChanged(mode)) {
           _logger.info("App mode changed during ML run, stopping");
-          return;
+          control.requestStop(MlStopReason.manual);
+          return MlRunDisposition.stopped;
         }
-        // Persist refreshed caches after ML so foreground can pick them up
-        // on the next resume, even when the work ran headlessly in background.
-        magicCacheService.updateCache().ignore();
-        memoriesCacheService.updateCache(forced: force).ignore();
-      }
+        if ((await mlDataDB.getUnclusteredFaceCount()) > 0) {
+          await _clusterAllImages(runControl: control, mode: mode);
+        }
+        if (control.stopRequested) return MlRunDisposition.stopped;
+        if (_mlControllerStatus == true) {
+          if (_hasModeChanged(mode)) {
+            _logger.info("App mode changed during ML run, stopping");
+            control.requestStop(MlStopReason.manual);
+            return MlRunDisposition.stopped;
+          }
+          // Persist refreshed caches after ML so foreground can pick them up
+          // on the next resume, even when the work ran headlessly in background.
+          magicCacheService.updateCache().ignore();
+          memoriesCacheService.updateCache(forced: force).ignore();
+        }
+        return MlRunDisposition.completed;
+      });
     } catch (e, s) {
       _logger.severe("runAllML failed", e, s);
-      rethrow;
+      return MlRunDisposition.failed;
     } finally {
-      _logger.info("ML finished running");
+      foregroundPollTimer?.cancel();
+      removeStopListener?.call();
       _isRunningML = false;
-      computeController.releaseCompute(ml: true);
+      if (identical(_activeRunControl, control)) {
+        _activeRunControl = null;
+        _cancelPauseIndexingAndClustering();
+      }
+      if (control.stopReason != null) {
+        _logger.info(
+          "ML drain completed after ${control.stopReason!.name} stop",
+        );
+      }
+      if (permit != null) {
+        try {
+          await permit.release();
+        } catch (e, s) {
+          _logger.severe("Failed to release ML process permit", e, s);
+        }
+      }
+      if (computeAcquired) computeController.releaseCompute(ml: true);
+      _logger.info("ML finished running");
+      if (!isProcessBg &&
+          control.stopReason == MlStopReason.controller &&
+          _mlControllerStatus &&
+          hasGrantedMLConsent) {
+        _scheduleAutomaticRetry(mode);
+      }
       if (!isProcessBg) {
         VideoPreviewService.instance.queueFiles();
       }
@@ -440,29 +563,151 @@ class MLService {
     }
   }
 
+  Future<({MlProcessPermit? permit, bool failed})> _acquireProcessPermit({
+    required MlProcessOperation operation,
+    required bool waitForExplicitAction,
+    required MLMode mode,
+  }) async {
+    final token = MlProcessLock.instance.newOperationToken();
+    final deadline = DateTime.now().add(_kPermitRetryTimeout);
+    while (true) {
+      try {
+        final attempt = await MlProcessLock.instance.tryAcquire(
+          origin: isProcessBg
+              ? MlProcessLockOrigin.background
+              : MlProcessLockOrigin.foreground,
+          operation: operation,
+          token: token,
+        );
+        if (attempt.permit != null) {
+          return (permit: attempt.permit, failed: false);
+        }
+      } catch (_) {
+        return (permit: null, failed: true);
+      }
+      if (!waitForExplicitAction ||
+          DateTime.now().add(_kPermitRetryInterval).isAfter(deadline)) {
+        if (waitForExplicitAction) {
+          _logger.warning(
+            "Timed out waiting for ${operation.name} ML process permit",
+          );
+        }
+        return (permit: null, failed: false);
+      }
+      await Future<void>.delayed(_kPermitRetryInterval);
+      if (!hasGrantedMLConsent || _hasModeChanged(mode)) {
+        return (permit: null, failed: false);
+      }
+    }
+  }
+
+  void _scheduleAutomaticRetry(MLMode mode) {
+    if (_automaticRetryTimer?.isActive == true) return;
+    _logger.info("Scheduling one automatic ML retry");
+    _automaticRetryTimer = Timer(_kPermitRetryInterval, () {
+      _automaticRetryTimer = null;
+      if (!hasGrantedMLConsent || isProcessBg || _hasModeChanged(mode)) return;
+      unawaited(
+        _runAllML(
+          force: false,
+          runControl: null,
+          scheduleAutomaticRetry: false,
+        ),
+      );
+    });
+  }
+
+  void _onRunStopRequested(MlStopReason reason) {
+    _logger.info("Stopping active ML run and draining: ${reason.name}");
+    _shouldPauseIndexingAndClustering = true;
+    MLIndexingIsolate.instance.shouldPauseIndexingAndClustering = true;
+  }
+
   void pauseIndexingAndClustering() {
-    if (_isIndexingOrClusteringRunning) {
+    final activeRunControl = _activeRunControl;
+    if (activeRunControl != null) {
+      activeRunControl.requestStop(MlStopReason.controller);
+    } else if (_isIndexingOrClusteringRunning) {
       _shouldPauseIndexingAndClustering = true;
       MLIndexingIsolate.instance.shouldPauseIndexingAndClustering = true;
     }
   }
 
   void _cancelPauseIndexingAndClustering() {
+    if (_activeRunControl?.stopRequested == true) return;
     _shouldPauseIndexingAndClustering = false;
     MLIndexingIsolate.instance.shouldPauseIndexingAndClustering = false;
+  }
+
+  Future<MlRunDisposition> _runDirectOperation({
+    required MlProcessOperation operation,
+    required MLMode mode,
+    required MlRunControl runControl,
+    required Future<void> Function() body,
+  }) async {
+    final permitResult = await _acquireProcessPermit(
+      operation: operation,
+      waitForExplicitAction: !isProcessBg,
+      mode: mode,
+    );
+    final permit = permitResult.permit;
+    if (permit == null) {
+      return permitResult.failed
+          ? MlRunDisposition.failed
+          : MlRunDisposition.denied;
+    }
+
+    void Function()? removeStopListener;
+    try {
+      _activeRunControl = runControl;
+      removeStopListener = runControl.addStopListener(_onRunStopRequested);
+      if (runControl.stopRequested) return MlRunDisposition.stopped;
+      await permit.run(body);
+      return runControl.stopRequested
+          ? MlRunDisposition.stopped
+          : MlRunDisposition.completed;
+    } finally {
+      removeStopListener?.call();
+      if (identical(_activeRunControl, runControl)) {
+        _activeRunControl = null;
+        _cancelPauseIndexingAndClustering();
+      }
+      if (runControl.stopReason != null) {
+        _logger.info(
+          "Direct ML drain completed after ${runControl.stopReason!.name} stop",
+        );
+      }
+      try {
+        await permit.release();
+      } catch (e, s) {
+        _logger.severe("Failed to release direct ML process permit", e, s);
+      }
+    }
   }
 
   /// Analyzes all the images in the user library with the latest ml version and stores the results in the database.
   ///
   /// This function first fetches from remote and checks if the image has already been analyzed
   /// with the lastest faceMlVersion and stored on remote or local database. If so, it skips the image.
-  Future<void> fetchAndIndexAllImages({required MLMode mode}) async {
-    if (!_canRunMLFunction(function: "Indexing")) return;
-    if (mode == MLMode.enteGallery && !isLocalGalleryMode) {
-      await _waitForOwnedRemoteHydrationIfRunning();
+  Future<MlRunDisposition> fetchAndIndexAllImages({
+    required MLMode mode,
+  }) async {
+    if (!_canRunMLFunction(function: "Indexing")) {
+      return MlRunDisposition.denied;
     }
-    if (!_canRunMLFunction(function: "Indexing")) return;
+    final control = MlRunControl();
+    return _runDirectOperation(
+      operation: MlProcessOperation.indexing,
+      mode: mode,
+      runControl: control,
+      body: () => _fetchAndIndexAllImages(mode: mode, runControl: control),
+    );
+  }
 
+  Future<void> _fetchAndIndexAllImages({
+    required MLMode mode,
+    required MlRunControl runControl,
+  }) async {
     bool rustRuntimePrepared = false;
     try {
       _isIndexingOrClusteringRunning = true;
@@ -480,6 +725,10 @@ class MLService {
 
       stream:
       await for (final chunk in instructionStream) {
+        if (runControl.stopRequested) {
+          _logger.info("Image indexing stopped before starting another chunk");
+          break stream;
+        }
         if ((isLocalGalleryMode ? MLMode.localGallery : MLMode.enteGallery) !=
             mode) {
           _logger.info(
@@ -508,18 +757,25 @@ class MLService {
             rustRuntimePrepared = true;
           }
         }
+        if (runControl.stopRequested) {
+          _logger.info("Image indexing stopped after preparing the next chunk");
+          break stream;
+        }
         final futures = <Future<bool>>[];
+        bool stopAfterChunk = false;
         for (final instruction in chunk) {
           if ((isLocalGalleryMode ? MLMode.localGallery : MLMode.enteGallery) !=
               mode) {
             _logger.info(
               "App mode changed during indexing, stopping current ML run",
             );
-            break stream;
+            stopAfterChunk = true;
+            break;
           }
-          if (_shouldPauseIndexingAndClustering) {
+          if (runControl.stopRequested || _shouldPauseIndexingAndClustering) {
             _logger.info("indexAllImages() was paused, stopping");
-            break stream;
+            stopAfterChunk = true;
+            break;
           }
           futures.add(processImage(instruction));
         }
@@ -529,12 +785,15 @@ class MLService {
           (previousValue, element) => previousValue + (element ? 1 : 0),
         );
         fileAnalyzedCount += sumFutures;
+        if (stopAfterChunk || runControl.stopRequested) {
+          break stream;
+        }
       }
       if (fileAnalyzedCount > 0) {
         magicCacheService.queueUpdate('fileIndexed');
       }
       _logger.info(
-        "`indexAllImages()` finished. Analyzed $fileAnalyzedCount images, in ${stopwatch.elapsed.inSeconds} seconds (avg of ${stopwatch.elapsed.inSeconds / fileAnalyzedCount} seconds per image)",
+        "`indexAllImages()` finished. Analyzed $fileAnalyzedCount images, in ${stopwatch.elapsed.inSeconds} seconds",
       );
       _logStatus();
     } on RustCorruptModelException catch (e) {
@@ -547,15 +806,35 @@ class MLService {
       await MLIndexingIsolate.instance.releaseRustRuntime();
       MLModelDownloadService.instance.invalidateModelDownloadCache();
       _isIndexingOrClusteringRunning = false;
-      _cancelPauseIndexingAndClustering();
     }
   }
 
-  Future<void> clusterAllImages({
+  Future<MlRunDisposition> clusterAllImages({
     bool clusterInBuckets = true,
     bool force = false,
   }) async {
-    if (!_canRunMLFunction(function: "Clustering") && !force) return;
+    if (!_canRunMLFunction(function: "Clustering") && !force) {
+      return MlRunDisposition.denied;
+    }
+    final mode = isLocalGalleryMode ? MLMode.localGallery : MLMode.enteGallery;
+    final control = MlRunControl();
+    return _runDirectOperation(
+      operation: MlProcessOperation.clustering,
+      mode: mode,
+      runControl: control,
+      body: () => _clusterAllImages(
+        runControl: control,
+        mode: mode,
+        clusterInBuckets: clusterInBuckets,
+      ),
+    );
+  }
+
+  Future<void> _clusterAllImages({
+    required MlRunControl runControl,
+    required MLMode mode,
+    bool clusterInBuckets = true,
+  }) async {
     if (_clusteringIsHappening) {
       _logger.info("clusterAllImages() is already running, returning");
       return;
@@ -565,35 +844,41 @@ class MLService {
     _isIndexingOrClusteringRunning = true;
     _clusteringIsHappening = true;
     final clusterAllImagesTime = DateTime.now();
-
-    final faceIdNotToCluster = <String, List<String>>{};
-    if (!isLocalGalleryMode) {
-      _logger.info('Pulling remote feedback before actually clustering');
-      await PersonService.instance.fetchRemoteClusterFeedback();
-      final persons = await PersonService.instance.getPersons();
-      for (final person in persons) {
-        if (person.data.rejectedFaceIDs.isNotEmpty) {
-          final personClusters = person.data.assigned.map((e) => e.id).toList();
-          for (final faceID in person.data.rejectedFaceIDs) {
-            faceIdNotToCluster[faceID] = personClusters;
-          }
-        }
-      }
-    } else {
-      _logger.info("Skipping person metadata in local gallery mode");
-    }
+    final mlDataDB = _dbForMode(mode);
 
     try {
+      if (runControl.stopRequested || _hasModeChanged(mode)) return;
+      final faceIdNotToCluster = <String, List<String>>{};
+      if (mode == MLMode.enteGallery) {
+        _logger.info('Pulling remote feedback before actually clustering');
+        await PersonService.instance.fetchRemoteClusterFeedback();
+        if (runControl.stopRequested || _hasModeChanged(mode)) return;
+        final persons = await PersonService.instance.getPersons();
+        for (final person in persons) {
+          if (person.data.rejectedFaceIDs.isNotEmpty) {
+            final personClusters = person.data.assigned
+                .map((e) => e.id)
+                .toList();
+            for (final faceID in person.data.rejectedFaceIDs) {
+              faceIdNotToCluster[faceID] = personClusters;
+            }
+          }
+        }
+      } else {
+        _logger.info("Skipping person metadata in local gallery mode");
+      }
       // Get a sense of the total number of faces in the database
-      final int totalFaces = await _mlDataDB.getTotalFaceCount();
-      final fileIDToCreationTime = isLocalGalleryMode
+      final int totalFaces = await mlDataDB.getTotalFaceCount();
+      if (runControl.stopRequested || _hasModeChanged(mode)) return;
+      final fileIDToCreationTime = mode == MLMode.localGallery
           ? await _getLocalGalleryFileIdToCreationTime()
           : await FilesDB.instance.getFileIDToCreationTime();
       final startEmbeddingFetch = DateTime.now();
       // read all embeddings
-      final result = await _mlDataDB.getFaceInfoForClustering(
+      final result = await mlDataDB.getFaceInfoForClustering(
         maxFaces: totalFaces,
       );
+      if (runControl.stopRequested || _hasModeChanged(mode)) return;
       final Set<int> missingFileIDs = {};
       final allFaceInfoForClustering = <FaceDbInfoForClustering>[];
       for (final faceInfo in result) {
@@ -618,8 +903,9 @@ class MLService {
       );
 
       // Get the current cluster statistics
-      final Map<String, (Uint8List, int)> oldClusterSummaries = await _mlDataDB
+      final Map<String, (Uint8List, int)> oldClusterSummaries = await mlDataDB
           .getAllClusterSummary();
+      if (runControl.stopRequested || _hasModeChanged(mode)) return;
 
       if (clusterInBuckets) {
         const int bucketSize = 10000;
@@ -628,7 +914,9 @@ class MLService {
         int bucket = 1;
 
         while (true) {
-          if (_shouldPauseIndexingAndClustering) {
+          if (runControl.stopRequested ||
+              _shouldPauseIndexingAndClustering ||
+              _hasModeChanged(mode)) {
             _logger.info(
               "MLController does not allow running ML, stopping before clustering bucket $bucket",
             );
@@ -677,11 +965,17 @@ class MLService {
             _logger.warning("faceIdToCluster is null");
             return;
           }
+          if (runControl.stopRequested || _hasModeChanged(mode)) {
+            _logger.info(
+              "Discarding clustering bucket $bucket because the run stopped",
+            );
+            break;
+          }
 
-          await _mlDataDB.updateFaceIdToClusterId(
+          await mlDataDB.updateFaceIdToClusterId(
             clusteringResult.newFaceIdToCluster,
           );
-          await _mlDataDB.clusterSummaryUpdate(
+          await mlDataDB.clusterSummaryUpdate(
             clusteringResult.newClusterSummaries,
           );
           Bus.instance.fire(PeopleChangedEvent());
@@ -716,6 +1010,10 @@ class MLService {
           _logger.warning("faceIdToCluster is null");
           return;
         }
+        if (runControl.stopRequested || _hasModeChanged(mode)) {
+          _logger.info("Discarding clustering result because the run stopped");
+          return;
+        }
         final clusterDoneTime = DateTime.now();
         _logger.info(
           'done with clustering ${allFaceInfoForClustering.length} in ${clusterDoneTime.difference(clusterStartTime).inSeconds} seconds ',
@@ -725,10 +1023,10 @@ class MLService {
         _logger.info(
           'Updating ${clusteringResult.newFaceIdToCluster.length} FaceIDs with clusterIDs in the DB',
         );
-        await _mlDataDB.updateFaceIdToClusterId(
+        await mlDataDB.updateFaceIdToClusterId(
           clusteringResult.newFaceIdToCluster,
         );
-        await _mlDataDB.clusterSummaryUpdate(
+        await mlDataDB.clusterSummaryUpdate(
           clusteringResult.newClusterSummaries,
         );
         Bus.instance.fire(PeopleChangedEvent());
@@ -746,7 +1044,6 @@ class MLService {
     } finally {
       _clusteringIsHappening = false;
       _isIndexingOrClusteringRunning = false;
-      _cancelPauseIndexingAndClustering();
     }
   }
 

--- a/mobile/apps/photos/lib/services/machine_learning/semantic_search/semantic_search_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/semantic_search/semantic_search_service.dart
@@ -1,5 +1,6 @@
 import "dart:async" show Timer, unawaited;
 
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/cache/lru_map.dart";
@@ -15,6 +16,7 @@ import "package:photos/models/ml/ml_versions.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/collections_service.dart";
 import "package:photos/services/machine_learning/ml_computer.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/services/machine_learning/ml_result.dart";
 import "package:photos/services/machine_learning/semantic_search/query_result.dart";
 import "package:photos/services/search_service.dart";
@@ -117,7 +119,17 @@ class SemanticSearchService {
         await Future.delayed(_vectorDbMigrationDelay);
         if (!_shouldUseVectorDbApproximateSearch) return;
         if (!flagService.hasGrantedMLConsent) return;
-        await _mlDataDB.checkMigrateFillClipVectorDB();
+        final migrated = await MlProcessLock.instance.runExclusive(
+          origin: MlProcessLockOrigin.foreground,
+          operation: MlProcessOperation.vectorMaintenance,
+          body: _mlDataDB.checkMigrateFillClipVectorDB,
+        );
+        if (!migrated) {
+          _logger.info(
+            "Skipping ClipVectorDB migration while another ML operation is active",
+          );
+          return;
+        }
       }
       if (await _vectorDB.checkIfMigrationDone()) {
         await _vectorDB.warmupApproxSearch();
@@ -163,7 +175,15 @@ class SemanticSearchService {
   }
 
   Future<void> clearIndexes() async {
-    await _mlDataDB.deleteClipIndexes();
+    final cleared = await MlProcessLock.instance.runExclusive(
+      origin: MlProcessLockOrigin.foreground,
+      operation: MlProcessOperation.vectorMaintenance,
+      retryFor: const Duration(seconds: 30),
+      body: _mlDataDB.deleteClipIndexes,
+    );
+    if (!cleared) {
+      throw StateError("ML is busy; Clip indexes were not cleared");
+    }
     final preferences = await SharedPreferences.getInstance();
     await preferences.remove("sync_time_embeddings_v3");
     _logger.info("Indexes cleared");
@@ -271,7 +291,7 @@ class SemanticSearchService {
     _logger.info(results.length.toString() + " results");
 
     if (deletedEntries.isNotEmpty) {
-      unawaited(_mlDataDB.deleteClipEmbeddings(deletedEntries));
+      unawaited(_deleteStaleClipEmbeddings(deletedEntries));
     }
 
     return results;
@@ -313,7 +333,7 @@ class SemanticSearchService {
     }
 
     if (deletedEntries.isNotEmpty) {
-      unawaited(_mlDataDB.deleteClipEmbeddings(deletedEntries));
+      unawaited(_deleteStaleClipEmbeddings(deletedEntries));
     }
 
     return results;
@@ -383,6 +403,19 @@ class SemanticSearchService {
   Future<void> storeEmptyClipImageResult(EnteFile entefile) async {
     final embedding = ClipEmbedding.empty(entefile.uploadedFileID!);
     await _mlDataDB.putClip([embedding]);
+  }
+
+  Future<void> _deleteStaleClipEmbeddings(List<int> fileIDs) async {
+    final deleted = await MlProcessLock.instance.runExclusive(
+      origin: MlProcessLockOrigin.foreground,
+      operation: MlProcessOperation.vectorMaintenance,
+      body: () => _mlDataDB.deleteClipEmbeddings(fileIDs),
+    );
+    if (!deleted) {
+      _logger.info(
+        "Skipping stale ClipVectorDB cleanup while another ML operation is active",
+      );
+    }
   }
 
   Future<List<double>> _getTextEmbedding(String query) async {

--- a/mobile/apps/photos/lib/services/machine_learning/similar_images_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/similar_images_service.dart
@@ -1,6 +1,7 @@
 import "dart:io" show File;
 import "dart:math" show max;
 
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/foundation.dart" show kDebugMode;
 import "package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart"
@@ -13,6 +14,7 @@ import 'package:photos/models/file/file.dart';
 import "package:photos/models/similar_files.dart";
 import "package:photos/services/favorites_service.dart";
 import "package:photos/services/machine_learning/ml_computer.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/services/machine_learning/ml_result.dart";
 import "package:photos/services/search_service.dart";
 import "package:photos/utils/cache_util.dart";
@@ -59,7 +61,15 @@ class SimilarImagesService {
     final w = (kDebugMode ? EnteWatch('getSimilarFiles') : null)?..start();
     final mlDataDB = MLDataDB.instance;
     _logger.info("Checking migration and filling clip vector DB");
-    await mlDataDB.checkMigrateFillClipVectorDB();
+    final migrated = await MlProcessLock.instance.runExclusive(
+      origin: MlProcessLockOrigin.foreground,
+      operation: MlProcessOperation.vectorMaintenance,
+      retryFor: const Duration(seconds: 30),
+      body: mlDataDB.checkMigrateFillClipVectorDB,
+    );
+    if (!migrated) {
+      throw StateError("ML is busy; similar-image index is not ready");
+    }
     w?.log("checkMigrateFillClipVectorDB");
 
     // Get all files with CLIP embeddings first to avoid caching unindexed files

--- a/mobile/apps/photos/lib/services/process_activity_service.dart
+++ b/mobile/apps/photos/lib/services/process_activity_service.dart
@@ -1,0 +1,23 @@
+import "package:shared_preferences/shared_preferences.dart";
+
+const lastBackgroundTaskHeartbeatKey = "bg_task_hb_time";
+const lastForegroundTaskHeartbeatKey = "fg_task_hb_time";
+const processHeartbeatFrequency = Duration(seconds: 1);
+const foregroundActivityTimeout = Duration(seconds: 5);
+
+class ProcessActivityService {
+  ProcessActivityService._();
+
+  static final instance = ProcessActivityService._();
+
+  bool isBackgroundProcess = true;
+
+  Future<bool> isForegroundRecentlyActive() async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.reload();
+    final lastHeartbeat = preferences.getInt(lastForegroundTaskHeartbeatKey);
+    if (lastHeartbeat == null) return false;
+    final cutoff = DateTime.now().subtract(foregroundActivityTimeout);
+    return lastHeartbeat > cutoff.microsecondsSinceEpoch;
+  }
+}

--- a/mobile/apps/photos/lib/ui/settings/debug/ml_debug_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/debug/ml_debug_settings_page.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
@@ -15,6 +16,7 @@ import "package:photos/services/machine_learning/face_ml/face_clustering/face_cl
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
 import "package:photos/services/machine_learning/ml_indexing_isolate.dart";
 import "package:photos/services/machine_learning/ml_model_download_service.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/services/machine_learning/ml_service.dart";
 import "package:photos/services/machine_learning/semantic_search/semantic_search_service.dart";
 import "package:photos/theme/ente_theme.dart";
@@ -46,6 +48,16 @@ class _MLDebugSettingsPageState extends State<MLDebugSettingsPage> {
   late double _defaultClusteringDistance;
   late bool _persistAutoMergeThreshold;
   late bool _persistDefaultClusteringDistance;
+
+  Future<void> _runVectorMaintenance(Future<void> Function() body) async {
+    final completed = await MlProcessLock.instance.runExclusive(
+      origin: MlProcessLockOrigin.foreground,
+      operation: MlProcessOperation.vectorMaintenance,
+      retryFor: const Duration(seconds: 30),
+      body: body,
+    );
+    if (!completed) throw StateError("ML is busy; action did not run");
+  }
 
   @override
   void initState() {
@@ -766,8 +778,9 @@ class _MLDebugSettingsPageState extends State<MLDebugSettingsPage> {
   Future<void> _onTriggerRunML(BuildContext context) async {
     try {
       MLService.instance.debugIndexingDisabled = false;
-      unawaited(MLService.instance.runAllML());
-      showShortToast(context, "ML started");
+      final disposition = await MLService.instance.runAllML(force: true);
+      if (!context.mounted) return;
+      _showMlDisposition(context, disposition, "ML");
     } catch (e, s) {
       logger.warning('indexAndClusterAll failed ', e, s);
       await showGenericErrorDialog(context: context, error: e);
@@ -777,12 +790,11 @@ class _MLDebugSettingsPageState extends State<MLDebugSettingsPage> {
   Future<void> _onTriggerRunIndexing(BuildContext context) async {
     try {
       MLService.instance.debugIndexingDisabled = false;
-      unawaited(
-        MLService.instance.fetchAndIndexAllImages(
-          mode: isLocalGalleryMode ? MLMode.localGallery : MLMode.enteGallery,
-        ),
+      final disposition = await MLService.instance.fetchAndIndexAllImages(
+        mode: isLocalGalleryMode ? MLMode.localGallery : MLMode.enteGallery,
       );
-      showShortToast(context, "Indexing started");
+      if (!context.mounted) return;
+      _showMlDisposition(context, disposition, "Indexing");
     } catch (e, s) {
       logger.warning('indexing failed ', e, s);
       await showGenericErrorDialog(context: context, error: e);
@@ -793,15 +805,30 @@ class _MLDebugSettingsPageState extends State<MLDebugSettingsPage> {
     try {
       await PersonService.instance.fetchRemoteClusterFeedback();
       MLService.instance.debugIndexingDisabled = false;
-      await MLService.instance.clusterAllImages();
-      Bus.instance.fire(PeopleChangedEvent());
+      final disposition = await MLService.instance.clusterAllImages();
       if (!context.mounted) return;
-      showShortToast(context, "Done");
+      _showMlDisposition(context, disposition, "Clustering");
+      if (disposition != MlRunDisposition.completed) return;
+      Bus.instance.fire(PeopleChangedEvent());
     } catch (e, s) {
       logger.warning('clustering failed ', e, s);
       if (!context.mounted) return;
       await showGenericErrorDialog(context: context, error: e);
     }
+  }
+
+  void _showMlDisposition(
+    BuildContext context,
+    MlRunDisposition disposition,
+    String operation,
+  ) {
+    final message = switch (disposition) {
+      MlRunDisposition.completed => "$operation completed",
+      MlRunDisposition.denied => "ML is busy; $operation did not start",
+      MlRunDisposition.stopped => "$operation stopped",
+      MlRunDisposition.failed => "$operation failed",
+    };
+    showShortToast(context, message);
   }
 
   Future<void> _onUpdateDiscover(BuildContext context) async {
@@ -909,7 +936,9 @@ class _MLDebugSettingsPageState extends State<MLDebugSettingsPage> {
           for (final PersonEntity p in persons) {
             await PersonService.instance.deletePerson(p.remoteID);
           }
-          await mlDataDB.dropClustersAndPersonTable();
+          await _runVectorMaintenance(
+            () => mlDataDB.dropClustersAndPersonTable(),
+          );
           Bus.instance.fire(PeopleChangedEvent());
           if (!context.mounted) return;
           showShortToast(context, "Done");
@@ -931,7 +960,9 @@ class _MLDebugSettingsPageState extends State<MLDebugSettingsPage> {
       firstButtonLabel: "Yes, confirm",
       firstButtonOnTap: () async {
         try {
-          await mlDataDB.dropClustersAndPersonTable(faces: true);
+          await _runVectorMaintenance(
+            () => mlDataDB.dropClustersAndPersonTable(faces: true),
+          );
           Bus.instance.fire(PeopleChangedEvent());
           if (!context.mounted) return;
           showShortToast(context, "Done");
@@ -977,7 +1008,7 @@ class _MLDebugSettingsPageState extends State<MLDebugSettingsPage> {
           final vectorDB = isLocalGalleryMode
               ? ClipVectorDB.localGalleryInstance
               : ClipVectorDB.instance;
-          await vectorDB.deleteIndexFile();
+          await _runVectorMaintenance(vectorDB.deleteIndexFile);
           if (!context.mounted) return;
           showShortToast(context, "Done");
           if (mounted) {

--- a/mobile/apps/photos/lib/ui/settings/ml/ml_user_dev_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/ml/ml_user_dev_screen.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:ente_components/ente_components.dart";
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import "package:flutter/material.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/event_bus.dart";
@@ -10,7 +11,7 @@ import "package:photos/events/people_changed_event.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/machine_learning/face_ml/face_clustering/face_clustering_service.dart";
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
-import "package:photos/services/machine_learning/semantic_search/semantic_search_service.dart";
+import "package:photos/services/machine_learning/ml_process_lock.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/components/buttons/button_widget.dart";
 import "package:photos/ui/components/models/button_type.dart";
@@ -41,6 +42,16 @@ class _MLUserDeveloperOptionsState extends State<MLUserDeveloperOptions> {
   late double _defaultClusteringDistance;
   late bool _persistAutoMergeThreshold;
   late bool _persistDefaultClusteringDistance;
+
+  Future<void> _runVectorMaintenance(Future<void> Function() body) async {
+    final completed = await MlProcessLock.instance.runExclusive(
+      origin: MlProcessLockOrigin.foreground,
+      operation: MlProcessOperation.vectorMaintenance,
+      retryFor: const Duration(seconds: 30),
+      body: body,
+    );
+    if (!completed) throw StateError("ML is busy; action did not run");
+  }
 
   @override
   void initState() {
@@ -179,9 +190,11 @@ class _MLUserDeveloperOptionsState extends State<MLUserDeveloperOptions> {
   Future<void> deleteEmptyIndices(BuildContext context) async {
     try {
       final Set<int> emptyFileIDs = await mlDataDB.getErroredFileIDs();
-      await mlDataDB.deleteFaceIndexForFiles(emptyFileIDs.toList());
-      await mlDataDB.deleteClipEmbeddings(emptyFileIDs.toList());
-      await mlDataDB.deletePetDataForFiles(emptyFileIDs.toList());
+      await _runVectorMaintenance(() async {
+        await mlDataDB.deleteFaceIndexForFiles(emptyFileIDs.toList());
+        await mlDataDB.deleteClipEmbeddings(emptyFileIDs.toList());
+        await mlDataDB.deletePetDataForFiles(emptyFileIDs.toList());
+      });
       if (!context.mounted) return;
       showShortToast(context, "Deleted ${emptyFileIDs.length} entries");
     } catch (e) {
@@ -193,8 +206,10 @@ class _MLUserDeveloperOptionsState extends State<MLUserDeveloperOptions> {
 
   Future<void> deleteAllLocalML(BuildContext context) async {
     try {
-      await mlDataDB.dropClustersAndPersonTable(faces: true);
-      await SemanticSearchService.instance.clearIndexes();
+      await _runVectorMaintenance(() async {
+        await mlDataDB.dropClustersAndPersonTable(faces: true);
+        await mlDataDB.deleteClipIndexes();
+      });
       Bus.instance.fire(PeopleChangedEvent());
       if (!context.mounted) return;
       showShortToast(context, "All local ML cleared");

--- a/mobile/apps/photos/lib/utils/bg_task_utils.dart
+++ b/mobile/apps/photos/lib/utils/bg_task_utils.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:ente_pure_utils/ente_pure_utils.dart";
@@ -7,6 +8,8 @@ import "package:permission_handler/permission_handler.dart";
 import "package:photos/db/upload_locks_db.dart";
 import "package:photos/main.dart";
 import "package:photos/module/upload/service/file_uploader.dart";
+import "package:photos/services/machine_learning/ml_run_control.dart";
+import "package:photos/services/process_activity_service.dart";
 import "package:shared_preferences/shared_preferences.dart";
 import "package:workmanager/workmanager.dart" as workmanager;
 
@@ -15,31 +18,45 @@ void callbackDispatcher() {
   workmanager.Workmanager().executeTask((taskName, inputData) async {
     final TimeLogger tlog = TimeLogger();
     Future<bool> result = Future.error("Task didn't run");
-    final prefs = await SharedPreferences.getInstance();
-
-    await runWithLogs(() async {
-      try {
-        BgTaskUtils.$.info('Task started $tlog');
-        await runBackgroundTask(taskName, tlog).timeout(
-          Platform.isIOS ? kBGTaskTimeout : const Duration(hours: 1),
-          onTimeout: () async {
-            BgTaskUtils.$.warning(
-              "TLE, committing seppuku for taskID: $taskName",
-            );
-            await BgTaskUtils.releaseResourcesForKill(taskName, prefs);
-          },
-        );
-        BgTaskUtils.$.info('Task run successful $tlog');
-        result = Future.value(true);
-      } catch (e) {
-        BgTaskUtils.$.warning('Task error: $e');
-        await BgTaskUtils.releaseResourcesForKill(taskName, prefs);
-        result = Future.error(e.toString());
-      }
-    }, prefix: "[bg]").onError((_, _) {
-      result = Future.error("Didn't finished correctly!");
-      return;
-    });
+    final runControl = MlRunControl();
+    final selfStopTimer = Timer(
+      Platform.isIOS
+          ? const Duration(seconds: 25)
+          : const Duration(minutes: 55),
+      () => runControl.requestStop(MlStopReason.backgroundDeadline),
+    );
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await runWithLogs(() async {
+        try {
+          BgTaskUtils.$.info('Task started $tlog');
+          await runBackgroundTask(
+            taskName,
+            tlog,
+            runControl: runControl,
+          ).timeout(
+            Platform.isIOS ? kBGTaskTimeout : const Duration(hours: 1),
+            onTimeout: () async {
+              BgTaskUtils.$.warning(
+                "TLE, committing seppuku for taskID: $taskName",
+              );
+              await BgTaskUtils.releaseResourcesForKill(taskName, prefs);
+            },
+          );
+          BgTaskUtils.$.info('Task run successful $tlog');
+          result = Future.value(true);
+        } catch (e) {
+          BgTaskUtils.$.warning('Task error: $e');
+          await BgTaskUtils.releaseResourcesForKill(taskName, prefs);
+          result = Future.error(e.toString());
+        }
+      }, prefix: "[bg]").onError((_, _) {
+        result = Future.error("Didn't finished correctly!");
+        return;
+      });
+    } finally {
+      selfStopTimer.cancel();
+    }
 
     return result;
   });
@@ -56,7 +73,7 @@ class BgTaskUtils {
       ProcessType.background.toString(),
       DateTime.now().microsecondsSinceEpoch,
     );
-    await prefs.remove(kLastBGTaskHeartBeatTime);
+    await prefs.remove(lastBackgroundTaskHeartbeatKey);
   }
 
   static Future configureWorkmanager() async {

--- a/mobile/apps/photos/plugins/ente_photos_platform/android/build.gradle
+++ b/mobile/apps/photos/plugins/ente_photos_platform/android/build.gradle
@@ -45,3 +45,7 @@ android {
         minSdkVersion 23
     }
 }
+
+dependencies {
+    testImplementation 'junit:junit:4.13.2'
+}

--- a/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/MlProcessLockRegistry.kt
+++ b/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/MlProcessLockRegistry.kt
@@ -1,0 +1,68 @@
+package io.ente.photos.platform
+
+internal data class MlProcessLockState(
+    val token: String,
+    val pluginInstanceId: String,
+    val origin: String,
+    val operation: String,
+    val acquiredAtNanos: Long,
+)
+
+internal data class MlProcessLockAcquireResult(
+    val acquired: Boolean,
+    val holder: MlProcessLockState,
+)
+
+internal object MlProcessLockRegistry {
+    private val monitor = Any()
+    private var holder: MlProcessLockState? = null
+
+    fun tryAcquire(
+        pluginInstanceId: String,
+        token: String,
+        origin: String,
+        operation: String,
+        acquiredAtNanos: Long = System.nanoTime(),
+    ): MlProcessLockAcquireResult =
+        synchronized(monitor) {
+            val current = holder
+            if (current == null) {
+                val acquired =
+                    MlProcessLockState(
+                        token = token,
+                        pluginInstanceId = pluginInstanceId,
+                        origin = origin,
+                        operation = operation,
+                        acquiredAtNanos = acquiredAtNanos,
+                    )
+                holder = acquired
+                MlProcessLockAcquireResult(true, acquired)
+            } else {
+                MlProcessLockAcquireResult(
+                    current.pluginInstanceId == pluginInstanceId && current.token == token,
+                    current,
+                )
+            }
+        }
+
+    fun release(pluginInstanceId: String, token: String): Boolean =
+        synchronized(monitor) {
+            val current = holder
+            if (current?.pluginInstanceId != pluginInstanceId || current.token != token) {
+                return@synchronized false
+            }
+            holder = null
+            true
+        }
+
+    fun resetForInstance(pluginInstanceId: String): Boolean =
+        synchronized(monitor) {
+            if (holder?.pluginInstanceId != pluginInstanceId) {
+                return@synchronized false
+            }
+            holder = null
+            true
+        }
+
+    fun state(): MlProcessLockState? = synchronized(monitor) { holder }
+}

--- a/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/PhotosPlatformPlugin.kt
+++ b/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/PhotosPlatformPlugin.kt
@@ -11,6 +11,7 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import java.util.UUID
 
 class PhotosPlatformPlugin :
     FlutterPlugin,
@@ -20,6 +21,7 @@ class PhotosPlatformPlugin :
     private lateinit var eventChannel: EventChannel
     private lateinit var healthService: DeviceHealthService
     private var eventSink: EventChannel.EventSink? = null
+    private val pluginInstanceId = UUID.randomUUID().toString()
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         healthService = DeviceHealthService(binding.applicationContext)
@@ -34,6 +36,11 @@ class PhotosPlatformPlugin :
             "deviceHealth.getSnapshot" -> result.success(healthService.snapshot().toChannelMap())
             "deviceHealth.getMemorySnapshot" ->
                 result.success(healthService.memorySnapshot().toMemoryChannelMap())
+            "mlLock.tryAcquire" -> tryAcquireMlLock(call, result)
+            "mlLock.release" -> releaseMlLock(call, result)
+            "mlLock.state" -> result.success(MlProcessLockRegistry.state()?.toChannelMap())
+            "mlLock.resetForInstance" ->
+                result.success(MlProcessLockRegistry.resetForInstance(pluginInstanceId))
             else -> result.notImplemented()
         }
     }
@@ -51,11 +58,56 @@ class PhotosPlatformPlugin :
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        MlProcessLockRegistry.resetForInstance(pluginInstanceId)
         eventSink = null
         healthService.stopObserving()
         methodChannel.setMethodCallHandler(null)
         eventChannel.setStreamHandler(null)
     }
+
+    private fun tryAcquireMlLock(call: MethodCall, result: MethodChannel.Result) {
+        val token = call.nonEmptyStringArgument("token", result) ?: return
+        val origin = call.nonEmptyStringArgument("origin", result) ?: return
+        val operation = call.nonEmptyStringArgument("operation", result) ?: return
+        val acquireResult =
+            MlProcessLockRegistry.tryAcquire(
+                pluginInstanceId = pluginInstanceId,
+                token = token,
+                origin = origin,
+                operation = operation,
+            )
+        result.success(
+            mapOf(
+                "acquired" to acquireResult.acquired,
+                "holder" to acquireResult.holder.toChannelMap(),
+            ),
+        )
+    }
+
+    private fun releaseMlLock(call: MethodCall, result: MethodChannel.Result) {
+        val token = call.nonEmptyStringArgument("token", result) ?: return
+        result.success(MlProcessLockRegistry.release(pluginInstanceId, token))
+    }
+
+    private fun MethodCall.nonEmptyStringArgument(
+        name: String,
+        result: MethodChannel.Result,
+    ): String? {
+        val value = argument<String>(name)
+        if (value.isNullOrBlank()) {
+            result.error("invalid_argument", "$name must be a non-empty string", null)
+            return null
+        }
+        return value
+    }
+
+    private fun MlProcessLockState.toChannelMap(): Map<String, Any> =
+        mapOf(
+            "origin" to origin,
+            "operation" to operation,
+            "heldDurationMs" to
+                ((System.nanoTime() - acquiredAtNanos).coerceAtLeast(0L) / 1_000_000L),
+        )
 
     private fun DeviceHealthSnapshot.toChannelMap(): Map<String, Any?> =
         mapOf(

--- a/mobile/apps/photos/plugins/ente_photos_platform/android/src/test/kotlin/io/ente/photos/platform/MlProcessLockRegistryTest.kt
+++ b/mobile/apps/photos/plugins/ente_photos_platform/android/src/test/kotlin/io/ente/photos/platform/MlProcessLockRegistryTest.kt
@@ -1,0 +1,63 @@
+package io.ente.photos.platform
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MlProcessLockRegistryTest {
+    @After
+    fun tearDown() {
+        MlProcessLockRegistry.state()?.let {
+            MlProcessLockRegistry.resetForInstance(it.pluginInstanceId)
+        }
+    }
+
+    @Test
+    fun concurrentDifferentTokensHaveOneWinner() {
+        val ready = CountDownLatch(2)
+        val start = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+        val results =
+            listOf("first", "second").map { token ->
+                executor.submit<Boolean> {
+                    ready.countDown()
+                    start.await()
+                    MlProcessLockRegistry.tryAcquire("instance-$token", token, "fg", "fullRun").acquired
+                }
+            }
+
+        assertTrue(ready.await(1, TimeUnit.SECONDS))
+        start.countDown()
+        assertEquals(1, results.count { it.get(1, TimeUnit.SECONDS) })
+        executor.shutdownNow()
+    }
+
+    @Test
+    fun exactOwnerIsIdempotentAndOtherTokensAreDenied() {
+        assertTrue(MlProcessLockRegistry.tryAcquire("instance", "token", "fg", "fullRun").acquired)
+        assertEquals("fg", MlProcessLockRegistry.state()?.origin)
+        assertEquals("fullRun", MlProcessLockRegistry.state()?.operation)
+        assertTrue(MlProcessLockRegistry.tryAcquire("instance", "token", "fg", "fullRun").acquired)
+        assertFalse(MlProcessLockRegistry.tryAcquire("instance", "other", "fg", "indexing").acquired)
+        assertFalse(MlProcessLockRegistry.tryAcquire("other", "token", "bg", "fullRun").acquired)
+        assertFalse(MlProcessLockRegistry.release("instance", "other"))
+        assertFalse(MlProcessLockRegistry.release("other", "token"))
+        assertTrue(MlProcessLockRegistry.release("instance", "token"))
+        assertNull(MlProcessLockRegistry.state())
+    }
+
+    @Test
+    fun resetOnlyReleasesTheCallingInstance() {
+        MlProcessLockRegistry.tryAcquire("instance", "token", "bg", "fullRun")
+        assertFalse(MlProcessLockRegistry.resetForInstance("other"))
+        assertEquals("instance", MlProcessLockRegistry.state()?.pluginInstanceId)
+        assertTrue(MlProcessLockRegistry.resetForInstance("instance"))
+        assertNull(MlProcessLockRegistry.state())
+    }
+}

--- a/mobile/apps/photos/plugins/ente_photos_platform/ios/Classes/DeviceHealthService.swift
+++ b/mobile/apps/photos/plugins/ente_photos_platform/ios/Classes/DeviceHealthService.swift
@@ -1,4 +1,5 @@
 import Foundation
+#if canImport(UIKit)
 import UIKit
 
 @MainActor
@@ -152,3 +153,4 @@ public final class DeviceHealthService {
         }
     }
 }
+#endif

--- a/mobile/apps/photos/plugins/ente_photos_platform/ios/Classes/PhotosPlatformPlugin.swift
+++ b/mobile/apps/photos/plugins/ente_photos_platform/ios/Classes/PhotosPlatformPlugin.swift
@@ -7,6 +7,7 @@ public final class PhotosPlatformPlugin: NSObject, @preconcurrency FlutterPlugin
     private let eventChannel: FlutterEventChannel
     private let healthService = DeviceHealthService()
     private var eventSink: FlutterEventSink?
+    private let pluginInstanceID = UUID().uuidString
 
     private init(registrar: FlutterPluginRegistrar) {
         methodChannel = FlutterMethodChannel(
@@ -33,20 +34,88 @@ public final class PhotosPlatformPlugin: NSObject, @preconcurrency FlutterPlugin
             result(healthService.snapshot().channelValue)
         case "deviceHealth.getMemorySnapshot":
             result(healthService.memorySnapshot().memoryChannelValue)
+        case "mlLock.tryAcquire":
+            tryAcquireMlLock(call, result: result)
+        case "mlLock.release":
+            releaseMlLock(call, result: result)
+        case "mlLock.state":
+            result(MlProcessLockRegistry.shared.state()?.channelValue)
+        case "mlLock.resetForInstance":
+            result(MlProcessLockRegistry.shared.reset(for: pluginInstanceID))
         default:
             result(FlutterMethodNotImplemented)
         }
     }
 
     public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        MlProcessLockRegistry.shared.reset(for: pluginInstanceID)
         eventSink = nil
         healthService.stopObserving()
         methodChannel.setMethodCallHandler(nil)
         eventChannel.setStreamHandler(nil)
     }
 
+    private func tryAcquireMlLock(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard
+            let arguments = call.arguments as? [String: Any],
+            let token = nonEmptyString(arguments["token"]),
+            let origin = nonEmptyString(arguments["origin"]),
+            let operation = nonEmptyString(arguments["operation"])
+        else {
+            result(FlutterError(
+                code: "invalid_argument",
+                message: "token, origin, and operation must be non-empty strings",
+                details: nil
+            ))
+            return
+        }
+        let acquireResult = MlProcessLockRegistry.shared.tryAcquire(
+            pluginInstanceID: pluginInstanceID,
+            token: token,
+            origin: origin,
+            operation: operation
+        )
+        result([
+            "acquired": acquireResult.acquired,
+            "holder": acquireResult.holder.channelValue,
+        ])
+    }
+
+    private func releaseMlLock(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard
+            let arguments = call.arguments as? [String: Any],
+            let token = nonEmptyString(arguments["token"])
+        else {
+            result(FlutterError(
+                code: "invalid_argument",
+                message: "token must be a non-empty string",
+                details: nil
+            ))
+            return
+        }
+        result(MlProcessLockRegistry.shared.release(pluginInstanceID: pluginInstanceID, token: token))
+    }
+
+    private func nonEmptyString(_ value: Any?) -> String? {
+        guard let value = value as? String, !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
     private static let methodChannelName = "io.ente.photos.platform"
     private static let eventChannelName = "io.ente.photos.platform/device_health_events"
+}
+
+private extension MlProcessLockState {
+    var channelValue: [String: Any] {
+        let now = DispatchTime.now().uptimeNanoseconds
+        return [
+            "origin": origin,
+            "operation": operation,
+            "heldDurationMs": Int64(now >= acquiredAtUptimeNanoseconds ? (now - acquiredAtUptimeNanoseconds) / 1_000_000 : 0),
+        ]
+    }
 }
 
 extension PhotosPlatformPlugin: @preconcurrency FlutterStreamHandler {

--- a/mobile/apps/photos/plugins/ente_photos_platform/ios/Package.swift
+++ b/mobile/apps/photos/plugins/ente_photos_platform/ios/Package.swift
@@ -13,7 +13,13 @@ let package = Package(
             name: "PhotosPlatformCore",
             path: "Classes",
             exclude: ["PhotosPlatformPlugin.swift"]
-        )
+        ),
+        .target(name: "MlProcessLockCore"),
+        .testTarget(
+            name: "PhotosPlatformCoreTests",
+            dependencies: ["MlProcessLockCore"],
+            path: "Tests/PhotosPlatformCoreTests"
+        ),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/mobile/apps/photos/plugins/ente_photos_platform/ios/Sources/MlProcessLockCore/MlProcessLockRegistry.swift
+++ b/mobile/apps/photos/plugins/ente_photos_platform/ios/Sources/MlProcessLockCore/MlProcessLockRegistry.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+struct MlProcessLockState: Equatable {
+    let token: String
+    let pluginInstanceID: String
+    let origin: String
+    let operation: String
+    let acquiredAtUptimeNanoseconds: UInt64
+}
+
+struct MlProcessLockAcquireResult {
+    let acquired: Bool
+    let holder: MlProcessLockState
+}
+
+final class MlProcessLockRegistry: @unchecked Sendable {
+    static let shared = MlProcessLockRegistry()
+
+    private let lock = NSLock()
+    private var holder: MlProcessLockState?
+
+    func tryAcquire(
+        pluginInstanceID: String,
+        token: String,
+        origin: String,
+        operation: String,
+        acquiredAtUptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) -> MlProcessLockAcquireResult {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let holder {
+            return MlProcessLockAcquireResult(
+                acquired: holder.pluginInstanceID == pluginInstanceID && holder.token == token,
+                holder: holder
+            )
+        }
+        let acquired = MlProcessLockState(
+            token: token,
+            pluginInstanceID: pluginInstanceID,
+            origin: origin,
+            operation: operation,
+            acquiredAtUptimeNanoseconds: acquiredAtUptimeNanoseconds
+        )
+        holder = acquired
+        return MlProcessLockAcquireResult(acquired: true, holder: acquired)
+    }
+
+    func release(pluginInstanceID: String, token: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard holder?.pluginInstanceID == pluginInstanceID, holder?.token == token else {
+            return false
+        }
+        holder = nil
+        return true
+    }
+
+    func reset(for pluginInstanceID: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard holder?.pluginInstanceID == pluginInstanceID else {
+            return false
+        }
+        holder = nil
+        return true
+    }
+
+    func state() -> MlProcessLockState? {
+        lock.lock()
+        defer { lock.unlock() }
+        return holder
+    }
+}

--- a/mobile/apps/photos/plugins/ente_photos_platform/ios/Tests/PhotosPlatformCoreTests/MlProcessLockRegistryTests.swift
+++ b/mobile/apps/photos/plugins/ente_photos_platform/ios/Tests/PhotosPlatformCoreTests/MlProcessLockRegistryTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import MlProcessLockCore
+
+final class MlProcessLockRegistryTests: XCTestCase {
+    private let registry = MlProcessLockRegistry.shared
+
+    override func tearDown() {
+        if let holder = registry.state() {
+            _ = registry.reset(for: holder.pluginInstanceID)
+        }
+        super.tearDown()
+    }
+
+    func testConcurrentDifferentTokensHaveOneWinner() {
+        let start = DispatchSemaphore(value: 0)
+        let results = LockedResults()
+        let group = DispatchGroup()
+
+        for token in ["first", "second"] {
+            group.enter()
+            DispatchQueue.global().async {
+                start.wait()
+                let acquired = self.registry.tryAcquire(
+                    pluginInstanceID: "instance-\(token)",
+                    token: token,
+                    origin: "fg",
+                    operation: "fullRun"
+                ).acquired
+                results.append(acquired)
+                group.leave()
+            }
+        }
+        start.signal()
+        start.signal()
+        XCTAssertEqual(group.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(results.values.filter { $0 }.count, 1)
+    }
+
+    func testOwnershipAndResetSemantics() {
+        XCTAssertTrue(registry.tryAcquire(
+            pluginInstanceID: "instance",
+            token: "token",
+            origin: "bg",
+            operation: "fullRun"
+        ).acquired)
+        XCTAssertEqual(registry.state()?.origin, "bg")
+        XCTAssertEqual(registry.state()?.operation, "fullRun")
+        XCTAssertTrue(registry.tryAcquire(
+            pluginInstanceID: "instance",
+            token: "token",
+            origin: "bg",
+            operation: "fullRun"
+        ).acquired)
+        XCTAssertFalse(registry.tryAcquire(
+            pluginInstanceID: "instance",
+            token: "other",
+            origin: "fg",
+            operation: "indexing"
+        ).acquired)
+        XCTAssertFalse(registry.release(pluginInstanceID: "other", token: "token"))
+        XCTAssertFalse(registry.reset(for: "other"))
+        XCTAssertTrue(registry.reset(for: "instance"))
+        XCTAssertNil(registry.state())
+    }
+}
+
+private final class LockedResults: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Bool] = []
+
+    var values: [Bool] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func append(_ value: Bool) {
+        lock.lock()
+        storage.append(value)
+        lock.unlock()
+    }
+}

--- a/mobile/apps/photos/plugins/ente_photos_platform/ios/ente_photos_platform.podspec
+++ b/mobile/apps/photos/plugins/ente_photos_platform/ios/ente_photos_platform.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'AGPL-3.0-only' }
   s.author           = { 'Ente' => 'code@ente.com' }
   s.source           = { :path => '.' }
-  s.source_files     = 'Classes/**/*'
+  s.source_files     = 'Classes/**/*', 'Sources/MlProcessLockCore/**/*'
   s.dependency 'Flutter'
   s.platform         = :ios, '15.1'
   s.swift_version    = '5.0'

--- a/mobile/apps/photos/plugins/ente_photos_platform/lib/ente_photos_platform.dart
+++ b/mobile/apps/photos/plugins/ente_photos_platform/lib/ente_photos_platform.dart
@@ -1,1 +1,2 @@
 export 'src/device_health.dart';
+export 'src/ml_process_lock.dart';

--- a/mobile/apps/photos/plugins/ente_photos_platform/lib/src/ml_process_lock.dart
+++ b/mobile/apps/photos/plugins/ente_photos_platform/lib/src/ml_process_lock.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/services.dart';
+
+enum MlProcessLockOrigin {
+  foreground('fg'),
+  background('bg');
+
+  const MlProcessLockOrigin(this.channelValue);
+
+  final String channelValue;
+}
+
+class MlProcessLockState {
+  const MlProcessLockState({
+    required this.origin,
+    required this.operation,
+    required this.heldDuration,
+  });
+
+  factory MlProcessLockState.fromMap(Map<dynamic, dynamic> map) {
+    final origin = switch (map['origin']) {
+      'fg' => MlProcessLockOrigin.foreground,
+      'bg' => MlProcessLockOrigin.background,
+      final value => throw FormatException(
+        'ML process lock returned unsupported origin: $value',
+      ),
+    };
+    final operation = map['operation'];
+    final heldDurationMs = map['heldDurationMs'];
+    if (operation is! String || operation.isEmpty) {
+      throw const FormatException(
+        'ML process lock operation must be a non-empty string',
+      );
+    }
+    if (heldDurationMs is! int || heldDurationMs < 0) {
+      throw const FormatException(
+        'ML process lock held duration must be a non-negative integer',
+      );
+    }
+    return MlProcessLockState(
+      origin: origin,
+      operation: operation,
+      heldDuration: Duration(milliseconds: heldDurationMs),
+    );
+  }
+
+  final MlProcessLockOrigin origin;
+  final String operation;
+  final Duration heldDuration;
+}
+
+class MlProcessLockAcquireResult {
+  const MlProcessLockAcquireResult({
+    required this.acquired,
+    required this.holder,
+  });
+
+  final bool acquired;
+  final MlProcessLockState holder;
+}
+
+class MlProcessLockClient {
+  MlProcessLockClient({MethodChannel? methodChannel})
+    : _methodChannel = methodChannel ?? const MethodChannel(_methodChannelName);
+
+  static final instance = MlProcessLockClient();
+  static const _methodChannelName = 'io.ente.photos.platform';
+
+  final MethodChannel _methodChannel;
+  Future<void>? _initialization;
+
+  Future<MlProcessLockAcquireResult> tryAcquire({
+    required String token,
+    required MlProcessLockOrigin origin,
+    required String operation,
+  }) async {
+    _validateNonEmpty(token, 'token');
+    _validateNonEmpty(operation, 'operation');
+    await _ensureInitialized();
+    final result = await _methodChannel.invokeMethod<Map<dynamic, dynamic>>(
+      'mlLock.tryAcquire',
+      {'token': token, 'origin': origin.channelValue, 'operation': operation},
+    );
+    if (result == null || result['acquired'] is! bool) {
+      throw const FormatException(
+        'ML process lock returned an invalid acquire result',
+      );
+    }
+    final holder = result['holder'];
+    if (holder is! Map<dynamic, dynamic>) {
+      throw const FormatException(
+        'ML process lock acquire result has no holder state',
+      );
+    }
+    return MlProcessLockAcquireResult(
+      acquired: result['acquired'] as bool,
+      holder: MlProcessLockState.fromMap(holder),
+    );
+  }
+
+  Future<bool> release(String token) async {
+    _validateNonEmpty(token, 'token');
+    await _ensureInitialized();
+    final released = await _methodChannel.invokeMethod<bool>('mlLock.release', {
+      'token': token,
+    });
+    if (released == null) {
+      throw const FormatException(
+        'ML process lock returned an invalid release result',
+      );
+    }
+    return released;
+  }
+
+  Future<MlProcessLockState?> state() async {
+    await _ensureInitialized();
+    final state = await _methodChannel.invokeMethod<Map<dynamic, dynamic>>(
+      'mlLock.state',
+    );
+    return state == null ? null : MlProcessLockState.fromMap(state);
+  }
+
+  Future<void> _ensureInitialized() {
+    return _initialization ??= _resetForCurrentDartSession();
+  }
+
+  Future<void> _resetForCurrentDartSession() async {
+    final reset = await _methodChannel.invokeMethod<bool>(
+      'mlLock.resetForInstance',
+    );
+    if (reset == null) {
+      throw const FormatException(
+        'ML process lock returned an invalid initialization result',
+      );
+    }
+  }
+
+  void _validateNonEmpty(String value, String name) {
+    if (value.isEmpty) {
+      throw ArgumentError.value(value, name, 'must not be empty');
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a process-global token-based ML permit on Android and iOS, including hot-restart and engine-detach cleanup
- serialize full ML runs, direct indexing/clustering, startup hydration, and vector-maintenance workflows across foreground and background engines
- add durable stop-and-drain behavior for foreground priority and Workmanager deadlines while leaving user feedback actions ungated
- add native registry concurrency and ownership tests plus debug diagnostics for unpermitted vector writes

## Verification

- `flutter analyze`
- Android native unit tests and lint
- Swift native tests
- plugin Flutter tests
- Android independent debug APK build
- iOS simulator debug build