### PR TITLE
Add missing Photos mobile changelog entries

### DIFF
--- a/mobile/apps/photos/changes/faster-machine-learning-sync.md
+++ b/mobile/apps/photos/changes/faster-machine-learning-sync.md
@@ -1,1 +1,0 @@
-- Improved machine learning sync speed and Magic Search reliability after interrupted processing.

--- a/mobile/apps/photos/changes/faster-machine-learning-sync.md
+++ b/mobile/apps/photos/changes/faster-machine-learning-sync.md
@@ -1,0 +1,1 @@
+- Improved machine learning sync speed and Magic Search reliability after interrupted processing.

--- a/mobile/apps/photos/changes/machine-learning-concurrency.md
+++ b/mobile/apps/photos/changes/machine-learning-concurrency.md
@@ -1,1 +1,1 @@
-- Improved on-device machine learning reliability when foreground and background processing overlap.
+- Proper foreground vs background lock for ML processing

--- a/mobile/apps/photos/changes/machine-learning-concurrency.md
+++ b/mobile/apps/photos/changes/machine-learning-concurrency.md
@@ -1,0 +1,1 @@
+- Improved on-device machine learning reliability when foreground and background processing overlap.

--- a/mobile/apps/photos/changes/machine-learning-model-updates.md
+++ b/mobile/apps/photos/changes/machine-learning-model-updates.md
@@ -1,0 +1,1 @@
+- Improved reliability when updating on-device machine learning models.

--- a/mobile/apps/photos/changes/machine-learning-model-updates.md
+++ b/mobile/apps/photos/changes/machine-learning-model-updates.md
@@ -1,1 +1,1 @@
-- Improved reliability when updating on-device machine learning models.
+- Fix ML model download cleanup bug

--- a/mobile/apps/photos/changes/people-sync-reliability.md
+++ b/mobile/apps/photos/changes/people-sync-reliability.md
@@ -1,0 +1,1 @@
+- Fixed synced changes to People sometimes not appearing after startup.

--- a/mobile/apps/photos/changes/smart-memories-performance.md
+++ b/mobile/apps/photos/changes/smart-memories-performance.md
@@ -1,1 +1,1 @@
-- Improved Smart Memories generation performance.
+- Improved Smart Memories generation performance by only moving ML data to isolate once

--- a/mobile/apps/photos/changes/smart-memories-performance.md
+++ b/mobile/apps/photos/changes/smart-memories-performance.md
@@ -1,0 +1,1 @@
+- Improved Smart Memories generation performance.

--- a/mobile/apps/photos/changes/text-selection-reliability.md
+++ b/mobile/apps/photos/changes/text-selection-reliability.md
@@ -1,0 +1,1 @@
+- Improved text selection in photos so controls stay reachable and tapping selected text clears the selection.


### PR DESCRIPTION
## Summary

- add Photos mobile dev changelog fragments for six user-facing changes opened this week by @laurens-pilot and @laurenspriem
- cover ML sync and reliability, People sync, photo text selection, and Smart Memories performance
- leave the docs changelog unchanged

Covered PRs: #12162, #12152, #12143, #12089, and #12068.

## Validation

- `git diff --check upstream/main...HEAD`
- release-note generator reports the fragments as new changes
