### PR TITLE
[mobile][photos] Fix retired model cleanup race

### DIFF
--- a/mobile/apps/photos/lib/services/remote_assets_service.dart
+++ b/mobile/apps/photos/lib/services/remote_assets_service.dart
@@ -4,6 +4,8 @@ import "dart:io";
 
 import "package:crypto/crypto.dart";
 import "package:dio/dio.dart";
+import "package:ente_pure_utils/ente_pure_utils.dart"
+    show deleteFileSystemEntityIfPresent;
 import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
 import "package:path_provider/path_provider.dart";
@@ -14,12 +16,11 @@ class RemoteAssetsService {
   static final _logger = Logger("RemoteAssetsService");
   static const int _resumableThresholdBytes = 10 * 1024 * 1024;
 
-  bool checkRemovedOldAssets = false;
-
   RemoteAssetsService._privateConstructor();
   final StreamController<(String, int, int)> _progressController =
       StreamController<(String, int, int)>.broadcast();
   final Map<String, Lock> _assetLocks = {};
+  Future<void>? _oldModelsCleanupFuture;
 
   Stream<(String, int, int)> get progressStream => _progressController.stream;
 
@@ -183,28 +184,33 @@ class RemoteAssetsService {
     );
   }
 
-  Future<void> cleanupOldModelsIfNeeded() async {
-    if (checkRemovedOldAssets) return;
-    const oldModelNames = [
-      "https://models.ente.io/clip-image-vit-32-float32.onnx",
-      "https://models.ente.io/clip-text-vit-32-uint8.onnx",
-      "https://models.ente.io/mobileclip_s2_image_opset18_rgba_sim.onnx",
-      "https://models.ente.io/mobileclip_s2_image_opset18_rgba_opt.onnx",
-      "https://models.ente.io/mobileclip_s2_text_int32.onnx",
-      "https://models.ente.io/yolov5s_face_opset18_rgba_opt.onnx",
-      "https://models.ente.io/yolov5s_face_opset18_rgba_opt_nosplits.onnx",
-      "https://models.ente.io/yolov5s_face_640_640_dynamic.onnx",
-      "https://models.ente.io/mobilefacenet_opset15.onnx",
-      "https://models.ente.com/yolov5s_face_640_640_dynamic.onnx",
-      "https://models.ente.com/mobilefacenet_opset15.onnx",
-      "https://models.ente.io/mobileclip_s2_image.onnx",
-      "https://models.ente.com/mobileclip_s2_image.onnx",
-    ];
+  Future<void> cleanupOldModelsIfNeeded() =>
+      _oldModelsCleanupFuture ??= _cleanupOldModels();
 
-    await cleanupSelectedModels(oldModelNames);
+  Future<void> _cleanupOldModels() async {
+    try {
+      const oldModelNames = [
+        "https://models.ente.io/clip-image-vit-32-float32.onnx",
+        "https://models.ente.io/clip-text-vit-32-uint8.onnx",
+        "https://models.ente.io/mobileclip_s2_image_opset18_rgba_sim.onnx",
+        "https://models.ente.io/mobileclip_s2_image_opset18_rgba_opt.onnx",
+        "https://models.ente.io/mobileclip_s2_text_int32.onnx",
+        "https://models.ente.io/yolov5s_face_opset18_rgba_opt.onnx",
+        "https://models.ente.io/yolov5s_face_opset18_rgba_opt_nosplits.onnx",
+        "https://models.ente.io/yolov5s_face_640_640_dynamic.onnx",
+        "https://models.ente.io/mobilefacenet_opset15.onnx",
+        "https://models.ente.com/yolov5s_face_640_640_dynamic.onnx",
+        "https://models.ente.com/mobilefacenet_opset15.onnx",
+        "https://models.ente.io/mobileclip_s2_image.onnx",
+        "https://models.ente.com/mobileclip_s2_image.onnx",
+      ];
 
-    checkRemovedOldAssets = true;
-    _logger.info("Old ML models cleaned up");
+      await cleanupSelectedModels(oldModelNames);
+      _logger.info("Old ML models cleaned up");
+    } catch (_) {
+      _oldModelsCleanupFuture = null;
+      rethrow;
+    }
   }
 
   Future<void> cleanupSelectedModels(List<String> modelRemotePaths) async {
@@ -626,9 +632,7 @@ class RemoteAssetsService {
   }
 
   Future<void> _deleteFileIfExists(File file) async {
-    if (await file.exists()) {
-      await file.delete();
-    }
+    await deleteFileSystemEntityIfPresent(file);
   }
 
   void _emitProgress(String url, int received, int total) {


### PR DESCRIPTION
## Summary

- coalesce retired ML model cleanup into one initialization future per Dart isolate
- make model artifact deletion idempotent when foreground/background isolates race
- reset failed cleanup initialization so real filesystem errors remain retryable
- preserve parallel downloads for independent current models

## Testing

- `dart format apps/photos/lib/services/remote_assets_service.dart`
- `flutter analyze --no-pub apps/photos/lib/services/remote_assets_service.dart`
- `flutter test --no-pub packages/ente_pure_utils/test/directory_content_util_test.dart` (6 passed)
- full mobile analysis currently reports pre-existing generated localization and Rust binding errors; the modified file passes targeted analysis