### PR TITLE
[mobile][photos] Atomically upsert device collection covers

### DIFF
--- a/mobile/apps/photos/lib/db/device_files_db.dart
+++ b/mobile/apps/photos/lib/db/device_files_db.dart
@@ -205,49 +205,35 @@ extension DeviceFiles on FilesDB {
         final String localID = tup.item2;
         final int modifiedAt =
             pathEntity.lastModified?.microsecondsSinceEpoch ?? 0;
-        final bool shouldUpdate = existingPathIds.contains(pathEntity.id);
-        if (shouldUpdate) {
-          final rowUpdated = await db.writeTransaction((tx) async {
-            await tx.execute(
-              "UPDATE device_collections SET name = ?, cover_id = ?, count"
-              " = ?, modified_at = ? where id = ? AND (name != ? OR "
-              "cover_id != ? OR count != ? OR modified_at != ?)",
-              [
-                pathEntity.name,
-                localID,
-                assetCount,
-                modifiedAt,
-                pathEntity.id,
-                pathEntity.name,
-                localID,
-                assetCount,
-                modifiedAt,
-              ],
-            );
-            final result = await tx.get("SELECT changes();");
-            return result["changes()"] as int;
-          });
-
-          if (rowUpdated > 0) {
-            _logger.info("Updated $rowUpdated rows for ${pathEntity.name}");
-            hasUpdated = true;
-          }
-        } else {
-          hasUpdated = true;
-          await db.execute(
-            '''
+        final updatedRows = await db.execute(
+          '''
             INSERT INTO device_collections (id, name, count, cover_id, modified_at, should_backup)
-            VALUES (?, ?, ?, ?, ?, ?);
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+              name = excluded.name,
+              count = excluded.count,
+              cover_id = excluded.cover_id,
+              modified_at = excluded.modified_at
+            WHERE device_collections.name IS NOT excluded.name
+              OR device_collections.count IS NOT excluded.count
+              OR device_collections.cover_id IS NOT excluded.cover_id
+              OR device_collections.modified_at IS NOT excluded.modified_at
+            RETURNING id;
           ''',
-            [
-              pathEntity.id,
-              pathEntity.name,
-              assetCount,
-              localID,
-              modifiedAt,
-              shouldBackup ? _sqlBoolTrue : _sqlBoolFalse,
-            ],
+          [
+            pathEntity.id,
+            pathEntity.name,
+            assetCount,
+            localID,
+            modifiedAt,
+            shouldBackup ? _sqlBoolTrue : _sqlBoolFalse,
+          ],
+        );
+        if (updatedRows.isNotEmpty) {
+          _logger.info(
+            "Updated ${updatedRows.length} rows for ${pathEntity.name}",
           );
+          hasUpdated = true;
         }
       }
       // delete existing pathIDs which are missing on device


### PR DESCRIPTION
## Problem

`updateDeviceCoverWithCount` chose between insert and update from an ID snapshot taken before awaiting asset counts. If another database operation inserted the collection meanwhile, the stale path attempted a plain insert and failed on the primary key, as seen in `PHOTOS-MOBILE-EYA`.

## Change

Use one `INSERT ... ON CONFLICT DO UPDATE` statement so SQLite resolves existence at write time. Conflict updates refresh collection metadata without overwriting `should_backup`; a null-safe condition skips unchanged rows, and `RETURNING` preserves the existing `hasUpdated` behavior.

## Result

Concurrent creation now becomes an update instead of an error, and repeated refreshes remain idempotent. This addresses the duplicate-key race, not the separately grouped `database is locked` failures.

## Database impact

No migration is required. One statement replaces the explicit update transaction and `SELECT changes()`, reducing database round trips. The bundled SQLite supports the query on both Android and iOS.

## Validation

- `flutter analyze --no-pub`
- Complete mobile workflow checks and workspace tests