### PR TITLE
[mobile][photos] Improve timeline loading for large galleries

### DIFF
--- a/mobile/apps/photos/changes/large-gallery-loading-performance.md
+++ b/mobile/apps/photos/changes/large-gallery-loading-performance.md
@@ -1,0 +1,1 @@
+- Improved timeline loading performance for large photo libraries.

--- a/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
+++ b/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
@@ -310,20 +310,12 @@ class GalleryGroups {
     final stopwatch = Stopwatch()..start();
 
     final yearsInGroups = <int>{};
-    List<EnteFile> groupFiles = [];
-    final allFilesLength = allFiles.length;
 
     if (groupType.showGroupHeader()) {
-      for (int index = 0; index < allFilesLength; index++) {
-        if (index > 0 &&
-            !groupType.areFromSameGroup(allFiles[index - 1], allFiles[index])) {
-          _createNewGroup(groupFiles, yearsInGroups);
-          groupFiles = [];
-        }
-        groupFiles.add(allFiles[index]);
-      }
-      if (groupFiles.isNotEmpty) {
-        _createNewGroup(groupFiles, yearsInGroups);
+      var start = 0;
+      for (final end in _timeGroupEndIndexes()) {
+        _createNewGroup(allFiles.sublist(start, end), yearsInGroups);
+        start = end;
       }
     } else {
       // Split allFiles into groups of max length 10 * crossAxisCount for
@@ -343,6 +335,37 @@ class GalleryGroups {
     stopwatch.stop();
   }
 
+  List<int> _timeGroupEndIndexes() {
+    final ends = <int>[];
+    if (allFiles.isEmpty) {
+      return ends;
+    }
+
+    if (groupType == GroupType.week) {
+      var previousFile = allFiles.first;
+      for (var index = 1; index < allFiles.length; index++) {
+        final file = allFiles[index];
+        if (!groupType.areFromSameGroup(previousFile, file)) {
+          ends.add(index);
+        }
+        previousFile = file;
+      }
+      ends.add(allFiles.length);
+      return ends;
+    }
+
+    var groupRange = groupType.getGroupRange(allFiles.first);
+    for (var index = 1; index < allFiles.length; index++) {
+      final creationTime = allFiles[index].creationTime!;
+      if (creationTime < groupRange.$1 || creationTime > groupRange.$2) {
+        ends.add(index);
+        groupRange = groupType.getGroupRange(allFiles[index]);
+      }
+    }
+    ends.add(allFiles.length);
+    return ends;
+  }
+
   void _createNewGroup(List<EnteFile> groupFiles, Set<int> yearsInGroups) {
     final uuid = _uuid.v1();
 
@@ -353,11 +376,9 @@ class GalleryGroups {
       final incompleteRowCount = groupFiles.length % crossAxisCount;
       if (incompleteRowCount != 0) {
         final dummiesNeeded = crossAxisCount - incompleteRowCount;
-        final filesWithDummies = List<EnteFile>.from(groupFiles);
         for (int i = 0; i < dummiesNeeded; i++) {
-          filesWithDummies.add(DummyFile(groupID: uuid, index: i));
+          groupFiles.add(DummyFile(groupID: uuid, index: i));
         }
-        groupFiles = filesWithDummies;
       }
     }
 

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/group/type.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/group/type.dart
@@ -2,7 +2,6 @@ import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_strings/ente_strings.dart";
 import "package:flutter/widgets.dart";
 import "package:intl/intl.dart";
-import "package:photos/core/constants.dart";
 import "package:photos/models/file/file.dart";
 
 enum GroupType { day, week, month, size, year, none }
@@ -118,9 +117,10 @@ extension GroupTypeExtension on GroupType {
       case GroupType.day:
         final date = DateTime.fromMicrosecondsSinceEpoch(file.creationTime!);
         final startOfDay = DateTime(date.year, date.month, date.day);
+        final endOfDay = DateTime(date.year, date.month, date.day + 1);
         return (
           startOfDay.microsecondsSinceEpoch,
-          (startOfDay.microsecondsSinceEpoch + microSecondsInDay - 1),
+          endOfDay.microsecondsSinceEpoch - 1,
         );
       case GroupType.week:
         final date = DateTime.fromMicrosecondsSinceEpoch(file.creationTime!);


### PR DESCRIPTION
## Summary

- Reuse each group’s calendar boundary while scanning the timeline instead of recalculating dates for every neighboring file.
- Add grid placeholders directly to the newly created group list, avoiding an additional copy.

## Performance

Debug iOS simulator, using the same signed-in account and the same 94,937 gallery files:

- Before: 2.27–2.30 seconds
- After: 341–344 milliseconds
- Both produced 3,397 day groups (~6.7× faster, ~85% less time)

Validation: exercised on the iOS simulator; Dart formatting and focused Flutter analysis passed. Full mobile checks are left to CI.