### PR TITLE
[server] Bump Go toolchain to 1.26.6

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -2,7 +2,7 @@ module github.com/ente/museum
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0


### PR DESCRIPTION
- Update the server toolchain from Go 1.26.5 to 1.26.6, picking up the standard-library security fixes that currently make the server vulnerability scan fail.
- This changes only the toolchain pin; application code and module dependencies are unchanged.

Validation: ./scripts/lint.sh; ./scripts/test-with-postgres.sh host