### PR TITLE
[mobile][photos] fix ui clipping in BillingQuestionsWidget & improve FAQ parsing safety

### DIFF
--- a/mobile/apps/photos/changes/billing-questions-widget.md
+++ b/mobile/apps/photos/changes/billing-questions-widget.md
@@ -1,0 +1,1 @@
+- Fixed clip behavior and error handling in billing questions widget. (@r4khul)

--- a/mobile/apps/photos/lib/ui/payment/billing_questions_widget.dart
+++ b/mobile/apps/photos/lib/ui/payment/billing_questions_widget.dart
@@ -16,8 +16,12 @@ class BillingQuestionsWidget extends StatelessWidget {
           .get("https://static.ente.com/faq.json")
           .then((response) {
             final faqItems = <FaqItem>[];
-            for (final item in response.data as List) {
-              faqItems.add(FaqItem.fromMap(item));
+            if (response.data is List) {
+              for (final item in response.data as List) {
+                if (item is Map<String, dynamic>) {
+                  faqItems.add(FaqItem.fromMap(item));
+                }
+              }
             }
             return faqItems;
           }),
@@ -33,7 +37,7 @@ class BillingQuestionsWidget extends StatelessWidget {
               ),
             ),
           );
-          for (final faq in snapshot.data) {
+          for (final faq in snapshot.data as List<FaqItem>) {
             faqs.add(FaqWidget(faq: faq));
           }
           faqs.add(const Padding(padding: EdgeInsets.all(16)));
@@ -49,7 +53,7 @@ class BillingQuestionsWidget extends StatelessWidget {
 class FaqWidget extends StatelessWidget {
   const FaqWidget({super.key, required this.faq});
 
-  final FaqItem? faq;
+  final FaqItem faq;
 
   @override
   Widget build(BuildContext context) {
@@ -59,11 +63,15 @@ class FaqWidget extends StatelessWidget {
       borderRadius: BorderRadius.all(Radius.circular(8)),
     );
 
+    final question = faq.q ?? '';
+    final answer = faq.a ?? '';
+
     return Padding(
       padding: const EdgeInsets.all(2),
       child: ExpansionTile(
-        key: PageStorageKey(faq!.q),
-        title: Text(faq!.q!),
+        key: PageStorageKey(question),
+        clipBehavior: Clip.antiAlias,
+        title: Text(question),
         tilePadding: const EdgeInsets.symmetric(horizontal: 18),
         textColor: expandedColor,
         collapsedTextColor: theme.textTheme.titleMedium?.color,
@@ -76,7 +84,7 @@ class FaqWidget extends StatelessWidget {
         children: [
           Padding(
             padding: const EdgeInsets.only(left: 16, right: 16, bottom: 12),
-            child: Text(faq!.a!, style: const TextStyle(height: 1.5)),
+            child: Text(answer, style: const TextStyle(height: 1.5)),
           ),
         ],
       ),
@@ -98,7 +106,10 @@ class FaqItem {
   }
 
   factory FaqItem.fromMap(Map<String, dynamic> map) {
-    return FaqItem(q: map['q'] ?? 'q', a: map['a'] ?? 'a');
+    return FaqItem(
+      q: map['q']?.toString() ?? '',
+      a: map['a']?.toString() ?? '',
+    );
   }
 
   String toJson() => json.encode(toMap());

--- a/mobile/apps/photos/lib/ui/payment/subscription_common_widgets.dart
+++ b/mobile/apps/photos/lib/ui/payment/subscription_common_widgets.dart
@@ -117,6 +117,10 @@ class SubFaqWidget extends StatelessWidget {
             backgroundColor: Theme.of(context).colorScheme.bgColorForQuestions,
             barrierColor: Colors.black87,
             context: context,
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+            ),
+            clipBehavior: Clip.antiAlias,
             builder: (context) {
               return const SafeArea(child: BillingQuestionsWidget());
             },


### PR DESCRIPTION
## Description

Fixed UI clipping behavior and improved parsing safety for the billing FAQ modal sheet.

* **UI Clipping:** Added `Clip.antiAlias` and rounded top corners (`Radius.circular(20)`) to the `SubFaqWidget` bottom sheet and FAQ `ExpansionTile` items to prevent visual overflow at the corners.
* **Parsing Safety:** Added type validation (`item is Map<String, dynamic>`) and null fallbacks (`q ?? ''`, `a ?? ''`) in `FaqItem.fromMap` and `FaqWidget` to handle malformed or missing FAQ data safely.


## Visuals
<img width="5542" height="1954" alt="image" src="https://github.com/user-attachments/assets/c259c34f-d3bc-45e6-b0cb-aad13cb41536" />