### PR TITLE
[mobile][photos] add double tap seek feature to video player

### DIFF
--- a/mobile/apps/photos/changes/video-double-tap-seek.md
+++ b/mobile/apps/photos/changes/video-double-tap-seek.md
@@ -1,0 +1,2 @@
+- Added double tap video seek. (@r4khul)
+- Fixed video seek bar snapping glitch during manual drag. (@r4khul)

--- a/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
@@ -40,6 +40,7 @@ class _NativeVideoProgressControlsState
   );
   StreamSubscription<void>? _eventsSubscription;
   StreamSubscription<SeekbarTriggeredEvent>? _seekbarSubscription;
+  Timer? _seekReleaseTimer;
 
   @override
   void initState() {
@@ -69,6 +70,7 @@ class _NativeVideoProgressControlsState
 
   @override
   void dispose() {
+    _seekReleaseTimer?.cancel();
     _seekbarSubscription?.cancel();
     _eventsSubscription?.cancel();
     _animationController.dispose();
@@ -99,6 +101,7 @@ class _NativeVideoProgressControlsState
             max: 1.0,
             value: _animationController.value,
             onChangeStart: (value) {
+              _seekReleaseTimer?.cancel();
               widget.isSeeking.value = true;
             },
             onChanged: (value) {
@@ -111,10 +114,9 @@ class _NativeVideoProgressControlsState
               _elapsedMilliseconds = _positionInMilliseconds(value) ?? 0;
               _animationController.value = value;
               _seekTo(value);
-              Future.delayed(_seekReleaseDelay, () {
-                if (mounted) {
-                  widget.isSeeking.value = false;
-                }
+              _seekReleaseTimer?.cancel();
+              _seekReleaseTimer = Timer(_seekReleaseDelay, () {
+                if (mounted) widget.isSeeking.value = false;
               });
             },
             allowedInteraction: SliderInteraction.tapAndSlide,

--- a/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
@@ -148,7 +148,7 @@ class _NativeVideoProgressControlsState
       _lastSeekTime = now;
       _lastSeekTargetMs = position;
       widget.lastSeekTime?.value = now;
-      widget.lastSeekTargetMs?.value = null;
+      widget.lastSeekTargetMs?.value = position;
       await widget.controller.seekTo(Duration(milliseconds: position));
     });
   }
@@ -196,6 +196,19 @@ class _NativeVideoProgressControlsState
     final target = widget.controller.playbackPosition.inMilliseconds;
     final duration = widget.controller.videoInfo?.durationInMilliseconds;
 
+    final lastSeek = widget.lastSeekTime?.value ?? _lastSeekTime;
+    if (lastSeek != null &&
+        DateTime.now().difference(lastSeek).inMilliseconds <
+            _staleEventWindow.inMilliseconds) {
+      final referenceMs =
+          widget.lastSeekTargetMs?.value ??
+          _lastSeekTargetMs ??
+          _elapsedMilliseconds;
+      if ((target - referenceMs).abs() > _staleDeltaThreshold.inMilliseconds) {
+        return;
+      }
+    }
+
     if (widget.controller.playbackStatus == PlaybackStatus.paused ||
         (widget.controller.playbackStatus == PlaybackStatus.stopped &&
             widget.controller.playbackPosition.inSeconds != 0)) {
@@ -212,19 +225,6 @@ class _NativeVideoProgressControlsState
     }
     if (!mounted) {
       return;
-    }
-
-    final lastSeek = widget.lastSeekTime?.value ?? _lastSeekTime;
-    if (lastSeek != null &&
-        DateTime.now().difference(lastSeek).inMilliseconds <
-            _staleEventWindow.inMilliseconds) {
-      final referenceMs =
-          widget.lastSeekTargetMs?.value ??
-          _lastSeekTargetMs ??
-          _elapsedMilliseconds;
-      if ((target - referenceMs).abs() > _staleDeltaThreshold.inMilliseconds) {
-        return;
-      }
     }
 
     final previousMilliseconds = _elapsedMilliseconds;

--- a/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
@@ -28,6 +28,10 @@ class NativeVideoProgressControls extends StatefulWidget {
 class _NativeVideoProgressControlsState
     extends State<NativeVideoProgressControls>
     with SingleTickerProviderStateMixin {
+  static const _seekReleaseDelay = Duration(milliseconds: 500);
+  static const _staleEventWindow = Duration(milliseconds: 1000);
+  static const _staleDeltaThreshold = Duration(milliseconds: 1500);
+
   late final AnimationController _animationController;
   int _elapsedMilliseconds = 0;
   final _debouncer = Debouncer(
@@ -107,7 +111,11 @@ class _NativeVideoProgressControlsState
               _elapsedMilliseconds = _positionInMilliseconds(value) ?? 0;
               _animationController.value = value;
               _seekTo(value);
-              widget.isSeeking.value = false;
+              Future.delayed(_seekReleaseDelay, () {
+                if (mounted) {
+                  widget.isSeeking.value = false;
+                }
+              });
             },
             allowedInteraction: SliderInteraction.tapAndSlide,
           ),
@@ -123,11 +131,14 @@ class _NativeVideoProgressControlsState
     );
   }
 
+  DateTime? _lastSeekTime;
+
   void _seekTo(double value) {
     _debouncer.run(() async {
       final position = _positionInMilliseconds(value);
       if (position == null) return;
-      unawaited(widget.controller.seekTo(Duration(milliseconds: position)));
+      _lastSeekTime = DateTime.now();
+      await widget.controller.seekTo(Duration(milliseconds: position));
     });
   }
 
@@ -169,12 +180,20 @@ class _NativeVideoProgressControlsState
   }
 
   void _onPlaybackPositionChanged() async {
+    if (widget.isSeeking.value) return;
+
+    final target = widget.controller.playbackPosition.inMilliseconds;
+    final duration = widget.controller.videoInfo?.durationInMilliseconds;
+
     if (widget.controller.playbackStatus == PlaybackStatus.paused ||
         (widget.controller.playbackStatus == PlaybackStatus.stopped &&
             widget.controller.playbackPosition.inSeconds != 0)) {
+      if (duration != null && duration > 0) {
+        _elapsedMilliseconds = target;
+        _animationController.value = (target / duration).clamp(0.0, 1.0);
+      }
       return;
     }
-    final target = widget.controller.playbackPosition.inMilliseconds;
 
     // The position event after zero arrives about 350 ms late.
     if (target == 0) {
@@ -184,13 +203,29 @@ class _NativeVideoProgressControlsState
       return;
     }
 
+    if (_lastSeekTime != null &&
+        DateTime.now().difference(_lastSeekTime!).inMilliseconds <
+            _staleEventWindow.inMilliseconds) {
+      if ((target - _elapsedMilliseconds).abs() >
+          _staleDeltaThreshold.inMilliseconds) {
+        return;
+      }
+    }
+
+    final previousMilliseconds = _elapsedMilliseconds;
     _elapsedMilliseconds = target;
-    final duration = widget.controller.videoInfo?.durationInMilliseconds;
+
     final double fractionTarget = duration == null || duration <= 0
         ? 0
         : target / duration;
 
     final nudge = _durationNudge();
+
+    if ((target - previousMilliseconds).abs() >
+        _staleDeltaThreshold.inMilliseconds) {
+      _animationController.value = fractionTarget.clamp(0.0, 1.0);
+    }
+
     unawaited(
       _animationController.animateTo(
         (fractionTarget + nudge).clamp(0.0, 1.0),

--- a/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
@@ -14,6 +14,7 @@ class NativeVideoProgressControls extends StatefulWidget {
   final ValueNotifier<bool> isSeeking;
   final ValueNotifier<DateTime?>? lastSeekTime;
   final ValueNotifier<int?>? lastSeekTargetMs;
+  final ValueNotifier<int>? seekGeneration;
 
   const NativeVideoProgressControls(
     this.controller,
@@ -21,6 +22,7 @@ class NativeVideoProgressControls extends StatefulWidget {
     this.isSeeking, {
     this.lastSeekTime,
     this.lastSeekTargetMs,
+    this.seekGeneration,
     super.key,
   });
 
@@ -141,14 +143,17 @@ class _NativeVideoProgressControlsState
   int? _lastSeekTargetMs;
 
   void _seekTo(double value) {
+    final position = _positionInMilliseconds(value);
+    if (position == null) return;
+    final now = DateTime.now();
+    _lastSeekTime = now;
+    _lastSeekTargetMs = position;
+    widget.lastSeekTime?.value = now;
+    widget.lastSeekTargetMs?.value = position;
+    if (widget.seekGeneration != null) {
+      widget.seekGeneration!.value++;
+    }
     _debouncer.run(() async {
-      final position = _positionInMilliseconds(value);
-      if (position == null) return;
-      final now = DateTime.now();
-      _lastSeekTime = now;
-      _lastSeekTargetMs = position;
-      widget.lastSeekTime?.value = now;
-      widget.lastSeekTargetMs?.value = position;
       await widget.controller.seekTo(Duration(milliseconds: position));
     });
   }
@@ -190,12 +195,7 @@ class _NativeVideoProgressControlsState
     }
   }
 
-  void _onPlaybackPositionChanged() async {
-    if (widget.isSeeking.value) return;
-
-    final target = widget.controller.playbackPosition.inMilliseconds;
-    final duration = widget.controller.videoInfo?.durationInMilliseconds;
-
+  bool _isEventStale(int target) {
     final lastSeek = widget.lastSeekTime?.value ?? _lastSeekTime;
     if (lastSeek != null &&
         DateTime.now().difference(lastSeek).inMilliseconds <
@@ -205,9 +205,19 @@ class _NativeVideoProgressControlsState
           _lastSeekTargetMs ??
           _elapsedMilliseconds;
       if ((target - referenceMs).abs() > _staleDeltaThreshold.inMilliseconds) {
-        return;
+        return true;
       }
     }
+    return false;
+  }
+
+  void _onPlaybackPositionChanged() async {
+    if (widget.isSeeking.value) return;
+
+    final target = widget.controller.playbackPosition.inMilliseconds;
+    final duration = widget.controller.videoInfo?.durationInMilliseconds;
+
+    if (_isEventStale(target)) return;
 
     if (widget.controller.playbackStatus == PlaybackStatus.paused ||
         (widget.controller.playbackStatus == PlaybackStatus.stopped &&
@@ -221,9 +231,15 @@ class _NativeVideoProgressControlsState
 
     // The position event after zero arrives about 350 ms late.
     if (target == 0) {
+      final generation = widget.seekGeneration?.value;
       await Future.delayed(const Duration(milliseconds: 450));
+      if (generation != widget.seekGeneration?.value) return;
     }
     if (!mounted) {
+      return;
+    }
+
+    if (target == 0 && (widget.isSeeking.value || _isEventStale(target))) {
       return;
     }
 

--- a/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
@@ -12,11 +12,15 @@ class NativeVideoProgressControls extends StatefulWidget {
   final NativeVideoPlayerController controller;
   final int? duration;
   final ValueNotifier<bool> isSeeking;
+  final ValueNotifier<DateTime?>? lastSeekTime;
+  final ValueNotifier<int?>? lastSeekTargetMs;
 
   const NativeVideoProgressControls(
     this.controller,
     this.duration,
     this.isSeeking, {
+    this.lastSeekTime,
+    this.lastSeekTargetMs,
     super.key,
   });
 
@@ -134,12 +138,17 @@ class _NativeVideoProgressControlsState
   }
 
   DateTime? _lastSeekTime;
+  int? _lastSeekTargetMs;
 
   void _seekTo(double value) {
     _debouncer.run(() async {
       final position = _positionInMilliseconds(value);
       if (position == null) return;
-      _lastSeekTime = DateTime.now();
+      final now = DateTime.now();
+      _lastSeekTime = now;
+      _lastSeekTargetMs = position;
+      widget.lastSeekTime?.value = now;
+      widget.lastSeekTargetMs?.value = null;
       await widget.controller.seekTo(Duration(milliseconds: position));
     });
   }
@@ -205,11 +214,15 @@ class _NativeVideoProgressControlsState
       return;
     }
 
-    if (_lastSeekTime != null &&
-        DateTime.now().difference(_lastSeekTime!).inMilliseconds <
+    final lastSeek = widget.lastSeekTime?.value ?? _lastSeekTime;
+    if (lastSeek != null &&
+        DateTime.now().difference(lastSeek).inMilliseconds <
             _staleEventWindow.inMilliseconds) {
-      if ((target - _elapsedMilliseconds).abs() >
-          _staleDeltaThreshold.inMilliseconds) {
+      final referenceMs =
+          widget.lastSeekTargetMs?.value ??
+          _lastSeekTargetMs ??
+          _elapsedMilliseconds;
+      if ((target - referenceMs).abs() > _staleDeltaThreshold.inMilliseconds) {
         return;
       }
     }

--- a/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
@@ -42,10 +42,18 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
   DateTime? _lastDoubleTapTime;
   bool? _lastDirection;
   Duration? _pendingTarget;
-  late final AnimationController _badgeAnimation = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 180),
-  );
+  TapDownDetails? _doubleTapDetails;
+  int _seekGeneration = 0;
+  late final AnimationController _badgeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _badgeAnimation = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 180),
+    );
+  }
 
   @override
   void dispose() {
@@ -54,7 +62,7 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
     super.dispose();
   }
 
-  void _handleDoubleTapDown(TapDownDetails details) {
+  void _handleDoubleTap(TapDownDetails details) {
     if (!widget.enabled()) return;
 
     final renderBox = context.findRenderObject() as RenderBox?;
@@ -70,23 +78,25 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
         now.difference(_lastDoubleTapTime!).inMilliseconds <= 750 &&
         _lastDirection == isForward;
 
-    if (isFastSequence) {
-      _accumulatedSeconds += 5;
-    } else {
-      _accumulatedSeconds = 5;
-      _lastDirection = isForward;
-    }
-    _lastDoubleTapTime = now;
-
-    final currentPos = isFastSequence && _pendingTarget != null
-        ? _pendingTarget!
-        : widget.position();
+    final currentPos = _pendingTarget ?? widget.position();
     var target = isForward
         ? currentPos + kDefaultSeekDuration
         : currentPos - kDefaultSeekDuration;
 
     if (target < Duration.zero) target = Duration.zero;
     if (target > totalDur) target = totalDur;
+
+    if (isFastSequence) {
+      final isAtSeekBoundary =
+          (isForward && target >= totalDur) ||
+          (!isForward && target <= Duration.zero);
+      if (!isAtSeekBoundary) _accumulatedSeconds += 5;
+    } else {
+      _accumulatedSeconds = 5;
+      _lastDirection = isForward;
+    }
+    _lastDoubleTapTime = now;
+    _seekGeneration++;
 
     _pendingTarget = target;
     widget.seekTo(target);
@@ -96,13 +106,14 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
 
   void _showSeekBadge(bool forward) {
     _badgeHideTimer?.cancel();
+    final generation = _seekGeneration;
     setState(() {
       _badgeForward = forward;
       _showBadge = true;
     });
     _badgeAnimation.forward(from: 0);
     _badgeHideTimer = Timer(const Duration(milliseconds: 750), () {
-      if (!mounted) return;
+      if (!mounted || generation != _seekGeneration) return;
       setState(() {
         _showBadge = false;
         _accumulatedSeconds = 0;
@@ -120,8 +131,14 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
         GestureDetector(
           behavior: HitTestBehavior.translucent,
           onTap: widget.onSingleTap,
-          onDoubleTapDown: _handleDoubleTapDown,
-          onDoubleTap: () {},
+          onDoubleTapDown: (details) => _doubleTapDetails = details,
+          onDoubleTapCancel: () => _doubleTapDetails = null,
+          onDoubleTap: () {
+            if (_doubleTapDetails != null) {
+              _handleDoubleTap(_doubleTapDetails!);
+              _doubleTapDetails = null;
+            }
+          },
           onLongPress: widget.onLongPress,
           onLongPressUp: widget.onLongPressUp,
           child: Container(constraints: const BoxConstraints.expand()),

--- a/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
@@ -1,0 +1,186 @@
+import "dart:async";
+
+import "package:flutter/material.dart";
+import "package:hugeicons/hugeicons.dart";
+import "package:photos/theme/colors.dart";
+import "package:photos/theme/ente_theme.dart";
+
+const kDefaultSeekDuration = Duration(seconds: 5);
+
+class DoubleTapSeekOverlay extends StatefulWidget {
+  final bool Function() enabled;
+  final Duration Function() position;
+  final Duration Function() duration;
+  final void Function(Duration) seekTo;
+  final VoidCallback? onSingleTap;
+  final VoidCallback? onSeekInteraction;
+  final GestureLongPressCallback? onLongPress;
+  final GestureLongPressUpCallback? onLongPressUp;
+
+  const DoubleTapSeekOverlay({
+    required this.enabled,
+    required this.position,
+    required this.duration,
+    required this.seekTo,
+    this.onSeekInteraction,
+    this.onSingleTap,
+    this.onLongPress,
+    this.onLongPressUp,
+    super.key,
+  });
+
+  @override
+  State<DoubleTapSeekOverlay> createState() => _DoubleTapSeekOverlayState();
+}
+
+class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
+    with SingleTickerProviderStateMixin {
+  Timer? _badgeHideTimer;
+  bool _showBadge = false;
+  bool _badgeForward = true;
+  int _accumulatedSeconds = 0;
+  DateTime? _lastDoubleTapTime;
+  bool? _lastDirection;
+  Duration? _pendingTarget;
+  late final AnimationController _badgeAnimation = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 180),
+  );
+
+  @override
+  void dispose() {
+    _badgeHideTimer?.cancel();
+    _badgeAnimation.dispose();
+    super.dispose();
+  }
+
+  void _handleDoubleTapDown(TapDownDetails details) {
+    if (!widget.enabled()) return;
+
+    final renderBox = context.findRenderObject() as RenderBox?;
+    final width = renderBox?.size.width ?? MediaQuery.of(context).size.width;
+    final isForward = details.localPosition.dx >= width / 2;
+
+    final totalDur = widget.duration();
+    if (totalDur == Duration.zero) return;
+
+    final now = DateTime.now();
+    final isFastSequence =
+        _lastDoubleTapTime != null &&
+        now.difference(_lastDoubleTapTime!).inMilliseconds <= 750 &&
+        _lastDirection == isForward;
+
+    if (isFastSequence) {
+      _accumulatedSeconds += 5;
+    } else {
+      _accumulatedSeconds = 5;
+      _lastDirection = isForward;
+    }
+    _lastDoubleTapTime = now;
+
+    final currentPos = isFastSequence && _pendingTarget != null
+        ? _pendingTarget!
+        : widget.position();
+    var target = isForward
+        ? currentPos + kDefaultSeekDuration
+        : currentPos - kDefaultSeekDuration;
+
+    if (target < Duration.zero) target = Duration.zero;
+    if (target > totalDur) target = totalDur;
+
+    _pendingTarget = target;
+    widget.seekTo(target);
+    widget.onSeekInteraction?.call();
+    _showSeekBadge(isForward);
+  }
+
+  void _showSeekBadge(bool forward) {
+    _badgeHideTimer?.cancel();
+    setState(() {
+      _badgeForward = forward;
+      _showBadge = true;
+    });
+    _badgeAnimation.forward(from: 0);
+    _badgeHideTimer = Timer(const Duration(milliseconds: 750), () {
+      if (!mounted) return;
+      setState(() {
+        _showBadge = false;
+        _accumulatedSeconds = 0;
+        _lastDoubleTapTime = null;
+        _pendingTarget = null;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: widget.onSingleTap,
+          onDoubleTapDown: _handleDoubleTapDown,
+          onDoubleTap: () {},
+          onLongPress: widget.onLongPress,
+          onLongPressUp: widget.onLongPressUp,
+          child: Container(constraints: const BoxConstraints.expand()),
+        ),
+        if (_showBadge)
+          SafeArea(
+            top: false,
+            bottom: false,
+            child: Align(
+              alignment: _badgeForward
+                  ? Alignment.centerRight
+                  : Alignment.centerLeft,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: IgnorePointer(
+                  child: AnimatedOpacity(
+                    opacity: _showBadge ? 1 : 0,
+                    duration: const Duration(milliseconds: 180),
+                    child: ScaleTransition(
+                      scale: Tween<double>(begin: 0.8, end: 1).animate(
+                        CurvedAnimation(
+                          parent: _badgeAnimation,
+                          curve: Curves.easeOutQuad,
+                        ),
+                      ),
+                      child: Container(
+                        width: 64,
+                        height: 64,
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.3),
+                          shape: BoxShape.circle,
+                          border: Border.all(color: strokeFaintDark, width: 1),
+                        ),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            HugeIcon(
+                              icon: _badgeForward
+                                  ? HugeIcons.strokeRoundedArrowRightDouble
+                                  : HugeIcons.strokeRoundedArrowLeftDouble,
+                              size: 22,
+                              color: textBaseDark,
+                            ),
+                            Text(
+                              "${_accumulatedSeconds}s",
+                              style: getEnteTextTheme(
+                                context,
+                              ).tiny.copyWith(color: textBaseDark),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
@@ -44,6 +44,7 @@ class _VideoWidgetState extends State<VideoWidget> {
   final showControlsNotifier = ValueNotifier<bool>(true);
   final _hideControlsDebouncer = Debouncer(const Duration(milliseconds: 2000));
   final _isSeekingNotifier = ValueNotifier<bool>(false);
+  Timer? _doubleTapSeekReleaseTimer;
   late final StreamSubscription<bool> _isPlayingStreamSubscription;
 
   @override
@@ -67,6 +68,7 @@ class _VideoWidgetState extends State<VideoWidget> {
 
   @override
   void dispose() {
+    _doubleTapSeekReleaseTimer?.cancel();
     showControlsNotifier.dispose();
     _isPlayingStreamSubscription.cancel();
     _hideControlsDebouncer.cancelDebounceTimer();
@@ -112,7 +114,16 @@ class _VideoWidgetState extends State<VideoWidget> {
           enabled: () => !widget.isFromMemories,
           position: () => widget.controller.player.state.position,
           duration: () => widget.controller.player.state.duration,
-          seekTo: (duration) => widget.controller.player.seek(duration),
+          seekTo: (duration) {
+            widget.controller.player.seek(duration);
+            _doubleTapSeekReleaseTimer?.cancel();
+            _doubleTapSeekReleaseTimer = Timer(
+              const Duration(milliseconds: 500),
+              () {
+                if (mounted) isSeekingListener();
+              },
+            );
+          },
           onSeekInteraction: () => showControlsNotifier.value = true,
           onSingleTap: widget.isFromMemories
               ? null

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
@@ -44,6 +44,8 @@ class _VideoWidgetState extends State<VideoWidget> {
   final showControlsNotifier = ValueNotifier<bool>(true);
   final _hideControlsDebouncer = Debouncer(const Duration(milliseconds: 2000));
   final _isSeekingNotifier = ValueNotifier<bool>(false);
+  final _lastSeekTime = ValueNotifier<DateTime?>(null);
+  final _lastSeekTargetMs = ValueNotifier<int?>(null);
   Timer? _doubleTapSeekReleaseTimer;
   late final StreamSubscription<bool> _isPlayingStreamSubscription;
 
@@ -74,6 +76,8 @@ class _VideoWidgetState extends State<VideoWidget> {
     _hideControlsDebouncer.cancelDebounceTimer();
     _isSeekingNotifier.removeListener(isSeekingListener);
     _isSeekingNotifier.dispose();
+    _lastSeekTime.dispose();
+    _lastSeekTargetMs.dispose();
     super.dispose();
   }
 
@@ -115,6 +119,8 @@ class _VideoWidgetState extends State<VideoWidget> {
           position: () => widget.controller.player.state.position,
           duration: () => widget.controller.player.state.duration,
           seekTo: (duration) {
+            _lastSeekTime.value = DateTime.now();
+            _lastSeekTargetMs.value = duration.inMilliseconds;
             widget.controller.player.seek(duration);
             _doubleTapSeekReleaseTimer?.cancel();
             _doubleTapSeekReleaseTimer = Timer(
@@ -124,7 +130,10 @@ class _VideoWidgetState extends State<VideoWidget> {
               },
             );
           },
-          onSeekInteraction: () => showControlsNotifier.value = true,
+          onSeekInteraction: () {
+            showControlsNotifier.value = true;
+            _hideControlsDebouncer.cancelDebounceTimer();
+          },
           onSingleTap: widget.isFromMemories
               ? null
               : () {
@@ -194,6 +203,8 @@ class _VideoWidgetState extends State<VideoWidget> {
                               child: _MediaKitVideoProgressControls(
                                 controller: widget.controller,
                                 isSeekingNotifier: _isSeekingNotifier,
+                                lastSeekTime: _lastSeekTime,
+                                lastSeekTargetMs: _lastSeekTargetMs,
                               ),
                             ),
                           ),
@@ -314,10 +325,14 @@ class _PlayPauseButtonState extends State<PlayPauseButtonMediaKit> {
 class _MediaKitVideoProgressControls extends StatefulWidget {
   final VideoController controller;
   final ValueNotifier<bool> isSeekingNotifier;
+  final ValueNotifier<DateTime?> lastSeekTime;
+  final ValueNotifier<int?> lastSeekTargetMs;
 
   const _MediaKitVideoProgressControls({
     required this.controller,
     required this.isSeekingNotifier,
+    required this.lastSeekTime,
+    required this.lastSeekTargetMs,
   });
 
   @override
@@ -327,12 +342,15 @@ class _MediaKitVideoProgressControls extends StatefulWidget {
 
 class _MediaKitVideoProgressControlsState
     extends State<_MediaKitVideoProgressControls> {
+  static const _staleEventWindow = Duration(milliseconds: 1000);
+  static const _staleDeltaThreshold = Duration(milliseconds: 1500);
+
   double _sliderValue = 0.0;
   Duration _elapsedTime = Duration.zero;
   late final StreamSubscription<Duration> _positionStreamSubscription;
   final _debouncer = Debouncer(
-    const Duration(milliseconds: 300),
-    executionInterval: const Duration(milliseconds: 300),
+    const Duration(milliseconds: 100),
+    executionInterval: const Duration(milliseconds: 325),
   );
   @override
   void initState() {
@@ -340,6 +358,18 @@ class _MediaKitVideoProgressControlsState
     _positionStreamSubscription = widget.controller.player.stream.position
         .listen((event) {
           if (widget.isSeekingNotifier.value) return;
+
+          final lastSeek = widget.lastSeekTime.value;
+          if (lastSeek != null &&
+              DateTime.now().difference(lastSeek) < _staleEventWindow) {
+            final referenceMs =
+                widget.lastSeekTargetMs.value ?? _elapsedTime.inMilliseconds;
+            if ((event.inMilliseconds - referenceMs).abs() >
+                _staleDeltaThreshold.inMilliseconds) {
+              return;
+            }
+          }
+
           if (mounted) {
             setState(() {
               _elapsedTime = event;
@@ -400,6 +430,9 @@ class _MediaKitVideoProgressControlsState
               _elapsedTime = _positionAt(value);
             });
           }
+
+          widget.lastSeekTime.value = DateTime.now();
+          widget.lastSeekTargetMs.value = _elapsedTime.inMilliseconds;
 
           _debouncer.run(() async {
             await widget.controller.player.seek(_positionAt(value));

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
@@ -46,6 +46,7 @@ class _VideoWidgetState extends State<VideoWidget> {
   final _isSeekingNotifier = ValueNotifier<bool>(false);
   final _lastSeekTime = ValueNotifier<DateTime?>(null);
   final _lastSeekTargetMs = ValueNotifier<int?>(null);
+  final _seekGeneration = ValueNotifier<int>(0);
   Timer? _doubleTapSeekReleaseTimer;
   late final StreamSubscription<bool> _isPlayingStreamSubscription;
 
@@ -78,6 +79,7 @@ class _VideoWidgetState extends State<VideoWidget> {
     _isSeekingNotifier.dispose();
     _lastSeekTime.dispose();
     _lastSeekTargetMs.dispose();
+    _seekGeneration.dispose();
     super.dispose();
   }
 
@@ -121,6 +123,7 @@ class _VideoWidgetState extends State<VideoWidget> {
           seekTo: (duration) {
             _lastSeekTime.value = DateTime.now();
             _lastSeekTargetMs.value = duration.inMilliseconds;
+            _seekGeneration.value++;
             widget.controller.player.seek(duration);
             _doubleTapSeekReleaseTimer?.cancel();
             _doubleTapSeekReleaseTimer = Timer(
@@ -205,6 +208,7 @@ class _VideoWidgetState extends State<VideoWidget> {
                                 isSeekingNotifier: _isSeekingNotifier,
                                 lastSeekTime: _lastSeekTime,
                                 lastSeekTargetMs: _lastSeekTargetMs,
+                                seekGeneration: _seekGeneration,
                               ),
                             ),
                           ),
@@ -327,12 +331,14 @@ class _MediaKitVideoProgressControls extends StatefulWidget {
   final ValueNotifier<bool> isSeekingNotifier;
   final ValueNotifier<DateTime?> lastSeekTime;
   final ValueNotifier<int?> lastSeekTargetMs;
+  final ValueNotifier<int> seekGeneration;
 
   const _MediaKitVideoProgressControls({
     required this.controller,
     required this.isSeekingNotifier,
     required this.lastSeekTime,
     required this.lastSeekTargetMs,
+    required this.seekGeneration,
   });
 
   @override
@@ -433,6 +439,7 @@ class _MediaKitVideoProgressControlsState
 
           widget.lastSeekTime.value = DateTime.now();
           widget.lastSeekTargetMs.value = _elapsedTime.inMilliseconds;
+          widget.seekGeneration.value++;
 
           _debouncer.run(() async {
             await widget.controller.player.seek(_positionAt(value));
@@ -440,6 +447,10 @@ class _MediaKitVideoProgressControlsState
         },
         divisions: 4500,
         onChangeEnd: (value) async {
+          widget.lastSeekTime.value = DateTime.now();
+          widget.lastSeekTargetMs.value = _positionAt(value).inMilliseconds;
+          widget.seekGeneration.value++;
+
           await widget.controller.player.seek(_positionAt(value));
           if (mounted) {
             setState(() {

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
@@ -9,6 +9,7 @@ import "package:photos/models/file/file.dart";
 import "package:photos/states/detail_page_state.dart";
 import "package:photos/theme/colors.dart";
 import "package:photos/ui/viewer/file/video_control/gallery_video_controls.dart";
+import "package:photos/ui/viewer/file/video_double_tap_seek.dart";
 import "package:photos/ui/viewer/file/video_stream_change.dart";
 import "package:photos/ui/viewer/file/zoomable_video_viewer.dart";
 
@@ -107,6 +108,46 @@ class _VideoWidgetState extends State<VideoWidget> {
                 child: videoWidget,
               )
             : videoWidget,
+        DoubleTapSeekOverlay(
+          enabled: () => !widget.isFromMemories,
+          position: () => widget.controller.player.state.position,
+          duration: () => widget.controller.player.state.duration,
+          seekTo: (duration) => widget.controller.player.seek(duration),
+          onSeekInteraction: () => showControlsNotifier.value = true,
+          onSingleTap: widget.isFromMemories
+              ? null
+              : () {
+                  showControlsNotifier.value = !showControlsNotifier.value;
+                  if (widget.playbackCallback != null) {
+                    widget.playbackCallback!(
+                      !showControlsNotifier.value,
+                      FullScreenRequestReason.userInteraction,
+                    );
+                  }
+                },
+          onLongPress: widget.isFromMemories
+              ? () {
+                  widget.playbackCallback?.call(
+                    false,
+                    FullScreenRequestReason.userInteraction,
+                  );
+                  if (widget.controller.player.state.playing) {
+                    widget.controller.player.pause();
+                  }
+                }
+              : null,
+          onLongPressUp: widget.isFromMemories
+              ? () {
+                  widget.playbackCallback?.call(
+                    true,
+                    FullScreenRequestReason.userInteraction,
+                  );
+                  if (!widget.controller.player.state.playing) {
+                    widget.controller.player.play();
+                  }
+                }
+              : null,
+        ),
         ValueListenableBuilder(
           valueListenable: showControlsNotifier,
           builder: (context, value, _) {
@@ -121,46 +162,6 @@ class _VideoWidgetState extends State<VideoWidget> {
                     VideoBottomScrim(
                       hasCaption: widget.file.caption?.isNotEmpty ?? false,
                     ),
-                  GestureDetector(
-                    behavior: HitTestBehavior.translucent,
-                    onTap: widget.isFromMemories
-                        ? null
-                        : () {
-                            showControlsNotifier.value =
-                                !showControlsNotifier.value;
-                            if (widget.playbackCallback != null) {
-                              widget.playbackCallback!(
-                                !showControlsNotifier.value,
-                                FullScreenRequestReason.userInteraction,
-                              );
-                            }
-                          },
-                    onLongPress: () {
-                      if (widget.isFromMemories) {
-                        widget.playbackCallback?.call(
-                          false,
-                          FullScreenRequestReason.userInteraction,
-                        );
-                        if (widget.controller.player.state.playing) {
-                          widget.controller.player.pause();
-                        }
-                      }
-                    },
-                    onLongPressUp: () {
-                      if (widget.isFromMemories) {
-                        widget.playbackCallback?.call(
-                          true,
-                          FullScreenRequestReason.userInteraction,
-                        );
-                        if (!widget.controller.player.state.playing) {
-                          widget.controller.player.play();
-                        }
-                      }
-                    },
-                    child: Container(
-                      constraints: const BoxConstraints.expand(),
-                    ),
-                  ),
                   widget.isFromMemories
                       ? const SizedBox.shrink()
                       : IgnorePointer(

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -34,6 +34,7 @@ import "package:photos/ui/viewer/file/native_video_player_controls/play_pause_bu
 import "package:photos/ui/viewer/file/native_video_player_controls/seek_bar.dart";
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
 import "package:photos/ui/viewer/file/video_control/gallery_video_controls.dart";
+import "package:photos/ui/viewer/file/video_double_tap_seek.dart";
 import "package:photos/ui/viewer/file/video_stream_change.dart";
 import "package:photos/ui/viewer/file/zoomable_video_viewer.dart";
 import "package:photos/utils/dialog_util.dart";
@@ -356,9 +357,20 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                     widget.file.caption?.isNotEmpty ?? false,
                               ),
                             ),
-                          GestureDetector(
-                            behavior: HitTestBehavior.translucent,
-                            onTap: widget.isFromMemories
+                          DoubleTapSeekOverlay(
+                            enabled: () => !widget.isFromMemories,
+                            position: () =>
+                                _controller?.playbackPosition ?? Duration.zero,
+                            duration: () => Duration(
+                              milliseconds:
+                                  _controller
+                                      ?.videoInfo
+                                      ?.durationInMilliseconds ??
+                                  0,
+                            ),
+                            seekTo: (duration) => _controller?.seekTo(duration),
+                            onSeekInteraction: () => _showControls.value = true,
+                            onSingleTap: widget.isFromMemories
                                 ? null
                                 : () {
                                     _showControls.value = !_showControls.value;
@@ -369,27 +381,24 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                       );
                                     }
                                   },
-                            onLongPress: () {
-                              if (widget.isFromMemories) {
-                                widget.playbackCallback?.call(
-                                  false,
-                                  FullScreenRequestReason.userInteraction,
-                                );
-                                _controller?.pause();
-                              }
-                            },
-                            onLongPressUp: () {
-                              if (widget.isFromMemories) {
-                                widget.playbackCallback?.call(
-                                  true,
-                                  FullScreenRequestReason.userInteraction,
-                                );
-                                _controller?.play();
-                              }
-                            },
-                            child: Container(
-                              constraints: const BoxConstraints.expand(),
-                            ),
+                            onLongPress: widget.isFromMemories
+                                ? () {
+                                    widget.playbackCallback?.call(
+                                      false,
+                                      FullScreenRequestReason.userInteraction,
+                                    );
+                                    _controller?.pause();
+                                  }
+                                : null,
+                            onLongPressUp: widget.isFromMemories
+                                ? () {
+                                    widget.playbackCallback?.call(
+                                      true,
+                                      FullScreenRequestReason.userInteraction,
+                                    );
+                                    _controller?.play();
+                                  }
+                                : null,
                           ),
                           if (!widget.isFromMemories && isPlaybackReady)
                             Positioned.fill(

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -89,6 +89,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   final _isSeeking = ValueNotifier(false);
   final _lastSeekTime = ValueNotifier<DateTime?>(null);
   final _lastSeekTargetMs = ValueNotifier<int?>(null);
+  final _seekGeneration = ValueNotifier<int>(0);
   Timer? _doubleTapSeekReleaseTimer;
   final _debouncer = Debouncer(const Duration(milliseconds: 2000));
   StreamSubscription<PlaybackEvent>? _subscription;
@@ -277,6 +278,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
     _doubleTapSeekReleaseTimer?.cancel();
     _lastSeekTime.dispose();
     _lastSeekTargetMs.dispose();
+    _seekGeneration.dispose();
     _debouncer.cancelDebounceTimer();
     _transformationController.dispose();
     wakeLockService.updateWakeLock(
@@ -369,14 +371,20 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                 _controller?.playbackPosition ?? Duration.zero,
                             duration: () => Duration(
                               milliseconds:
-                                  _controller
-                                      ?.videoInfo
-                                      ?.durationInMilliseconds ??
-                                  0,
+                                  ((_controller
+                                              ?.videoInfo
+                                              ?.durationInMilliseconds ??
+                                          0) >
+                                      0
+                                  ? _controller!
+                                        .videoInfo!
+                                        .durationInMilliseconds
+                                  : (durationToSeconds(duration) ?? 0) * 1000),
                             ),
                             seekTo: (duration) {
                               _lastSeekTime.value = DateTime.now();
                               _lastSeekTargetMs.value = duration.inMilliseconds;
+                              _seekGeneration.value++;
                               _controller?.seekTo(duration);
                               _doubleTapSeekReleaseTimer?.cancel();
                               _doubleTapSeekReleaseTimer = Timer(
@@ -461,6 +469,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                             isSeeking: _isSeeking,
                                             lastSeekTime: _lastSeekTime,
                                             lastSeekTargetMs: _lastSeekTargetMs,
+                                            seekGeneration: _seekGeneration,
                                           )
                                         : const SizedBox.shrink(),
                                   ),
@@ -883,6 +892,7 @@ class _VideoProgressControls extends StatelessWidget {
   final ValueNotifier<bool> isSeeking;
   final ValueNotifier<DateTime?> lastSeekTime;
   final ValueNotifier<int?> lastSeekTargetMs;
+  final ValueNotifier<int> seekGeneration;
 
   const _VideoProgressControls({
     required this.controller,
@@ -891,6 +901,7 @@ class _VideoProgressControls extends StatelessWidget {
     required this.isSeeking,
     required this.lastSeekTime,
     required this.lastSeekTargetMs,
+    required this.seekGeneration,
   });
 
   @override
@@ -910,6 +921,7 @@ class _VideoProgressControls extends StatelessWidget {
               isSeeking,
               lastSeekTime: lastSeekTime,
               lastSeekTargetMs: lastSeekTargetMs,
+              seekGeneration: seekGeneration,
             ),
           ),
         );

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -386,7 +386,10 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                 },
                               );
                             },
-                            onSeekInteraction: () => _showControls.value = true,
+                            onSeekInteraction: () {
+                              _showControls.value = true;
+                              _debouncer.cancelDebounceTimer();
+                            },
                             onSingleTap: widget.isFromMemories
                                 ? null
                                 : () {

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -87,6 +87,9 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   bool _isCompletelyVisible = false;
   final _showControls = ValueNotifier(true);
   final _isSeeking = ValueNotifier(false);
+  final _lastSeekTime = ValueNotifier<DateTime?>(null);
+  final _lastSeekTargetMs = ValueNotifier<int?>(null);
+  Timer? _doubleTapSeekReleaseTimer;
   final _debouncer = Debouncer(const Duration(milliseconds: 2000));
   StreamSubscription<PlaybackEvent>? _subscription;
   StreamSubscription<StreamSwitchedEvent>? _streamSwitchedSubscription;
@@ -271,6 +274,9 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
     _showControls.dispose();
     _isSeeking.removeListener(_seekListener);
     _isSeeking.dispose();
+    _doubleTapSeekReleaseTimer?.cancel();
+    _lastSeekTime.dispose();
+    _lastSeekTargetMs.dispose();
     _debouncer.cancelDebounceTimer();
     _transformationController.dispose();
     wakeLockService.updateWakeLock(
@@ -368,7 +374,18 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                       ?.durationInMilliseconds ??
                                   0,
                             ),
-                            seekTo: (duration) => _controller?.seekTo(duration),
+                            seekTo: (duration) {
+                              _lastSeekTime.value = DateTime.now();
+                              _lastSeekTargetMs.value = duration.inMilliseconds;
+                              _controller?.seekTo(duration);
+                              _doubleTapSeekReleaseTimer?.cancel();
+                              _doubleTapSeekReleaseTimer = Timer(
+                                const Duration(milliseconds: 500),
+                                () {
+                                  if (mounted) _seekListener();
+                                },
+                              );
+                            },
                             onSeekInteraction: () => _showControls.value = true,
                             onSingleTap: widget.isFromMemories
                                 ? null
@@ -439,6 +456,8 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                             duration: duration,
                                             showControls: _showControls,
                                             isSeeking: _isSeeking,
+                                            lastSeekTime: _lastSeekTime,
+                                            lastSeekTargetMs: _lastSeekTargetMs,
                                           )
                                         : const SizedBox.shrink(),
                                   ),
@@ -859,12 +878,16 @@ class _VideoProgressControls extends StatelessWidget {
   final String? duration;
   final ValueNotifier<bool> showControls;
   final ValueNotifier<bool> isSeeking;
+  final ValueNotifier<DateTime?> lastSeekTime;
+  final ValueNotifier<int?> lastSeekTargetMs;
 
   const _VideoProgressControls({
     required this.controller,
     required this.duration,
     required this.showControls,
     required this.isSeeking,
+    required this.lastSeekTime,
+    required this.lastSeekTargetMs,
   });
 
   @override
@@ -882,6 +905,8 @@ class _VideoProgressControls extends StatelessWidget {
               controller,
               durationToSeconds(duration),
               isSeeking,
+              lastSeekTime: lastSeekTime,
+              lastSeekTargetMs: lastSeekTargetMs,
             ),
           ),
         );


### PR DESCRIPTION
## Description

* Replaced the video player's base gesture detector with a new `DoubleTapSeekOverlay` to introduce double-tap timeline navigation.
* Double tapping the left or right halves of the screen skips the video -5 seconds or +5 seconds, displaying an animated ripple badge for visual feedback.
* Double-tap seeking automatically reveals the seek bar so users have immediate context of their new position on the timeline.
* Resolved three side effect cases (due to change) within the native seek bar and seeking logic:
  * **Fast-Tap Accumulation:** Used last computed target to calculate the seek target while rapid double-tapping instead of using player position (which might be stale).
  * **Paused State Freeze:** Seeking while paused would jump the media, but the slider UI wouldn't update. So patched the position listener to catch this state and instantly snap the slider thumb to the new time code.
  * **Manual Drag Glitch:** Fixed an issue where manually dragging or clicking the slider thumb caused it to glitch or jump erratically due to stale position events.
* Double-tap gesture works seamlessly while the video is zoomed in / paused, and is disabled for Memories.


### Visuals

**Portrait:**

https://github.com/user-attachments/assets/73d76bdd-026c-462e-be04-1cc5facbe28b

**Landscape:**

https://github.com/user-attachments/assets/238c92b1-a40c-4130-b33d-a1b26f474f7c

**Double tap seek shows seekbar for context about timeline to the user:**

https://github.com/user-attachments/assets/73476790-adde-42aa-9ffb-b285f8279784

**While zooming:**

https://github.com/user-attachments/assets/1575df41-1594-44f0-a8e2-2756e4837afc



## Verification
Physical device : Realme C67 5g & Realme Pad 2
