### PR TITLE
[server] Add Library Sharing entity support

### DIFF
--- a/server/ente/remotestore.go
+++ b/server/ente/remotestore.go
@@ -57,6 +57,7 @@ const (
 	// CastSessionsV2 gates cast sessions v2 support.
 	CastSessionsV2             int64 = 1 << 5
 	DeferredMultipartChecksums int64 = 1 << 6
+	LibrarySharing             int64 = 1 << 7
 )
 
 type FlagKey string

--- a/server/ente/userentity/entity.go
+++ b/server/ente/userentity/entity.go
@@ -2,9 +2,11 @@ package userentity
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/ente/museum/ente"
 	"github.com/ente/museum/ente/base"
-	"strings"
 )
 
 type EntityType string
@@ -14,16 +16,17 @@ const (
 	// Person entity is deprecated and will be removed in the future.
 	Person EntityType = "person"
 	// CGroup replaces Person; its data is gzipped before encryption.
-	CGroup     EntityType = "cgroup"
-	SmartAlbum EntityType = "smart_album"
-	Memory     EntityType = "memory"
-	Contact    EntityType = "contact"
-	Space      EntityType = "space"
+	CGroup       EntityType = "cgroup"
+	SmartAlbum   EntityType = "smart_album"
+	Memory       EntityType = "memory"
+	Contact      EntityType = "contact"
+	Space        EntityType = "space"
+	LibraryShare EntityType = "library_share"
 )
 
 func (et EntityType) IsValid() error {
 	switch et {
-	case Location, Person, CGroup, SmartAlbum, Memory, Contact, Space:
+	case Location, Person, CGroup, SmartAlbum, Memory, Contact, Space, LibraryShare:
 		return nil
 	}
 	return ente.NewBadRequestWithMessage(fmt.Sprintf("Invalid EntityType: %s", et))
@@ -34,7 +37,7 @@ func (et EntityType) GetNewID() (*string, error) {
 }
 
 func (et EntityType) CanRestoreDeletedData() bool {
-	return et == SmartAlbum
+	return et == SmartAlbum || et == LibraryShare
 }
 
 type EntityKey struct {
@@ -85,17 +88,41 @@ func (edr *EntityDataRequest) IsValid(userID int64) error {
 		if !strings.HasPrefix(*edr.ID, fmt.Sprintf("sa_%d_", userID)) {
 			return ente.NewBadRequestWithMessage(fmt.Sprintf("ID %s is not valid for SmartAlbum entity type", *edr.ID))
 		}
-		return nil
-	default:
-		return nil
+	case LibraryShare:
+		if edr.ID == nil {
+			return ente.NewBadRequestWithMessage("ID is required for LibraryShare entity type")
+		}
+		parts := strings.Split(*edr.ID, "_")
+		if len(parts) != 3 || parts[0] != "ls" {
+			return ente.NewBadRequestWithMessage(fmt.Sprintf("ID %s is not valid for LibraryShare entity type", *edr.ID))
+		}
+		ownerID, ownerErr := strconv.ParseInt(parts[1], 10, 64)
+		recipientID, recipientErr := strconv.ParseInt(parts[2], 10, 64)
+		if ownerErr != nil || recipientErr != nil || ownerID != userID || recipientID <= 0 || recipientID == userID || *edr.ID != fmt.Sprintf("ls_%d_%d", ownerID, recipientID) {
+			return ente.NewBadRequestWithMessage(fmt.Sprintf("ID %s is not valid for LibraryShare entity type", *edr.ID))
+		}
 	}
+	return nil
 }
 
 type UpdateEntityDataRequest struct {
-	ID            string     `json:"id" binding:"required"`
-	Type          EntityType `json:"type" binding:"required"`
-	EncryptedData string     `json:"encryptedData" binding:"required"`
-	Header        string     `json:"header" binding:"required"`
+	ID                string     `json:"id" binding:"required"`
+	Type              EntityType `json:"type" binding:"required"`
+	EncryptedData     string     `json:"encryptedData" binding:"required"`
+	Header            string     `json:"header" binding:"required"`
+	ExpectedUpdatedAt *int64     `json:"expectedUpdatedAt"`
+}
+
+func (uedr *UpdateEntityDataRequest) IsValid() error {
+	if err := uedr.Type.IsValid(); err != nil {
+		return err
+	}
+	if uedr.Type == LibraryShare {
+		if uedr.ExpectedUpdatedAt == nil || *uedr.ExpectedUpdatedAt <= 0 {
+			return ente.NewBadRequestWithMessage("expectedUpdatedAt is required for LibraryShare entity type")
+		}
+	}
+	return nil
 }
 
 type GetEntityDiffRequest struct {

--- a/server/ente/userentity/entity_test.go
+++ b/server/ente/userentity/entity_test.go
@@ -1,0 +1,15 @@
+package userentity
+
+import "testing"
+
+func TestLibraryShareEntityValidation(t *testing.T) {
+	validID := "ls_123_456"
+	if err := (&EntityDataRequest{Type: LibraryShare, ID: &validID}).IsValid(123); err != nil {
+		t.Fatalf("valid library share ID rejected: %v", err)
+	}
+
+	invalidID := "ls_124_456"
+	if err := (&EntityDataRequest{Type: LibraryShare, ID: &invalidID}).IsValid(123); err == nil {
+		t.Fatal("library share ID with a different owner accepted")
+	}
+}

--- a/server/pkg/api/userentity_test.go
+++ b/server/pkg/api/userentity_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -168,6 +169,50 @@ func TestCreateSmartAlbumEntityRestoresDeletedEntry(t *testing.T) {
 	}
 	if entity.Header == nil || *entity.Header != "new-header" {
 		t.Fatalf("unexpected header: got %v want %q", entity.Header, "new-header")
+	}
+}
+
+func TestUpdateLibraryShareEntityRejectsStaleWrite(t *testing.T) {
+	handler, db := setupUserEntityHandlerTest(t)
+
+	userID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       205,
+		Email:        "library-share-update@ente.io",
+		CreationTime: 1,
+	})
+	ctx := context.Background()
+	if err := handler.Controller.Repo.CreateKey(ctx, userID, model.EntityKeyRequest{
+		Type:         model.LibraryShare,
+		EncryptedKey: "encrypted-key",
+		Header:       "key-header",
+	}); err != nil {
+		t.Fatalf("failed to create entity key: %v", err)
+	}
+
+	id := "ls_205_206"
+	if _, err := handler.Controller.Repo.Create(ctx, userID, model.EntityDataRequest{
+		ID:            &id,
+		Type:          model.LibraryShare,
+		EncryptedData: "initial-data",
+		Header:        "initial-header",
+	}); err != nil {
+		t.Fatalf("failed to create entity: %v", err)
+	}
+	created, err := handler.Controller.Repo.Get(ctx, userID, id)
+	if err != nil {
+		t.Fatalf("failed to fetch created entity: %v", err)
+	}
+
+	staleUpdatedAt := created.UpdatedAt - 1
+	err = handler.Controller.Repo.Update(ctx, userID, model.UpdateEntityDataRequest{
+		ID:                id,
+		Type:              model.LibraryShare,
+		EncryptedData:     "updated-data",
+		Header:            "updated-header",
+		ExpectedUpdatedAt: &staleUpdatedAt,
+	})
+	if !errors.Is(err, ente.ErrVersionMismatch) {
+		t.Fatalf("stale update error = %v, want %v", err, ente.ErrVersionMismatch)
 	}
 }
 

--- a/server/pkg/controller/remotestore/controller.go
+++ b/server/pkg/controller/remotestore/controller.go
@@ -138,6 +138,9 @@ func (c *Controller) GetFeatureFlags(ctx *gin.Context) (*ente.FeatureFlagRespons
 		}
 	}
 
+	if response.InternalUser {
+		response.ServerApiFlag |= ente.LibrarySharing
+	}
 	if response.InternalUser ||
 		rollout.IsInPercentageRollout(userID, videoStreamingRolloutNonce, videoStreamingRolloutPercentage) {
 		response.ServerApiFlag |= ente.VideoStreaming

--- a/server/pkg/controller/userentity/controller.go
+++ b/server/pkg/controller/userentity/controller.go
@@ -50,6 +50,9 @@ func (c *Controller) CreateEntity(ctx *gin.Context, req model.EntityDataRequest)
 
 func (c *Controller) UpdateEntity(ctx *gin.Context, req model.UpdateEntityDataRequest) (*model.EntityData, error) {
 	userID := auth.GetUserID(ctx.Request.Header)
+	if err := req.IsValid(); err != nil {
+		return nil, stacktrace.Propagate(err, "invalid UpdateEntityDataRequest")
+	}
 	err := c.Repo.Update(ctx, userID, req)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to updateEntity")

--- a/server/pkg/repo/userentity/data.go
+++ b/server/pkg/repo/userentity/data.go
@@ -101,9 +101,13 @@ func (r *Repository) Delete(ctx context.Context, userID int64, id string) (bool,
 }
 
 func (r *Repository) Update(ctx context.Context, userID int64, req model.UpdateEntityDataRequest) error {
-	result, err := r.DB.ExecContext(ctx,
-		`UPDATE entity_data SET encrypted_data = $1, header = $2 where id=$3 and user_id = $4 and is_deleted = FALSE`,
-		req.EncryptedData, req.Header, req.ID, userID)
+	query := `UPDATE entity_data SET encrypted_data = $1, header = $2 where id=$3 and user_id = $4 and type = $5 and is_deleted = FALSE`
+	args := []any{req.EncryptedData, req.Header, req.ID, userID, req.Type}
+	if req.ExpectedUpdatedAt != nil {
+		query += ` and updated_at = $6`
+		args = append(args, *req.ExpectedUpdatedAt)
+	}
+	result, err := r.DB.ExecContext(ctx, query, args...)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
@@ -118,9 +122,16 @@ func (r *Repository) Update(ctx context.Context, userID int64, req model.UpdateE
 		}
 		if dbEntity.IsDeleted {
 			return stacktrace.Propagate(ente.NewBadRequestWithMessage("entity is already deleted"), "")
-		} else if *dbEntity.EncryptedData == req.EncryptedData && *dbEntity.Header == req.Header {
+		}
+		if dbEntity.Type != req.Type {
+			return stacktrace.Propagate(ente.NewBadRequestWithMessage("entity type does not match"), "")
+		}
+		if *dbEntity.EncryptedData == req.EncryptedData && *dbEntity.Header == req.Header {
 			logrus.WithField("id", req.ID).Info("entity is already updated")
 			return nil
+		}
+		if req.ExpectedUpdatedAt != nil && dbEntity.UpdatedAt != *req.ExpectedUpdatedAt {
+			return stacktrace.Propagate(ente.ErrVersionMismatch, "entity was updated")
 		}
 		return stacktrace.Propagate(errors.New("exactly one row should be updated"), "")
 	}


### PR DESCRIPTION
- Add validated `library_share` entities with `ls_<owner>_<recipient>` IDs and conflict-safe updates.
- Advertise backend support through `serverApiFlag` bit 7.

Validation: `./scripts/lint.sh`; `./scripts/test-with-postgres.sh host`