### PR TITLE
[server] Batch collection file upserts

### DIFF
--- a/server/pkg/controller/collections/file_action.go
+++ b/server/pkg/controller/collections/file_action.go
@@ -55,7 +55,7 @@ func (c *CollectionController) AddFiles(ctx *gin.Context, userID int64, files []
 		return stacktrace.Propagate(&ente.ErrFileInTrash, "")
 	}
 
-	err = c.CollectionRepo.AddFiles(cID, collectionOwnerID, files, filesOwnerID)
+	err = c.CollectionRepo.AddFiles(ctx.Request.Context(), cID, collectionOwnerID, files, filesOwnerID)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}

--- a/server/pkg/repo/collection.go
+++ b/server/pkg/repo/collection.go
@@ -674,45 +674,83 @@ func (repo *CollectionRepository) UnShareContext(
 }
 
 func (repo *CollectionRepository) AddFiles(
+	ctx context.Context,
 	collectionID int64,
 	collectionOwnerID int64,
 	files []ente.CollectionFileItem,
 	fileOwnerID int64,
 ) error {
 	updationTime := time.Microseconds()
-	context := context.Background()
-	tx, err := repo.DB.BeginTx(context, nil)
+	tx, err := repo.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	for _, file := range files {
-		_, err := tx.ExecContext(context, `INSERT INTO collection_files
-            (collection_id, file_id, encrypted_key, key_decryption_nonce, is_deleted, updation_time, c_owner_id, f_owner_id)
-            VALUES($1, $2, $3, $4, $5, $6, $7, $8)
-            ON CONFLICT ON CONSTRAINT unique_collection_files_cid_fid
-            DO UPDATE SET
-                is_deleted = EXCLUDED.is_deleted,
-                updation_time = EXCLUDED.updation_time,
-                action_user = NULL,
-                action = NULL,
-                created_at = CASE
-                    WHEN collection_files.is_deleted = TRUE AND EXCLUDED.is_deleted = FALSE
-                        THEN now_utc_micro_seconds()
-                    ELSE collection_files.created_at
-                END`, collectionID, file.ID, file.EncryptedKey,
-			file.KeyDecryptionNonce, false, updationTime, collectionOwnerID, fileOwnerID)
-		if err != nil {
-			tx.Rollback()
-			return stacktrace.Propagate(err, "")
-		}
+	if err := upsertCollectionFiles(ctx, tx, collectionID, collectionOwnerID, files, fileOwnerID, updationTime); err != nil {
+		tx.Rollback()
+		return stacktrace.Propagate(err, "")
 	}
-	_, err = tx.ExecContext(context, `UPDATE collections SET updation_time = $1
+	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
 		 WHERE collection_id = $2`, updationTime, collectionID)
 	if err != nil {
 		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	err = tx.Commit()
+	return stacktrace.Propagate(err, "")
+}
+
+func upsertCollectionFiles(
+	ctx context.Context,
+	tx *sql.Tx,
+	collectionID int64,
+	collectionOwnerID int64,
+	files []ente.CollectionFileItem,
+	fileOwnerID int64,
+	updationTime int64,
+) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	fileIDs := make([]int64, 0, len(files))
+	encryptedKeys := make([]string, 0, len(files))
+	keyDecryptionNonces := make([]string, 0, len(files))
+	seenFileIDs := make(map[int64]struct{}, len(files))
+	for _, file := range files {
+		if _, ok := seenFileIDs[file.ID]; ok {
+			continue
+		}
+		seenFileIDs[file.ID] = struct{}{}
+		fileIDs = append(fileIDs, file.ID)
+		encryptedKeys = append(encryptedKeys, file.EncryptedKey)
+		keyDecryptionNonces = append(keyDecryptionNonces, file.KeyDecryptionNonce)
+	}
+
+	_, err := tx.ExecContext(ctx, `INSERT INTO collection_files
+			(collection_id, file_id, encrypted_key, key_decryption_nonce, is_deleted, updation_time, c_owner_id, f_owner_id)
+		SELECT $1, input.file_id, input.encrypted_key, input.key_decryption_nonce, FALSE, $2, $3, $4
+		FROM unnest($5::bigint[], $6::text[], $7::text[])
+			AS input(file_id, encrypted_key, key_decryption_nonce)
+		ORDER BY input.file_id
+		ON CONFLICT ON CONSTRAINT unique_collection_files_cid_fid
+		DO UPDATE SET
+			is_deleted = EXCLUDED.is_deleted,
+			updation_time = EXCLUDED.updation_time,
+			action_user = NULL,
+			action = NULL,
+			created_at = CASE
+				WHEN collection_files.is_deleted = TRUE AND EXCLUDED.is_deleted = FALSE
+					THEN now_utc_micro_seconds()
+				ELSE collection_files.created_at
+			END`,
+		collectionID,
+		updationTime,
+		collectionOwnerID,
+		fileOwnerID,
+		pq.Array(fileIDs),
+		pq.Array(encryptedKeys),
+		pq.Array(keyDecryptionNonces),
+	)
 	return stacktrace.Propagate(err, "")
 }
 
@@ -735,26 +773,9 @@ func (repo *CollectionRepository) RestoreFiles(ctx context.Context, userID int64
 		return stacktrace.Propagate(err, "")
 	}
 
-	for _, file := range newCollectionFiles {
-		_, err := tx.ExecContext(ctx, `INSERT INTO collection_files
-            (collection_id, file_id, encrypted_key, key_decryption_nonce, is_deleted, updation_time, c_owner_id, f_owner_id)
-            VALUES($1, $2, $3, $4, $5, $6, $7, $8)
-            ON CONFLICT ON CONSTRAINT unique_collection_files_cid_fid
-            DO UPDATE SET
-                is_deleted = EXCLUDED.is_deleted,
-                updation_time = EXCLUDED.updation_time,
-                action_user = NULL,
-                action = NULL,
-                created_at = CASE
-                    WHEN collection_files.is_deleted = TRUE AND EXCLUDED.is_deleted = FALSE
-                        THEN now_utc_micro_seconds()
-                    ELSE collection_files.created_at
-                END`, collectionID, file.ID, file.EncryptedKey,
-			file.KeyDecryptionNonce, false, updationTime, userID, userID)
-		if err != nil {
-			tx.Rollback()
-			return stacktrace.Propagate(err, "")
-		}
+	if err := upsertCollectionFiles(ctx, tx, collectionID, userID, newCollectionFiles, userID, updationTime); err != nil {
+		tx.Rollback()
+		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
 		 WHERE collection_id = $2`, updationTime, collectionID)
@@ -845,28 +866,13 @@ func (repo *CollectionRepository) MoveFiles(ctx context.Context,
 	fileIDs := make([]int64, 0)
 	for _, file := range fileItems {
 		fileIDs = append(fileIDs, file.ID)
-		_, err := tx.ExecContext(ctx, `INSERT INTO collection_files
-            (collection_id, file_id, encrypted_key, key_decryption_nonce, is_deleted, updation_time, c_owner_id, f_owner_id)
-            VALUES($1, $2, $3, $4, $5, $6, $7, $8)
-            ON CONFLICT ON CONSTRAINT unique_collection_files_cid_fid
-            DO UPDATE SET
-                is_deleted = EXCLUDED.is_deleted,
-                updation_time = EXCLUDED.updation_time,
-                action_user = NULL,
-                action = NULL,
-                created_at = CASE
-                    WHEN collection_files.is_deleted = TRUE AND EXCLUDED.is_deleted = FALSE
-                        THEN now_utc_micro_seconds()
-                    ELSE collection_files.created_at
-                END`, toCollectionID, file.ID, file.EncryptedKey,
-			file.KeyDecryptionNonce, false, updationTime, collectionOwner, fileOwner)
-		if err != nil {
-			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				logrus.WithError(rollbackErr).Error("transaction rollback failed")
-				return stacktrace.Propagate(rollbackErr, "")
-			}
-			return stacktrace.Propagate(err, "")
+	}
+	if err := upsertCollectionFiles(ctx, tx, toCollectionID, collectionOwner, fileItems, fileOwner, updationTime); err != nil {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			logrus.WithError(rollbackErr).Error("transaction rollback failed")
+			return stacktrace.Propagate(rollbackErr, "")
 		}
+		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE collection_files 
 		SET is_deleted = $1, updation_time = $2 WHERE collection_id = $3 AND file_id = ANY($4)`,

--- a/server/pkg/repo/collection_memberships_test.go
+++ b/server/pkg/repo/collection_memberships_test.go
@@ -1,0 +1,407 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/internal/testutil"
+)
+
+func TestAddFilesUpsertsBatchAndPreservesConflictFields(t *testing.T) {
+	repository, db, ownerID := setupCollectionMembershipTest(t)
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	deletedFileID := insertObjectTestFile(t, db, ownerID)
+	activeFileID := insertObjectTestFile(t, db, ownerID)
+	newFileID := insertObjectTestFile(t, db, ownerID)
+	linkObjectTestFileToCollection(t, db, collectionID, deletedFileID, ownerID)
+	linkObjectTestFileToCollection(t, db, collectionID, activeFileID, ownerID)
+
+	if _, err := db.Exec(`UPDATE collection_files
+		SET is_deleted = TRUE, action_user = $1, action = $2, created_at = 10
+		WHERE collection_id = $3 AND file_id = $4`, ownerID, ente.ActionRemove, collectionID, deletedFileID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE collection_files
+		SET action_user = $1, action = $2, created_at = 20
+		WHERE collection_id = $3 AND file_id = $4`, ownerID, ente.ActionRemove, collectionID, activeFileID); err != nil {
+		t.Fatal(err)
+	}
+
+	files := []ente.CollectionFileItem{
+		collectionMembershipTestItem(newFileID),
+		collectionMembershipTestItem(activeFileID),
+		collectionMembershipTestItem(deletedFileID),
+	}
+	if err := repository.AddFiles(t.Context(), collectionID, ownerID, files, ownerID); err != nil {
+		t.Fatalf("AddFiles() error = %v", err)
+	}
+
+	deletedState := readCollectionMembershipState(t, db, collectionID, deletedFileID)
+	activeState := readCollectionMembershipState(t, db, collectionID, activeFileID)
+	newState := readCollectionMembershipState(t, db, collectionID, newFileID)
+	for fileID, state := range map[int64]collectionMembershipState{
+		deletedFileID: deletedState,
+		activeFileID:  activeState,
+		newFileID:     newState,
+	} {
+		if state.isDeleted {
+			t.Errorf("file %d remained deleted", fileID)
+		}
+		if state.action.Valid || state.actionUser.Valid {
+			t.Errorf("file %d retained action state: action=%v user=%v", fileID, state.action, state.actionUser)
+		}
+		if state.collectionOwnerID != ownerID || state.fileOwnerID != ownerID {
+			t.Errorf("file %d owners = (%d, %d), want (%d, %d)", fileID, state.collectionOwnerID, state.fileOwnerID, ownerID, ownerID)
+		}
+	}
+
+	if deletedState.encryptedKey != "collection-file-key" || deletedState.keyDecryptionNonce != "collection-file-nonce" {
+		t.Errorf("reactivated membership replaced encrypted fields: %+v", deletedState)
+	}
+	if deletedState.createdAt <= 10 {
+		t.Errorf("reactivated membership created_at = %d, want greater than 10", deletedState.createdAt)
+	}
+	if activeState.createdAt != 20 {
+		t.Errorf("active membership created_at = %d, want 20", activeState.createdAt)
+	}
+	if activeState.encryptedKey != "collection-file-key" || activeState.keyDecryptionNonce != "collection-file-nonce" {
+		t.Errorf("active membership replaced encrypted fields: %+v", activeState)
+	}
+	wantNewItem := collectionMembershipTestItem(newFileID)
+	if newState.encryptedKey != wantNewItem.EncryptedKey || newState.keyDecryptionNonce != wantNewItem.KeyDecryptionNonce {
+		t.Errorf("new membership encrypted fields = (%q, %q), want (%q, %q)",
+			newState.encryptedKey, newState.keyDecryptionNonce, wantNewItem.EncryptedKey, wantNewItem.KeyDecryptionNonce)
+	}
+
+	var collectionUpdationTime int64
+	if err := db.QueryRow(`SELECT updation_time FROM collections WHERE collection_id = $1`, collectionID).Scan(&collectionUpdationTime); err != nil {
+		t.Fatal(err)
+	}
+	for fileID, state := range map[int64]collectionMembershipState{
+		deletedFileID: deletedState,
+		activeFileID:  activeState,
+		newFileID:     newState,
+	} {
+		if state.updationTime != collectionUpdationTime {
+			t.Errorf("file %d updation_time = %d, collection updation_time = %d", fileID, state.updationTime, collectionUpdationTime)
+		}
+	}
+}
+
+func TestAddFilesSupportsMaximumBatchSize(t *testing.T) {
+	repository, db, ownerID := setupCollectionMembershipTest(t)
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	fileIDs := insertCollectionMembershipTestFiles(t, db, ownerID, 1000)
+	files := make([]ente.CollectionFileItem, len(fileIDs))
+	for index, fileID := range fileIDs {
+		files[index] = collectionMembershipTestItem(fileID)
+	}
+
+	if err := repository.AddFiles(t.Context(), collectionID, ownerID, files, ownerID); err != nil {
+		t.Fatalf("AddFiles() error = %v", err)
+	}
+
+	var count, activeCount int
+	if err := db.QueryRow(`SELECT COUNT(*), COUNT(*) FILTER (WHERE is_deleted = FALSE)
+		FROM collection_files WHERE collection_id = $1`, collectionID).Scan(&count, &activeCount); err != nil {
+		t.Fatal(err)
+	}
+	if count != len(files) || activeCount != len(files) {
+		t.Fatalf("collection membership counts = (%d total, %d active), want (%d, %d)", count, activeCount, len(files), len(files))
+	}
+}
+
+func TestAddFilesPreservesFirstItemForDuplicateFileID(t *testing.T) {
+	repository, db, ownerID := setupCollectionMembershipTest(t)
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	fileID := insertObjectTestFile(t, db, ownerID)
+	first := collectionMembershipTestItem(fileID)
+	second := ente.CollectionFileItem{
+		ID:                 fileID,
+		EncryptedKey:       "second-encrypted-key",
+		KeyDecryptionNonce: "second-key-nonce",
+	}
+
+	if err := repository.AddFiles(t.Context(), collectionID, ownerID, []ente.CollectionFileItem{first, second}, ownerID); err != nil {
+		t.Fatalf("AddFiles() error = %v", err)
+	}
+
+	state := readCollectionMembershipState(t, db, collectionID, fileID)
+	if state.encryptedKey != first.EncryptedKey || state.keyDecryptionNonce != first.KeyDecryptionNonce {
+		t.Fatalf("duplicate membership encrypted fields = (%q, %q), want first item (%q, %q)",
+			state.encryptedKey, state.keyDecryptionNonce, first.EncryptedKey, first.KeyDecryptionNonce)
+	}
+}
+
+func TestAddFilesRollsBackBatchOnFailure(t *testing.T) {
+	repository, db, ownerID := setupCollectionMembershipTest(t)
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	validFileID := insertObjectTestFile(t, db, ownerID)
+	files := []ente.CollectionFileItem{
+		collectionMembershipTestItem(validFileID),
+		collectionMembershipTestItem(int64(^uint64(0) >> 1)),
+	}
+
+	if err := repository.AddFiles(t.Context(), collectionID, ownerID, files, ownerID); err == nil {
+		t.Fatal("AddFiles() succeeded with a nonexistent file")
+	}
+
+	var membershipCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM collection_files WHERE collection_id = $1`, collectionID).Scan(&membershipCount); err != nil {
+		t.Fatal(err)
+	}
+	if membershipCount != 0 {
+		t.Fatalf("membership count after rollback = %d, want 0", membershipCount)
+	}
+	assertCollectionMembershipTestUpdationTime(t, db, collectionID, 1)
+}
+
+func TestAddFilesHonorsCanceledContext(t *testing.T) {
+	repository, db, ownerID := setupCollectionMembershipTest(t)
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	fileID := insertObjectTestFile(t, db, ownerID)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	if err := repository.AddFiles(ctx, collectionID, ownerID, []ente.CollectionFileItem{collectionMembershipTestItem(fileID)}, ownerID); err == nil {
+		t.Fatal("AddFiles() succeeded with a canceled context")
+	}
+
+	var membershipCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM collection_files WHERE collection_id = $1`, collectionID).Scan(&membershipCount); err != nil {
+		t.Fatal(err)
+	}
+	if membershipCount != 0 {
+		t.Fatalf("membership count after canceled request = %d, want 0", membershipCount)
+	}
+	assertCollectionMembershipTestUpdationTime(t, db, collectionID, 1)
+}
+
+func TestRestoreFilesUpsertsBatchAndMarksTrashRestored(t *testing.T) {
+	repository, db, ownerID := setupCollectionMembershipTest(t)
+	collectionID := insertObjectTestCollection(t, db, ownerID)
+	fileIDs := []int64{
+		insertObjectTestFile(t, db, ownerID),
+		insertObjectTestFile(t, db, ownerID),
+	}
+	for _, fileID := range fileIDs {
+		linkObjectTestFileToCollection(t, db, collectionID, fileID, ownerID)
+		if _, err := db.Exec(`UPDATE collection_files SET is_deleted = TRUE
+			WHERE collection_id = $1 AND file_id = $2`, collectionID, fileID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`INSERT INTO trash(file_id, user_id, collection_id, delete_by)
+			VALUES($1, $2, $3, $4)`, fileID, ownerID, collectionID, int64(100)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := []ente.CollectionFileItem{
+		collectionMembershipTestItem(fileIDs[1]),
+		collectionMembershipTestItem(fileIDs[0]),
+	}
+
+	if err := repository.RestoreFiles(t.Context(), ownerID, collectionID, files); err != nil {
+		t.Fatalf("RestoreFiles() error = %v", err)
+	}
+
+	var activeCount, restoredCount int
+	if err := db.QueryRow(`SELECT
+			COUNT(*) FILTER (WHERE cf.is_deleted = FALSE),
+			COUNT(*) FILTER (WHERE t.is_restored = TRUE)
+		FROM collection_files AS cf
+		JOIN trash AS t ON t.collection_id = cf.collection_id AND t.file_id = cf.file_id
+		WHERE cf.collection_id = $1`, collectionID).Scan(&activeCount, &restoredCount); err != nil {
+		t.Fatal(err)
+	}
+	if activeCount != len(files) || restoredCount != len(files) {
+		t.Fatalf("restore counts = (%d active, %d restored), want (%d, %d)", activeCount, restoredCount, len(files), len(files))
+	}
+}
+
+func TestMoveFilesUpsertsDestinationAndDeletesSource(t *testing.T) {
+	repository, db, ownerID := setupCollectionMembershipTest(t)
+	fromCollectionID := insertObjectTestCollection(t, db, ownerID)
+	toCollectionID := insertObjectTestCollection(t, db, ownerID)
+	fileIDs := []int64{
+		insertObjectTestFile(t, db, ownerID),
+		insertObjectTestFile(t, db, ownerID),
+	}
+	for _, fileID := range fileIDs {
+		linkObjectTestFileToCollection(t, db, fromCollectionID, fileID, ownerID)
+	}
+	linkObjectTestFileToCollection(t, db, toCollectionID, fileIDs[1], ownerID)
+	if _, err := db.Exec(`UPDATE collection_files SET is_deleted = TRUE, created_at = 10
+		WHERE collection_id = $1 AND file_id = $2`, toCollectionID, fileIDs[1]); err != nil {
+		t.Fatal(err)
+	}
+	files := []ente.CollectionFileItem{
+		collectionMembershipTestItem(fileIDs[1]),
+		collectionMembershipTestItem(fileIDs[0]),
+	}
+
+	if err := repository.MoveFiles(t.Context(), toCollectionID, fromCollectionID, files, ownerID, ownerID); err != nil {
+		t.Fatalf("MoveFiles() error = %v", err)
+	}
+
+	for _, fileID := range fileIDs {
+		fromState := readCollectionMembershipState(t, db, fromCollectionID, fileID)
+		toState := readCollectionMembershipState(t, db, toCollectionID, fileID)
+		if !fromState.isDeleted {
+			t.Errorf("source membership for file %d is still active", fileID)
+		}
+		if toState.isDeleted {
+			t.Errorf("destination membership for file %d is still deleted", fileID)
+		}
+	}
+
+	newDestinationState := readCollectionMembershipState(t, db, toCollectionID, fileIDs[0])
+	wantNewItem := collectionMembershipTestItem(fileIDs[0])
+	if newDestinationState.encryptedKey != wantNewItem.EncryptedKey || newDestinationState.keyDecryptionNonce != wantNewItem.KeyDecryptionNonce {
+		t.Errorf("new destination membership encrypted fields = (%q, %q), want (%q, %q)",
+			newDestinationState.encryptedKey, newDestinationState.keyDecryptionNonce, wantNewItem.EncryptedKey, wantNewItem.KeyDecryptionNonce)
+	}
+	existingDestinationState := readCollectionMembershipState(t, db, toCollectionID, fileIDs[1])
+	if existingDestinationState.encryptedKey != "collection-file-key" || existingDestinationState.keyDecryptionNonce != "collection-file-nonce" {
+		t.Errorf("existing destination membership replaced encrypted fields: %+v", existingDestinationState)
+	}
+	if existingDestinationState.createdAt <= 10 {
+		t.Errorf("reactivated destination membership created_at = %d, want greater than 10", existingDestinationState.createdAt)
+	}
+
+	var fromUpdationTime, toUpdationTime int64
+	if err := db.QueryRow(`SELECT source.updation_time, destination.updation_time
+		FROM collections AS source
+		JOIN collections AS destination ON destination.collection_id = $2
+		WHERE source.collection_id = $1`, fromCollectionID, toCollectionID).Scan(&fromUpdationTime, &toUpdationTime); err != nil {
+		t.Fatal(err)
+	}
+	if fromUpdationTime <= 1 || fromUpdationTime != toUpdationTime {
+		t.Errorf("collection updation times = (%d, %d), want equal values greater than 1", fromUpdationTime, toUpdationTime)
+	}
+}
+
+type collectionMembershipState struct {
+	encryptedKey       string
+	keyDecryptionNonce string
+	isDeleted          bool
+	updationTime       int64
+	collectionOwnerID  int64
+	fileOwnerID        int64
+	createdAt          int64
+	actionUser         sql.NullInt64
+	action             sql.NullString
+}
+
+func setupCollectionMembershipTest(t *testing.T) (*CollectionRepository, *sql.DB, int64) {
+	t.Helper()
+
+	_, db := setupAccessibleObjectTest(t)
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "collection-membership-owner@ente.com",
+		CreationTime: 1,
+	})
+	return &CollectionRepository{
+		DB:        db,
+		TrashRepo: &TrashRepository{DB: db},
+	}, db, ownerID
+}
+
+func collectionMembershipTestItem(fileID int64) ente.CollectionFileItem {
+	return ente.CollectionFileItem{
+		ID:                 fileID,
+		EncryptedKey:       fmt.Sprintf("encrypted-key-%d", fileID),
+		KeyDecryptionNonce: fmt.Sprintf("key-nonce-%d", fileID),
+	}
+}
+
+func insertCollectionMembershipTestFiles(t *testing.T, db *sql.DB, ownerID int64, count int) []int64 {
+	t.Helper()
+
+	rows, err := db.Query(`INSERT INTO files(
+			owner_id,
+			file_decryption_header,
+			thumbnail_decryption_header,
+			metadata_decryption_header,
+			encrypted_metadata,
+			updation_time,
+			info
+		)
+		SELECT
+			$1,
+			'file-header-' || generated.sequence,
+			'thumbnail-header-' || generated.sequence,
+			'metadata-header-' || generated.sequence,
+			'encrypted-metadata-' || generated.sequence,
+			1,
+			'{}'::jsonb
+		FROM generate_series(1, $2) AS generated(sequence)
+		RETURNING file_id`, ownerID, count)
+	if err != nil {
+		t.Fatalf("failed to insert %d files: %v", count, err)
+	}
+	defer rows.Close()
+
+	fileIDs := make([]int64, 0, count)
+	for rows.Next() {
+		var fileID int64
+		if err := rows.Scan(&fileID); err != nil {
+			t.Fatal(err)
+		}
+		fileIDs = append(fileIDs, fileID)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(fileIDs) != count {
+		t.Fatalf("inserted file count = %d, want %d", len(fileIDs), count)
+	}
+	return fileIDs
+}
+
+func readCollectionMembershipState(t *testing.T, db *sql.DB, collectionID int64, fileID int64) collectionMembershipState {
+	t.Helper()
+
+	var state collectionMembershipState
+	err := db.QueryRow(`SELECT
+			encrypted_key,
+			key_decryption_nonce,
+			is_deleted,
+			updation_time,
+			c_owner_id,
+			f_owner_id,
+			created_at,
+			action_user,
+			action
+		FROM collection_files
+		WHERE collection_id = $1 AND file_id = $2`, collectionID, fileID).Scan(
+		&state.encryptedKey,
+		&state.keyDecryptionNonce,
+		&state.isDeleted,
+		&state.updationTime,
+		&state.collectionOwnerID,
+		&state.fileOwnerID,
+		&state.createdAt,
+		&state.actionUser,
+		&state.action,
+	)
+	if err != nil {
+		t.Fatalf("failed to read collection membership for collection %d file %d: %v", collectionID, fileID, err)
+	}
+	return state
+}
+
+func assertCollectionMembershipTestUpdationTime(t *testing.T, db *sql.DB, collectionID int64, want int64) {
+	t.Helper()
+
+	var got int64
+	if err := db.QueryRow(`SELECT updation_time FROM collections WHERE collection_id = $1`, collectionID).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("collection updation_time = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

AddFiles, RestoreFiles, and MoveFiles accept batches of up to 1,000 files, but previously executed one collection_files upsert per file sequentially inside their transaction. The repeated database round trips could keep the transaction and its connection open substantially longer when database latency or contention was present.

This PR:

- Consolidates the duplicated membership upsert policy into one repository helper.
- Uses PostgreSQL arrays and unnest to write a batch in one statement, ordered by file_id for deterministic conflict processing.
- Preserves existing reactivation behavior, pending-action clearing, encrypted membership fields, ownership fields, updation times, and first-item behavior for duplicate file IDs.
- Passes the HTTP request context into the AddFiles transaction so cancellation reaches pending database work.

At the maximum request size, the membership-write portion decreases from 1,000 database round trips to one. RestoreFiles and MoveFiles use the same bulk path. No migration or additional index is required.

## Database behavior

For successful, non-cancelled requests, the same logical collection_files, collections, Trash, and source-collection state is committed as before.

The observable differences are:

- New or reactivated membership created_at values are generated within one statement ordered by file_id, so their exact microsecond values and relative timing can differ from the previous request-order loop.
- A cancelled AddFiles request can now stop and roll back instead of continuing under a background context.

The transaction remains atomic. A failing row rolls back the complete batch and the associated collection update.

## Validation

- Full server lint, including govulncheck: ./scripts/lint.sh
- Full disposable-PostgreSQL server suite: ./scripts/test-with-postgres.sh host
- Added PostgreSQL coverage for mixed inserts and reactivation, the 1,000-file limit, duplicate IDs, rollback, cancellation, Trash restoration, and collection moves.