### PR TITLE
[server] Ignore stale subscription verification replays

### DIFF
--- a/server/pkg/controller/billing.go
+++ b/server/pkg/controller/billing.go
@@ -290,6 +290,7 @@ func shouldSkipVerifiedSubscriptionReplacement(currentSubscription ente.Subscrip
 		(currentSubscription.ProductID != ente.FreePlanProductID &&
 			currentSubscription.PaymentProvider == verifiedSubscription.PaymentProvider &&
 			currentSubscription.OriginalTransactionID == verifiedSubscription.OriginalTransactionID &&
+			currentSubscription.ProductID == verifiedSubscription.ProductID &&
 			verifiedSubscription.ExpiryTime < currentSubscription.ExpiryTime)
 }
 

--- a/server/pkg/controller/billing.go
+++ b/server/pkg/controller/billing.go
@@ -211,7 +211,16 @@ func (c *BillingController) VerifySubscription(
 	}
 	isUpgradingFromFreePlan := currentSubscription.ProductID == ente.FreePlanProductID
 	if shouldSkipVerifiedSubscriptionReplacement(currentSubscription, newSubscription, time.Microseconds()) {
-		log.Info("Outdated or expired purchase reported")
+		log.WithFields(log.Fields{
+			"user_id":                      userID,
+			"stored_payment_provider":      currentSubscription.PaymentProvider,
+			"stored_product_id":            currentSubscription.ProductID,
+			"stored_expiry_time":           currentSubscription.ExpiryTime,
+			"verified_payment_provider":    newSubscription.PaymentProvider,
+			"verified_product_id":          newSubscription.ProductID,
+			"verified_expiry_time":         newSubscription.ExpiryTime,
+			"same_original_transaction_id": currentSubscription.OriginalTransactionID == newSubscription.OriginalTransactionID,
+		}).Info("Skipping verified subscription replacement")
 		return currentSubscription, nil
 	}
 	if newSubscription.Storage < currentSubscription.Storage {

--- a/server/pkg/controller/billing.go
+++ b/server/pkg/controller/billing.go
@@ -209,12 +209,9 @@ func (c *BillingController) VerifySubscription(
 	if err != nil {
 		return ente.Subscription{}, stacktrace.Propagate(err, "")
 	}
-	newSubscriptionExpiresSooner := newSubscription.ExpiryTime < currentSubscription.ExpiryTime
 	isUpgradingFromFreePlan := currentSubscription.ProductID == ente.FreePlanProductID
-	hasChangedProductID := currentSubscription.ProductID != newSubscription.ProductID
-	isOutdatedPurchase := !isUpgradingFromFreePlan && !hasChangedProductID && newSubscriptionExpiresSooner
-	if isOutdatedPurchase {
-		log.Info("Outdated purchase reported")
+	if shouldSkipVerifiedSubscriptionReplacement(currentSubscription, newSubscription, time.Microseconds()) {
+		log.Info("Outdated or expired purchase reported")
 		return currentSubscription, nil
 	}
 	if newSubscription.Storage < currentSubscription.Storage {
@@ -285,6 +282,15 @@ func (c *BillingController) VerifySubscription(
 	}
 	log.Info("Returning new subscription with ID " + strconv.FormatInt(newSubscription.ID, 10))
 	return newSubscription, nil
+}
+
+func shouldSkipVerifiedSubscriptionReplacement(currentSubscription ente.Subscription, verifiedSubscription ente.Subscription, now int64) bool {
+	effectiveExpiry := verifiedSubscription.ExpiryTime + billing.ProviderToExpiryGracePeriodMap[verifiedSubscription.PaymentProvider]
+	return effectiveExpiry < now ||
+		(currentSubscription.ProductID != ente.FreePlanProductID &&
+			currentSubscription.PaymentProvider == verifiedSubscription.PaymentProvider &&
+			currentSubscription.OriginalTransactionID == verifiedSubscription.OriginalTransactionID &&
+			verifiedSubscription.ExpiryTime < currentSubscription.ExpiryTime)
 }
 
 func (c *BillingController) getAllPlans(countryCode string, stripeAccountCountry ente.StripeAccountCountry) []ente.BillingPlan {

--- a/server/pkg/controller/billing.go
+++ b/server/pkg/controller/billing.go
@@ -286,11 +286,13 @@ func (c *BillingController) VerifySubscription(
 
 func shouldSkipVerifiedSubscriptionReplacement(currentSubscription ente.Subscription, verifiedSubscription ente.Subscription, now int64) bool {
 	effectiveExpiry := verifiedSubscription.ExpiryTime + billing.ProviderToExpiryGracePeriodMap[verifiedSubscription.PaymentProvider]
+	isSameSubscription := currentSubscription.PaymentProvider == verifiedSubscription.PaymentProvider &&
+		currentSubscription.ProductID == verifiedSubscription.ProductID &&
+		(verifiedSubscription.PaymentProvider == ente.PlayStore ||
+			currentSubscription.OriginalTransactionID == verifiedSubscription.OriginalTransactionID)
 	return effectiveExpiry < now ||
 		(currentSubscription.ProductID != ente.FreePlanProductID &&
-			currentSubscription.PaymentProvider == verifiedSubscription.PaymentProvider &&
-			currentSubscription.OriginalTransactionID == verifiedSubscription.OriginalTransactionID &&
-			currentSubscription.ProductID == verifiedSubscription.ProductID &&
+			isSameSubscription &&
 			verifiedSubscription.ExpiryTime < currentSubscription.ExpiryTime)
 }
 

--- a/server/pkg/controller/billing_test.go
+++ b/server/pkg/controller/billing_test.go
@@ -1,0 +1,64 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/pkg/utils/billing"
+)
+
+func TestShouldSkipVerifiedSubscriptionReplacement(t *testing.T) {
+	now := int64(10_000_000_000_000)
+	appStoreGrace := billing.ProviderToExpiryGracePeriodMap[ente.AppStore]
+	paid := func(provider ente.PaymentProvider, transactionID string, expiry int64) ente.Subscription {
+		return ente.Subscription{
+			ProductID:             "paid",
+			PaymentProvider:       provider,
+			OriginalTransactionID: transactionID,
+			ExpiryTime:            expiry,
+		}
+	}
+
+	tests := []struct {
+		name     string
+		current  ente.Subscription
+		verified ente.Subscription
+		want     bool
+	}{
+		{
+			name:     "rejects receipt beyond provider grace",
+			current:  paid(ente.Stripe, "stripe", now+15),
+			verified: paid(ente.AppStore, "apple", now-appStoreGrace-1),
+			want:     true,
+		},
+		{
+			name:     "accepts receipt within provider grace for free account",
+			current:  ente.Subscription{ProductID: ente.FreePlanProductID},
+			verified: paid(ente.AppStore, "apple", now-appStoreGrace+1),
+		},
+		{
+			name:     "accepts cross-provider switch within provider grace",
+			current:  paid(ente.Stripe, "stripe", now+45),
+			verified: paid(ente.AppStore, "apple", now-appStoreGrace+1),
+		},
+		{
+			name:     "accepts active Play purchase with a new token",
+			current:  paid(ente.PlayStore, "old-token", now+45),
+			verified: paid(ente.PlayStore, "new-token", now+30),
+		},
+		{
+			name:     "rejects older version of the same subscription",
+			current:  paid(ente.AppStore, "apple", now+45),
+			verified: paid(ente.AppStore, "apple", now+30),
+			want:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shouldSkipVerifiedSubscriptionReplacement(test.current, test.verified, now); got != test.want {
+				t.Fatalf("shouldSkipVerifiedSubscriptionReplacement() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}

--- a/server/pkg/controller/billing_test.go
+++ b/server/pkg/controller/billing_test.go
@@ -52,6 +52,15 @@ func TestShouldSkipVerifiedSubscriptionReplacement(t *testing.T) {
 			verified: paid(ente.AppStore, "apple", now+30),
 			want:     true,
 		},
+		{
+			name: "accepts App Store product change with earlier expiry",
+			current: ente.Subscription{
+				ProductID: "old", PaymentProvider: ente.AppStore, OriginalTransactionID: "apple", ExpiryTime: now + 45,
+			},
+			verified: ente.Subscription{
+				ProductID: "new", PaymentProvider: ente.AppStore, OriginalTransactionID: "apple", ExpiryTime: now + 30,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/server/pkg/controller/billing_test.go
+++ b/server/pkg/controller/billing_test.go
@@ -42,9 +42,15 @@ func TestShouldSkipVerifiedSubscriptionReplacement(t *testing.T) {
 			verified: paid(ente.AppStore, "apple", now-appStoreGrace+1),
 		},
 		{
-			name:     "accepts active Play purchase with a new token",
-			current:  paid(ente.PlayStore, "old-token", now+45),
-			verified: paid(ente.PlayStore, "new-token", now+30),
+			name:     "rejects older Play purchase with a different token",
+			current:  paid(ente.PlayStore, "new-token", now+45),
+			verified: paid(ente.PlayStore, "old-token", now+30),
+			want:     true,
+		},
+		{
+			name:     "accepts newer Play purchase with a different token",
+			current:  paid(ente.PlayStore, "old-token", now+30),
+			verified: paid(ente.PlayStore, "new-token", now+45),
 		},
 		{
 			name:     "rejects older version of the same subscription",
@@ -59,6 +65,15 @@ func TestShouldSkipVerifiedSubscriptionReplacement(t *testing.T) {
 			},
 			verified: ente.Subscription{
 				ProductID: "new", PaymentProvider: ente.AppStore, OriginalTransactionID: "apple", ExpiryTime: now + 30,
+			},
+		},
+		{
+			name: "accepts Play Store product change with earlier expiry",
+			current: ente.Subscription{
+				ProductID: "old", PaymentProvider: ente.PlayStore, OriginalTransactionID: "old-token", ExpiryTime: now + 45,
+			},
+			verified: ente.Subscription{
+				ProductID: "new", PaymentProvider: ente.PlayStore, OriginalTransactionID: "new-token", ExpiryTime: now + 30,
 			},
 		},
 	}


### PR DESCRIPTION
- Mobile purchase streams can replay historical store receipts while billing is opened, including after a Stripe purchase; prevent expired or older same-entitlement replays from replacing the stored subscription.
- Apply provider grace periods consistently. App Store and Stripe use stable transaction identity, while Play compares same-product receipts across rotating purchase tokens so an older token cannot roll entitlement backward; valid provider switches and product changes remain eligible.