### PR TITLE
[mobile] Fix syncing edited iOS photos after origin fetches

### DIFF
--- a/mobile/apps/photos/changes/ios-edited-photo-sync.md
+++ b/mobile/apps/photos/changes/ios-edited-photo-sync.md
@@ -1,0 +1,1 @@
+- Fixed edited iOS photos sometimes not syncing after their originals were fetched.

--- a/mobile/apps/photos/lib/module/upload/upload_data.dart
+++ b/mobile/apps/photos/lib/module/upload/upload_data.dart
@@ -24,7 +24,7 @@ import "package:photos/module/metadata/exif.dart";
 import 'package:photos/module/metadata/location.dart';
 import "package:photos/module/metadata/video.dart";
 import 'package:photos/module/upload/model/media_upload_data.dart';
-import "package:photos/services/sync/local_sync_service.dart";
+import "package:photos/services/sync/origin_fetch_tracker.dart";
 import "package:photos/src/rust/api/motion_photo_api.dart";
 import "package:photos/utils/apple_photos_errors.dart";
 import "package:photos/utils/device_storage_error.dart";
@@ -174,7 +174,13 @@ Future<AssetEntity> _getAsset(EnteFile file) async {
 
 Future<File> _getOriginFile(AssetEntity asset, EnteFile file) async {
   if (Platform.isIOS) {
-    trackOriginFetchForUploadOrML.put(file.localID!, true);
+    final modifiedDateSecond = asset.modifiedDateSecond;
+    originFetchTracker.record(
+      localID: file.localID,
+      modificationTime: modifiedDateSecond == null
+          ? null
+          : modifiedDateSecond * Duration.microsecondsPerSecond,
+    );
   }
   File? sourceFile;
   try {

--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -5,7 +5,6 @@ import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
 import "package:photo_manager/photo_manager.dart";
-import "package:photos/core/cache/lru_map.dart";
 import "package:photos/core/configuration.dart";
 import "package:photos/core/errors.dart";
 import "package:photos/core/event_bus.dart";
@@ -26,14 +25,10 @@ import "package:photos/services/ignored_files_service.dart";
 import "package:photos/services/sync/import/diff.dart";
 import "package:photos/services/sync/import/local_assets.dart";
 import "package:photos/services/sync/import/model.dart";
+import "package:photos/services/sync/origin_fetch_tracker.dart";
 import "package:shared_preferences/shared_preferences.dart";
 import "package:synchronized/synchronized.dart";
 import "package:tuple/tuple.dart";
-
-// This map is used to track if a iOS origin file is being fetched for uploading
-// or ML processing. In such cases, we want to ignore these files if they come in response
-// from the local sync service. When a file is download
-final LRUMap<String, bool> trackOriginFetchForUploadOrML = LRUMap(200);
 
 class LocalSyncService {
   final _logger = Logger("LocalSyncService");
@@ -397,10 +392,7 @@ class LocalSyncService {
     if (allFiles.isEmpty) return;
     final bool discoveredNewFiles = newlyInsertedFiles.isNotEmpty;
     if (!discoveredNewFiles) {
-      allFiles.removeWhere(
-        (file) =>
-            trackOriginFetchForUploadOrML.get(file.localID ?? '') ?? false,
-      );
+      allFiles.removeWhere(originFetchTracker.isUnchangedSinceFetch);
       if (allFiles.isEmpty) {
         _logger.info("skipping firing LocalPhotosUpdatedEvent as no new files");
         return;
@@ -431,26 +423,36 @@ class LocalSyncService {
     List<EnteFile> files,
     Set<String> existingLocalFileIDs,
   ) async {
-    final List<String> updatedLocalIDs = files
+    final List<EnteFile> updatedFiles = files
         .where(
           (file) =>
               file.localID != null &&
               existingLocalFileIDs.contains(file.localID),
         )
-        .map((e) => e.localID!)
         .toList();
 
-    if (updatedLocalIDs.isNotEmpty) {
-      final int updateCount = updatedLocalIDs.length;
-      updatedLocalIDs.removeWhere(
-        (x) => trackOriginFetchForUploadOrML.get(x) ?? false,
-      );
+    if (updatedFiles.isNotEmpty) {
+      final int updateCount = updatedFiles.length;
+      updatedFiles.removeWhere((file) {
+        final comparison = originFetchTracker.comparisonFor(file);
+        if (comparison == null) return false;
+
+        final title = file.title;
+        _logger.info(
+          "Origin fetch update decision for localID=${file.localID}"
+          "${title == null || title.isEmpty ? '' : ', title=$title'}, "
+          "modificationTime=${comparison.modificationTimeAtFetch} -> "
+          "${comparison.observedModificationTime}, "
+          "skipped=${comparison.shouldSkip}",
+        );
+        return comparison.shouldSkip;
+      });
       _logger.info(
-        "track ${updatedLocalIDs.length}/ $updateCount files due to modification change",
+        "track ${updatedFiles.length}/ $updateCount files due to modification change",
       );
-      if (updatedLocalIDs.isNotEmpty) {
+      if (updatedFiles.isNotEmpty) {
         await FileUpdationDB.instance.insertMultiple(
-          updatedLocalIDs,
+          updatedFiles.map((file) => file.localID!).toList(),
           FileUpdationDB.modificationTimeUpdated,
         );
       }

--- a/mobile/apps/photos/lib/services/sync/origin_fetch_tracker.dart
+++ b/mobile/apps/photos/lib/services/sync/origin_fetch_tracker.dart
@@ -1,0 +1,39 @@
+import "package:photos/core/cache/lru_map.dart";
+import "package:photos/models/file/file.dart";
+
+final originFetchTracker = OriginFetchTracker();
+
+typedef OriginFetchComparison = ({
+  int modificationTimeAtFetch,
+  int? observedModificationTime,
+  bool shouldSkip,
+});
+
+class OriginFetchTracker {
+  OriginFetchTracker({int capacity = 200})
+    : _modificationTimes = LRUMap(capacity);
+
+  final LRUMap<String, int> _modificationTimes;
+
+  void record({required String? localID, required int? modificationTime}) {
+    if (localID == null || modificationTime == null) return;
+    _modificationTimes.put(localID, modificationTime);
+  }
+
+  bool isUnchangedSinceFetch(EnteFile file) {
+    return comparisonFor(file)?.shouldSkip ?? false;
+  }
+
+  OriginFetchComparison? comparisonFor(EnteFile file) {
+    final localID = file.localID;
+    if (localID == null) return null;
+    final modificationTimeAtFetch = _modificationTimes.get(localID);
+    if (modificationTimeAtFetch == null) return null;
+    final observedModificationTime = file.modificationTime;
+    return (
+      modificationTimeAtFetch: modificationTimeAtFetch,
+      observedModificationTime: observedModificationTime,
+      shouldSkip: modificationTimeAtFetch == observedModificationTime,
+    );
+  }
+}

--- a/mobile/apps/photos/lib/utils/ml_util.dart
+++ b/mobile/apps/photos/lib/utils/ml_util.dart
@@ -31,7 +31,7 @@ import "package:photos/services/machine_learning/face_ml/face_detection/detectio
 import "package:photos/services/machine_learning/ml_exceptions.dart";
 import "package:photos/services/machine_learning/ml_result.dart";
 import "package:photos/services/search_service.dart";
-import "package:photos/services/sync/local_sync_service.dart";
+import "package:photos/services/sync/origin_fetch_tracker.dart";
 import "package:photos/src/rust/api/ml_indexing_api.dart" as rust_ml;
 import "package:photos/utils/network_util.dart";
 
@@ -740,8 +740,11 @@ Future<String> getImagePathForML(EnteFile enteFile) async {
       );
     }
     try {
-      if (Platform.isIOS && enteFile.localID != null) {
-        trackOriginFetchForUploadOrML.put(enteFile.localID!, true);
+      if (Platform.isIOS) {
+        originFetchTracker.record(
+          localID: enteFile.localID,
+          modificationTime: enteFile.modificationTime,
+        );
       }
       file = await getFile(enteFile, isOrigin: true);
     } catch (e, s) {


### PR DESCRIPTION
- Track iOS origin fetches by asset modification time instead of a Boolean marker.
- Suppress PhotoKit updates only while the modification time is unchanged, allowing genuine edits into the re-upload flow.
- Log tracked update decisions with the local ID, modification times, and skip result.

cc @AmanRajSinghMourya