### PR TITLE
[mobile][photos] optimize timeline gallery lookups for large galleries

### DIFF
--- a/mobile/apps/photos/changes/timeline-gallery-performance.md
+++ b/mobile/apps/photos/changes/timeline-gallery-performance.md
@@ -1,0 +1,1 @@
+- Improved timeline gallery scrolling performance for large galleries. (@r4khul)

--- a/mobile/apps/photos/lib/models/gallery/fixed_extent_section_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/fixed_extent_section_layout.dart
@@ -50,3 +50,41 @@ class FixedExtentSectionLayout {
     return bodyFirstIndex + (scrollOffset / mainAxisStride).ceil() - 1;
   }
 }
+
+extension FixedExtentSectionLayoutList on List<FixedExtentSectionLayout> {
+  FixedExtentSectionLayout? sectionForIndex(int index) {
+    if (isEmpty) return null;
+    int low = 0;
+    int high = length - 1;
+    while (low <= high) {
+      final int mid = (low + high) >>> 1;
+      final FixedExtentSectionLayout section = this[mid];
+      if (index < section.firstIndex) {
+        high = mid - 1;
+      } else if (index > section.lastIndex) {
+        low = mid + 1;
+      } else {
+        return section;
+      }
+    }
+    return null;
+  }
+
+  FixedExtentSectionLayout? sectionForOffset(double scrollOffset) {
+    if (isEmpty) return null;
+    int low = 0;
+    int high = length - 1;
+    while (low <= high) {
+      final int mid = (low + high) >>> 1;
+      final FixedExtentSectionLayout section = this[mid];
+      if (scrollOffset < section.minOffset) {
+        high = mid - 1;
+      } else if (scrollOffset > section.maxOffset) {
+        low = mid + 1;
+      } else {
+        return section;
+      }
+    }
+    return last;
+  }
+}

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/sectioned_sliver_list.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/sectioned_sliver_list.dart
@@ -1,6 +1,4 @@
 import 'dart:math' as math;
-
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -44,9 +42,7 @@ class SectionedListSliver<T> extends StatelessWidget {
       delegate: SliverChildBuilderDelegate(
         (context, index) {
           if (index >= childCount) return null;
-          final sectionLayout = sectionLayouts.firstWhereOrNull(
-            (section) => section.hasChild(index),
-          );
+          final sectionLayout = sectionLayouts.sectionForIndex(index);
           return sectionLayout?.builder(context, index) ?? const SizedBox();
         },
         childCount: childCount,
@@ -100,13 +96,10 @@ class _RenderSliverKnownExtentBoxAdaptor extends RenderSliverMultiBoxAdaptor {
   }) : _sectionLayouts = sectionLayouts;
 
   FixedExtentSectionLayout? sectionAtIndex(int index) =>
-      sectionLayouts.firstWhereOrNull((section) => section.hasChild(index));
+      sectionLayouts.sectionForIndex(index);
 
   FixedExtentSectionLayout? sectionAtOffset(double scrollOffset) =>
-      sectionLayouts.firstWhereOrNull(
-        (section) => section.hasChildAtOffset(scrollOffset),
-      ) ??
-      sectionLayouts.lastOrNull;
+      sectionLayouts.sectionForOffset(scrollOffset);
 
   double indexToLayoutOffset(int index) {
     return (sectionAtIndex(index) ?? sectionLayouts.lastOrNull)


### PR DESCRIPTION
## Description
- Replaced **linear search (firstWhereOrNull) with binary search** for section lookups to resolve layout calculation bottlenecks in large galleries.
- Extracted layout lookup logic into a new `FixedExtentSectionLayoutList` extension with `sectionForIndex` and `sectionForOffset` methods.

### Verification:
Tested this realme c67 & realme pad 2. It works as expected and does not introduce any anomalies.

### Unit Benchmark Test:
<img width="743" height="319" alt="image" src="https://github.com/user-attachments/assets/684b0f1f-e427-4001-9502-0da204f817d8" />