### PR TITLE
Fix Ensu settings modal on macOS

### DIFF
--- a/web/packages/base/components/utils/theme.ts
+++ b/web/packages/base/components/utils/theme.ts
@@ -460,15 +460,6 @@ const components: Components = {
         },
     },
 
-    MuiModal: {
-        styleOverrides: {
-            root: {
-                // Invisible stale modal roots must not block clicks.
-                '&:has(> div[style*="opacity: 0"])': { pointerEvents: "none" },
-            },
-        },
-    },
-
     MuiDrawer: {
         styleOverrides: {
             root: {


### PR DESCRIPTION
- Removed shared workaround for modal opacity bug in MUI
- Workaround not needed after updating to MUI 9.3.1
- Will resolve Ensu bug in Mac settings modal