### PR TITLE
[mobile][photos] Stop Memory Lane when ML is disabled

### DIFF
--- a/mobile/apps/photos/lib/events/ml_consent_changed_event.dart
+++ b/mobile/apps/photos/lib/events/ml_consent_changed_event.dart
@@ -1,0 +1,7 @@
+import "package:photos/events/event.dart";
+
+class MLConsentChangedEvent extends Event {
+  final bool enabled;
+
+  MLConsentChangedEvent(this.enabled);
+}

--- a/mobile/apps/photos/lib/main.dart
+++ b/mobile/apps/photos/lib/main.dart
@@ -203,12 +203,12 @@ Future<void> _warmPickerFilesDb() async {
 Future<void> _warmForegroundDeferredServices() async {
   try {
     await MemoryLaneService.instance.init();
-    if (flagService.facesTimeline) {
+    if (MemoryLaneService.instance.isFeatureEnabled) {
       MemoryLaneService.instance
           .queueFullRecompute(trigger: "startup")
           .ignore();
     } else {
-      _logger.info("Memory Lane disabled via feature flag");
+      _logger.info("Memory Lane disabled");
     }
   } catch (e, s) {
     _logger.warning("Deferred MemoryLaneService warm failed", e, s);

--- a/mobile/apps/photos/lib/service_locator.dart
+++ b/mobile/apps/photos/lib/service_locator.dart
@@ -4,7 +4,9 @@ import "package:ente_feature_flag/ente_feature_flag.dart";
 import "package:ente_install_source/ente_install_source.dart";
 import "package:package_info_plus/package_info_plus.dart";
 import "package:photos/core/configuration.dart";
+import "package:photos/core/event_bus.dart";
 import "package:photos/core/network/endpoint_config.dart";
+import "package:photos/events/ml_consent_changed_event.dart";
 import "package:photos/gateways/billing/billing_gateway.dart";
 import "package:photos/gateways/cast/cast_gateway.dart";
 import "package:photos/gateways/collections/collection_files_gateway.dart";
@@ -135,9 +137,10 @@ bool get hasGrantedMLConsent {
 Future<void> setMLConsent(bool enabled) async {
   if (isLocalGalleryMode) {
     await localSettings.setLocalGalleryMLConsent(enabled);
-    return;
+  } else {
+    await flagService.setMLConsent(enabled);
   }
-  await flagService.setMLConsent(enabled);
+  Bus.instance.fire(MLConsentChangedEvent(enabled));
 }
 
 bool get mapEnabled {

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -9,6 +9,7 @@ import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/db/ml/db.dart";
 import "package:photos/events/memory_lane_changed_event.dart";
+import "package:photos/events/ml_consent_changed_event.dart";
 import "package:photos/events/people_changed_event.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/memory_lane/memory_lane_models.dart";
@@ -66,9 +67,10 @@ class MemoryLaneService {
   bool _initialized = false;
 
   StreamSubscription<PeopleChangedEvent>? _peopleChangedSubscription;
+  StreamSubscription<MLConsentChangedEvent>? _mlConsentChangedSubscription;
   Timer? _startupBackfillTimer;
 
-  bool get isFeatureEnabled => flagService.facesTimeline;
+  bool get isFeatureEnabled => flagService.facesTimeline && hasGrantedMLConsent;
 
   Future<void> init() async {
     if (_initialized) return;
@@ -78,14 +80,36 @@ class MemoryLaneService {
     _peopleChangedSubscription = Bus.instance.on<PeopleChangedEvent>().listen(
       _handlePeopleChange,
     );
+    _mlConsentChangedSubscription = Bus.instance
+        .on<MLConsentChangedEvent>()
+        .listen(_handleMlConsentChange);
     _scheduleStartupBackfill();
     _initialized = true;
   }
 
   Future<void> dispose() async {
     await _peopleChangedSubscription?.cancel();
-    _startupBackfillTimer?.cancel();
+    await _mlConsentChangedSubscription?.cancel();
+    _cancelPendingWork();
     readyPersonIds.dispose();
+  }
+
+  void _handleMlConsentChange(MLConsentChangedEvent event) {
+    if (event.enabled && isFeatureEnabled) {
+      _scheduleStartupBackfill();
+      unawaited(queueFullRecompute(trigger: "ml_enabled"));
+      return;
+    }
+    _cancelPendingWork();
+  }
+
+  void _cancelPendingWork() {
+    _startupBackfillTimer?.cancel();
+    _startupBackfillTimer = null;
+    _pendingRequests.clear();
+    _cropReadinessInFlight.clear();
+    _precomputeQueue.clear();
+    _cropReadinessQueue.clear();
   }
 
   Future<void> queueFullRecompute({
@@ -106,6 +130,9 @@ class MemoryLaneService {
     }
     final persons = await PersonService.instance.getPersons();
     for (final person in persons) {
+      if (!isFeatureEnabled) {
+        return;
+      }
       if (person.data.isIgnored) {
         await _handleIgnoredPerson(person.remoteID);
         continue;
@@ -156,6 +183,9 @@ class MemoryLaneService {
         })
         .catchError((error, stackTrace) {
           _pendingRequests.remove(personId);
+          if (!isFeatureEnabled) {
+            return;
+          }
           _logger.warning(
             "Memory Lane recompute task failed to enqueue for $personId",
             error,
@@ -259,7 +289,7 @@ class MemoryLaneService {
   }
 
   void _queueTimelineCropReadiness(String personId, {required String trigger}) {
-    if (_cropReadinessInFlight.contains(personId)) {
+    if (!isFeatureEnabled || _cropReadinessInFlight.contains(personId)) {
       return;
     }
     _cropReadinessInFlight.add(personId);
@@ -273,6 +303,9 @@ class MemoryLaneService {
         })
         .catchError((error, stackTrace) {
           _cropReadinessInFlight.remove(personId);
+          if (!isFeatureEnabled) {
+            return;
+          }
           _logger.warning(
             "Memory Lane crop readiness task failed for $personId",
             error,
@@ -335,6 +368,9 @@ class MemoryLaneService {
       timeline.entries,
       filesById,
     );
+    if (!isFeatureEnabled) {
+      return;
+    }
     await _refreshReadyPersonIds();
     if (cropsReady) {
       Bus.instance.fire(
@@ -652,6 +688,9 @@ class MemoryLaneService {
 
     try {
       final result = await _computeTimeline(person, nowMicros);
+      if (!isFeatureEnabled) {
+        return;
+      }
       await _cacheService.upsertTimeline(result.timeline);
       await _cacheService.upsertComputeLogEntry(
         MemoryLaneComputeLogEntry(
@@ -678,6 +717,9 @@ class MemoryLaneService {
         result.timeline.entries,
         result.filesById,
       );
+      if (!isFeatureEnabled) {
+        return;
+      }
       await _refreshReadyPersonIds();
       if (cropsReady) {
         Bus.instance.fire(
@@ -883,6 +925,9 @@ class MemoryLaneService {
     }
 
     for (final entry in entriesByFile.entries) {
+      if (!isFeatureEnabled) {
+        return false;
+      }
       final file = fileMap[entry.key];
       if (file == null) {
         allCropsReady = false;
@@ -915,6 +960,9 @@ class MemoryLaneService {
       }
       if (selectedFaces.isEmpty) {
         continue;
+      }
+      if (!isFeatureEnabled) {
+        return false;
       }
       try {
         final cropMap = await getCachedFaceCrops(
@@ -971,6 +1019,9 @@ class MemoryLaneService {
       final stopwatch = Stopwatch()..start();
       int warmed = 0;
       for (final entry in entries) {
+        if (!isFeatureEnabled) {
+          return;
+        }
         final file = filesById[entry.fileId];
         if (file == null) {
           continue;
@@ -985,6 +1036,9 @@ class MemoryLaneService {
         );
         if (face == null) {
           continue;
+        }
+        if (!isFeatureEnabled) {
+          return;
         }
         try {
           await getCachedFaceCrops(

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -29,7 +29,7 @@ typedef _TimelineComputationResult = ({
 });
 
 class MemoryLaneService {
-  MemoryLaneService._internal();
+  MemoryLaneService._internal() : _enabledForSession = hasGrantedMLConsent;
 
   static final MemoryLaneService instance = MemoryLaneService._internal();
 
@@ -64,13 +64,15 @@ class MemoryLaneService {
   final Map<String, _PendingRecomputeRequest> _pendingRequests = {};
   final Set<String> _cropReadinessInFlight = {};
 
+  bool _enabledForSession;
   bool _initialized = false;
 
   StreamSubscription<PeopleChangedEvent>? _peopleChangedSubscription;
   StreamSubscription<MLConsentChangedEvent>? _mlConsentChangedSubscription;
   Timer? _startupBackfillTimer;
 
-  bool get isFeatureEnabled => flagService.facesTimeline && hasGrantedMLConsent;
+  bool get isFeatureEnabled =>
+      _enabledForSession && flagService.facesTimeline && hasGrantedMLConsent;
 
   Future<void> init() async {
     if (_initialized) return;
@@ -95,11 +97,8 @@ class MemoryLaneService {
   }
 
   void _handleMlConsentChange(MLConsentChangedEvent event) {
-    if (event.enabled && isFeatureEnabled) {
-      _scheduleStartupBackfill();
-      unawaited(queueFullRecompute(trigger: "ml_enabled"));
-      return;
-    }
+    if (event.enabled) return;
+    _enabledForSession = false;
     _startupBackfillTimer?.cancel();
     _startupBackfillTimer = null;
   }

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -90,7 +90,7 @@ class MemoryLaneService {
   Future<void> dispose() async {
     await _peopleChangedSubscription?.cancel();
     await _mlConsentChangedSubscription?.cancel();
-    _cancelPendingWork();
+    _startupBackfillTimer?.cancel();
     readyPersonIds.dispose();
   }
 
@@ -100,16 +100,8 @@ class MemoryLaneService {
       unawaited(queueFullRecompute(trigger: "ml_enabled"));
       return;
     }
-    _cancelPendingWork();
-  }
-
-  void _cancelPendingWork() {
     _startupBackfillTimer?.cancel();
     _startupBackfillTimer = null;
-    _pendingRequests.clear();
-    _cropReadinessInFlight.clear();
-    _precomputeQueue.clear();
-    _cropReadinessQueue.clear();
   }
 
   Future<void> queueFullRecompute({
@@ -130,9 +122,6 @@ class MemoryLaneService {
     }
     final persons = await PersonService.instance.getPersons();
     for (final person in persons) {
-      if (!isFeatureEnabled) {
-        return;
-      }
       if (person.data.isIgnored) {
         await _handleIgnoredPerson(person.remoteID);
         continue;
@@ -183,9 +172,6 @@ class MemoryLaneService {
         })
         .catchError((error, stackTrace) {
           _pendingRequests.remove(personId);
-          if (!isFeatureEnabled) {
-            return;
-          }
           _logger.warning(
             "Memory Lane recompute task failed to enqueue for $personId",
             error,
@@ -289,7 +275,7 @@ class MemoryLaneService {
   }
 
   void _queueTimelineCropReadiness(String personId, {required String trigger}) {
-    if (!isFeatureEnabled || _cropReadinessInFlight.contains(personId)) {
+    if (_cropReadinessInFlight.contains(personId)) {
       return;
     }
     _cropReadinessInFlight.add(personId);
@@ -303,9 +289,6 @@ class MemoryLaneService {
         })
         .catchError((error, stackTrace) {
           _cropReadinessInFlight.remove(personId);
-          if (!isFeatureEnabled) {
-            return;
-          }
           _logger.warning(
             "Memory Lane crop readiness task failed for $personId",
             error,
@@ -368,9 +351,6 @@ class MemoryLaneService {
       timeline.entries,
       filesById,
     );
-    if (!isFeatureEnabled) {
-      return;
-    }
     await _refreshReadyPersonIds();
     if (cropsReady) {
       Bus.instance.fire(
@@ -688,9 +668,6 @@ class MemoryLaneService {
 
     try {
       final result = await _computeTimeline(person, nowMicros);
-      if (!isFeatureEnabled) {
-        return;
-      }
       await _cacheService.upsertTimeline(result.timeline);
       await _cacheService.upsertComputeLogEntry(
         MemoryLaneComputeLogEntry(
@@ -717,9 +694,6 @@ class MemoryLaneService {
         result.timeline.entries,
         result.filesById,
       );
-      if (!isFeatureEnabled) {
-        return;
-      }
       await _refreshReadyPersonIds();
       if (cropsReady) {
         Bus.instance.fire(
@@ -925,9 +899,6 @@ class MemoryLaneService {
     }
 
     for (final entry in entriesByFile.entries) {
-      if (!isFeatureEnabled) {
-        return false;
-      }
       final file = fileMap[entry.key];
       if (file == null) {
         allCropsReady = false;
@@ -960,9 +931,6 @@ class MemoryLaneService {
       }
       if (selectedFaces.isEmpty) {
         continue;
-      }
-      if (!isFeatureEnabled) {
-        return false;
       }
       try {
         final cropMap = await getCachedFaceCrops(
@@ -1019,9 +987,6 @@ class MemoryLaneService {
       final stopwatch = Stopwatch()..start();
       int warmed = 0;
       for (final entry in entries) {
-        if (!isFeatureEnabled) {
-          return;
-        }
         final file = filesById[entry.fileId];
         if (file == null) {
           continue;
@@ -1036,9 +1001,6 @@ class MemoryLaneService {
         );
         if (face == null) {
           continue;
-        }
-        if (!isFeatureEnabled) {
-          return;
         }
         try {
           await getCachedFaceCrops(

--- a/mobile/apps/photos/lib/ui/viewer/people/memory_lane_debug_panel.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/memory_lane_debug_panel.dart
@@ -6,7 +6,6 @@ import "package:photos/core/event_bus.dart";
 import "package:photos/events/memory_lane_changed_event.dart";
 import "package:photos/models/memory_lane/memory_lane_models.dart";
 import "package:photos/models/ml/face/person.dart";
-import "package:photos/service_locator.dart";
 import "package:photos/services/memory_lane/memory_lane_cache_service.dart";
 import "package:photos/services/memory_lane/memory_lane_service.dart";
 import "package:photos/theme/ente_theme.dart";
@@ -27,7 +26,7 @@ class _MemoryLaneDebugPanelState extends State<MemoryLaneDebugPanel> {
   String? _info;
   StreamSubscription<MemoryLaneChangedEvent>? _timelineSubscription;
 
-  bool get _featureEnabled => flagService.facesTimeline;
+  bool get _featureEnabled => MemoryLaneService.instance.isFeatureEnabled;
 
   @override
   void initState() {

--- a/mobile/apps/photos/lib/ui/viewer/people/memory_lane_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/memory_lane_page.dart
@@ -92,7 +92,7 @@ class _MemoryLanePageState extends State<MemoryLanePage>
   int _currentCaptionValue = 0;
   _CaptionType _currentCaptionType = _CaptionType.yearsAgo;
   int _maxCaptionDigits = 1;
-  bool get _featureEnabled => flagService.facesTimeline;
+  bool get _featureEnabled => MemoryLaneService.instance.isFeatureEnabled;
   bool get _showShareAction =>
       _featureEnabled &&
       flagService.enableMemoryShareLink &&

--- a/mobile/apps/photos/lib/ui/viewer/people/people_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/people_page.dart
@@ -72,7 +72,7 @@ class _PeoplePageState extends State<PeoplePage> {
   bool _memoryLanePrewarmStarted = false;
   bool _isTryingToPopDeletedPersonPage = false;
 
-  bool get _memoryLaneEnabled => flagService.facesTimeline;
+  bool get _memoryLaneEnabled => MemoryLaneService.instance.isFeatureEnabled;
 
   @override
   void initState() {


### PR DESCRIPTION
## Summary

- Gate Memory Lane startup and UI availability on global ML consent.
- Reuse the existing per-person work-entry checks so queued work becomes a no-op while allowing an already-running person job to finish.

## Verification

- Ran Dart formatting on all affected files.
- Ran targeted Flutter analysis on all affected files; no issues found.
- No regression tests added, as requested.