### PR TITLE
[server] Classify canceled requests as client closed

### DIFF
--- a/server/pkg/utils/handler/handler.go
+++ b/server/pkg/utils/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"io"
@@ -17,6 +18,8 @@ import (
 )
 
 var errBindJSON = errors.New("bind json")
+
+const statusClientClosedRequest = 499
 
 type bindJSONError struct {
 	err error
@@ -42,6 +45,11 @@ func BindJSON(c *gin.Context, obj any) error {
 }
 
 func Error(c *gin.Context, err error) {
+	if c.Request.Context().Err() == context.Canceled {
+		c.AbortWithStatus(statusClientClosedRequest)
+		return
+	}
+
 	unWrappedErr := errors.Unwrap(err)
 	if unWrappedErr == nil {
 		unWrappedErr = err

--- a/server/pkg/utils/handler/handler_test.go
+++ b/server/pkg/utils/handler/handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -166,6 +167,21 @@ func TestErrorLogsUnexpectedErrors(t *testing.T) {
 	require.NotNil(t, entry)
 	require.Equal(t, log.ErrorLevel, entry.Level)
 	require.Equal(t, "Request failed", entry.Message)
+}
+
+func TestErrorDoesNotReportCanceledRequestAsServerFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder, ctx := testContext()
+	requestContext, cancel := context.WithCancel(ctx.Request.Context())
+	ctx.Request = ctx.Request.WithContext(requestContext)
+	cancel()
+	hook := testLogHook(t)
+
+	Error(ctx, errors.New("database query canceled"))
+
+	require.Equal(t, statusClientClosedRequest, recorder.Code)
+	require.Empty(t, hook.AllEntries())
 }
 
 func TestErrorPreservesNotFoundAPIErrorResponse(t *testing.T) {


### PR DESCRIPTION
- Return 499 without error-level logging when the HTTP request context is already canceled.
- Preserve existing error classification for active requests.

Validation: `go test -race ./pkg/utils/handler -count=1`, `./scripts/lint.sh`, `./scripts/test-with-postgres.sh host`