### PR TITLE
[mobile][photos] Format delete file utility

### DIFF
--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -293,10 +293,7 @@ Future<List<EnteFile>> deleteFilesOnDeviceOnly(
   return deletedFiles;
 }
 
-Future<bool> deleteFromTrash(
-  BuildContext context,
-  List<EnteFile> files,
-) async {
+Future<bool> deleteFromTrash(BuildContext context, List<EnteFile> files) async {
   final trashFiles = files.map((file) => file as EnteTrashFile).toList();
   bool didDeletionStart = false;
   final l10n = context.strings;


### PR DESCRIPTION
## What changed

Formatted `mobile/apps/photos/lib/utils/delete_file_util.dart` with the Dart formatter.

## Why

The file on `main` did not pass the repository's mobile formatting check.

## Impact

No behavior changes. This only updates whitespace and line wrapping.

## Checks

- `fvm dart format --output=none --set-exit-if-changed .` (from `mobile`)