### PR TITLE
[mobile] Upgrade file_picker to 11.0.3

### DIFF
--- a/mobile/apps/auth/lib/ui/settings/data/import/encrypted_ente_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/encrypted_ente_import.dart
@@ -106,7 +106,7 @@ Future<void> _decryptExportData(
 }
 
 Future<void> _pickEnteJsonFile(BuildContext context) async {
-  FilePickerResult? result = await FilePicker.platform.pickFiles();
+  FilePickerResult? result = await FilePicker.pickFiles();
   if (result == null) {
     return;
   }

--- a/mobile/apps/auth/lib/ui/settings/data/import/import_flow.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/import_flow.dart
@@ -86,7 +86,7 @@ Future<void> pickAndProcessImportFile({
   bool showProgressBeforeProcessing = true,
   String Function(BuildContext context, Object error)? errorMessage,
 }) async {
-  final result = await FilePicker.platform.pickFiles(
+  final result = await FilePicker.pickFiles(
     dialogTitle: dialogTitle,
     allowMultiple: false,
     type: type,

--- a/mobile/apps/auth/lib/utils/gallery_import_util.dart
+++ b/mobile/apps/auth/lib/utils/gallery_import_util.dart
@@ -153,7 +153,7 @@ Future<GalleryImportResult?> pickCodeFromImage(
 
   try {
     if (!context.mounted) return null;
-    final FilePickerResult? result = await FilePicker.platform.pickFiles(
+    final FilePickerResult? result = await FilePicker.pickFiles(
       type: pickFromFiles ? FileType.custom : FileType.image,
       allowedExtensions: pickFromFiles
           ? const ['png', 'jpg', 'jpeg', 'webp', 'heic']

--- a/mobile/apps/auth/pubspec.yaml
+++ b/mobile/apps/auth/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   expandable: 5.0.1
   ffi: 2.2.0
   figma_squircle: 0.6.3
-  file_picker: 10.3.10
+  file_picker: 11.0.3
   file_saver: 0.3.1
   fixnum: 1.1.1
   flutter:

--- a/mobile/apps/locker/lib/ui/pages/uploader_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/uploader_page.dart
@@ -39,7 +39,7 @@ abstract class UploaderPageState<T extends UploaderPage> extends State<T> {
 
   /// Opens a file picker dialog and uploads the selected file
   Future<bool> addFile() async {
-    final FilePickerResult? result = await FilePicker.platform.pickFiles(
+    final FilePickerResult? result = await FilePicker.pickFiles(
       type: FileType.any,
       allowMultiple: true,
     );

--- a/mobile/apps/locker/pubspec.yaml
+++ b/mobile/apps/locker/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   event_bus: 2.0.1
   expandable: 5.0.1
   fast_base58: 0.2.1
-  file_picker: 10.3.10
+  file_picker: 11.0.3
   file_saver: 0.3.1
   flutter:
     sdk: flutter

--- a/mobile/packages/scoped_dir_access/lib/scoped_dir_access.dart
+++ b/mobile/packages/scoped_dir_access/lib/scoped_dir_access.dart
@@ -140,7 +140,7 @@ class DirUtils {
   Future<PickedDirectory?> _pickDirectoryMacOS() async {
     try {
       // Use file_picker to pick the directory
-      final path = await FilePicker.platform.getDirectoryPath();
+      final path = await FilePicker.getDirectoryPath();
       if (path == null) return null;
 
       // Create a security-scoped bookmark from the picked path
@@ -173,7 +173,7 @@ class DirUtils {
 
   Future<PickedDirectory?> _pickDirectoryOther() async {
     try {
-      final path = await FilePicker.platform.getDirectoryPath();
+      final path = await FilePicker.getDirectoryPath();
       if (path == null) return null;
 
       return PickedDirectory(path: path);

--- a/mobile/packages/scoped_dir_access/pubspec.yaml
+++ b/mobile/packages/scoped_dir_access/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   flutter: ">=2.5.0"
 
 dependencies:
-  file_picker: 10.3.10
+  file_picker: 11.0.3
   flutter:
     sdk: flutter
   logging: 1.3.0

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -744,10 +744,10 @@ packages:
     dependency: transitive
     description:
       name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      sha256: "29cc1fdb20613876cc7afc529738c1c0f11a9ca159b010edad0c566ac330847e"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "11.0.3"
   file_saver:
     dependency: transitive
     description:


### PR DESCRIPTION
Updates `file_picker` from 10.3.10 to 11.0.3 and migrates its six call sites to the static API.

This includes the Android cache path-traversal fix shipped in 11.0.2 and removes the package’s Tika dependency. No behavior change is intended.