### PR TITLE
[mobile][photos] disable page swiping while albums are selected

### DIFF
--- a/mobile/apps/photos/changes/lock-page-swipe-album-selection.md
+++ b/mobile/apps/photos/changes/lock-page-swipe-album-selection.md
@@ -1,0 +1,1 @@
+- Lock page swipe during album selection. (@r4khul)

--- a/mobile/apps/photos/lib/ui/tabs/home_widget.dart
+++ b/mobile/apps/photos/lib/ui/tabs/home_widget.dart
@@ -1024,9 +1024,15 @@ class _HomeWidgetState extends State<HomeWidget> {
       children: [
         Builder(
           builder: (context) {
-            return ValueListenableBuilder(
-              valueListenable: _swipeToSelectInProgressNotifier,
-              builder: (context, inProgress, child) {
+            return ListenableBuilder(
+              listenable: Listenable.merge([
+                _swipeToSelectInProgressNotifier,
+                _selectedAlbums,
+              ]),
+              builder: (context, child) {
+                final isPageScrollLocked =
+                    _swipeToSelectInProgressNotifier.value ||
+                    _selectedAlbums.albums.isNotEmpty;
                 return ValueListenableBuilder<int>(
                   valueListenable: _selectedTabIndexNotifier,
                   builder: (context, selectedTabIndex, _) {
@@ -1038,7 +1044,7 @@ class _HomeWidgetState extends State<HomeWidget> {
                       },
                       controller: _pageController,
                       openDrawer: Scaffold.of(context).openDrawer,
-                      physics: inProgress
+                      physics: isPageScrollLocked
                           ? const NeverScrollableScrollPhysics()
                           : const BouncingScrollPhysics(),
                       children: [


### PR DESCRIPTION
## Description
Disable horizontal page swiping in the home tab bar while albums are selected in the Albums tab, matching the existing gallery swipe-to-select behavior.
- `home_widget.dart`: replaced the outer `_swipeToSelectInProgressNotifier` listener with a `ListenableBuilder` over `Listenable.merge([_swipeToSelectInProgressNotifier, _selectedAlbums])`.
- Page view `physics` is now `NeverScrollableScrollPhysics` whenever a swipe-select is in progress **or** any album is selected, preventing accidental navigation to other tabs during selection.

## Visuals
### Before 
Album selection widget active state, **yet scroll between pages works - issue caused: btm bar hides on scroll to other pages**



https://github.com/user-attachments/assets/595be197-8bd1-4abf-b9f9-33d37000082b





### After
Album selection widget active state, **locked as similar to File selection widget active state.**


https://github.com/user-attachments/assets/1f5f6689-c36c-4c4b-b4c8-a7f3abf4bcd2


