### PR TITLE
[mobile] Avoid redundant home gallery reloads

### DIFF
--- a/mobile/apps/photos/changes/home-gallery-local-media-reloads.md
+++ b/mobile/apps/photos/changes/home-gallery-local-media-reloads.md
@@ -1,0 +1,1 @@
+- Fixed home gallery lag caused by unnecessary reloads after local media changes.

--- a/mobile/apps/photos/lib/db/device_files_db.dart
+++ b/mobile/apps/photos/lib/db/device_files_db.dart
@@ -239,7 +239,6 @@ extension DeviceFiles on FilesDB {
       // delete existing pathIDs which are missing on device
       existingPathIds.removeAll(devicePathInfo.map((e) => e.item1.id).toSet());
       if (existingPathIds.isNotEmpty) {
-        hasUpdated = true;
         _logger.info(
           'Deleting non-backed up pathIds from local '
           '$existingPathIds',
@@ -250,12 +249,14 @@ extension DeviceFiles on FilesDB {
           // feature, where we delete files which are backed up. Deleting such
           // entries here result in us losing out on the information that
           // those folders were marked for automatic backup.
-          await db.execute(
+          final deletedRows = await db.execute(
             '''
-            DELETE FROM device_collections WHERE id = ? AND should_backup = $_sqlBoolFalse;
+            DELETE FROM device_collections WHERE id = ? AND should_backup = $_sqlBoolFalse
+            RETURNING id;
           ''',
             [pathID],
           );
+          hasUpdated |= deletedRows.isNotEmpty;
           await db.execute(
             '''
             DELETE FROM device_files WHERE path_id = ?;

--- a/mobile/apps/photos/lib/ui/home/home_gallery_widget.dart
+++ b/mobile/apps/photos/lib/ui/home/home_gallery_widget.dart
@@ -6,7 +6,6 @@ import 'package:photos/core/configuration.dart';
 import 'package:photos/core/event_bus.dart';
 import "package:photos/core/user_config.dart";
 import 'package:photos/db/files_db.dart';
-import 'package:photos/events/backup_folders_updated_event.dart';
 import 'package:photos/events/files_updated_event.dart';
 import 'package:photos/events/force_reload_home_gallery_event.dart';
 import "package:photos/events/hide_shared_items_from_home_gallery_event.dart";
@@ -130,9 +129,6 @@ class _HomeGalleryWidgetState extends State<HomeGalleryWidget> {
         EventType.hide,
       },
       forceReloadEvents: [
-        Bus.instance.on<BackupFoldersUpdatedEvent>().where(
-          (_) => !largeBackupSession.isStandbyScreenActive,
-        ),
         Bus.instance.on<ForceReloadHomeGalleryEvent>().where(
           (_) => !largeBackupSession.isStandbyScreenActive,
         ),


### PR DESCRIPTION
## Problem

Device-folder reconciliation can force the home gallery to reload every file even when timeline membership is unchanged. Preserved backed-up folders also report a change when their collection delete is a no-op.

## Change

Keep backup-folder updates scoped to folder UI consumers, and report folder deletion only when a collection row is actually removed.

## Validation

- Dart formatting
- Flutter analysis
- Mobile dependency and repository validation scripts
- Rust codegen and clippy