### PR TITLE
[mobile] Speed up search and Smart Memories for large libraries

### DIFF
--- a/mobile/apps/photos/changes/large-library-search-performance.md
+++ b/mobile/apps/photos/changes/large-library-search-performance.md
@@ -1,0 +1,1 @@
+- Improved search responsiveness for large photo libraries.

--- a/mobile/apps/photos/changes/smart-memories-large-library-performance.md
+++ b/mobile/apps/photos/changes/smart-memories-large-library-performance.md
@@ -1,0 +1,1 @@
+- Improved Smart Memories generation performance for large photo libraries.

--- a/mobile/apps/photos/lib/db/files_db.dart
+++ b/mobile/apps/photos/lib/db/files_db.dart
@@ -944,41 +944,6 @@ class FilesDB with SqlDbBase {
     return FileLoadResult(files, files.length == limit);
   }
 
-  Future<List<EnteFile>> getFilesCreatedWithinDurations(
-    List<List<int>> durations,
-    Set<int> ignoredCollectionIDs, {
-    int? visibility,
-    String order = 'ASC',
-    bool dedupeUploadID = true,
-  }) async {
-    if (durations.isEmpty) {
-      return <EnteFile>[];
-    }
-    final db = await instance.sqliteAsyncDB;
-    String whereClause = durations
-        .map(
-          (duration) =>
-              "($columnCreationTime >= ${duration[0]} AND $columnCreationTime < ${duration[1]})",
-        )
-        .join(" OR ");
-
-    whereClause = "( $whereClause )";
-    if (visibility != null) {
-      whereClause += ' AND $columnMMdVisibility = $visibility';
-    }
-    final query =
-        'SELECT * FROM $filesTable WHERE $whereClause ORDER BY $columnCreationTime $order';
-    final results = await db.getAll(query);
-    final files = convertToFiles(results);
-    return applyDBFilters(
-      files,
-      DBFilterOptions(
-        ignoredCollectionIDs: ignoredCollectionIDs,
-        dedupeUploadID: dedupeUploadID,
-      ),
-    );
-  }
-
   Future<List<EnteFile>> getFilesPendingForUpload() async {
     final db = await instance.sqliteAsyncDB;
     final results = await db.getAll(

--- a/mobile/apps/photos/lib/services/location_service.dart
+++ b/mobile/apps/photos/lib/services/location_service.dart
@@ -21,6 +21,46 @@ import "package:shared_preferences/shared_preferences.dart";
 
 const double earthRadius = 6371; // Earth's radius in kilometers
 
+class CitySearchIndex {
+  static const empty = CitySearchIndex(
+    cities: <City>[],
+    nodes: <List<int>>[],
+    root: -1,
+    maxLatDelta: 0,
+    maxLngDelta: 0,
+  );
+
+  final List<City> cities;
+  final List<List<int>> nodes;
+  final int root;
+  final double maxLatDelta;
+  final double maxLngDelta;
+
+  const CitySearchIndex({
+    required this.cities,
+    required this.nodes,
+    required this.root,
+    required this.maxLatDelta,
+    required this.maxLngDelta,
+  });
+
+  bool get isEmpty => cities.isEmpty;
+
+  Map<String, dynamic> searchArgs(List<EnteFile> files, {String query = ''}) {
+    return <String, dynamic>{
+      "query": query,
+      "cities": cities,
+      "files": files,
+      if (nodes.isNotEmpty && root >= 0) ...{
+        "kdTreeNodes": nodes,
+        "kdTreeRoot": root,
+        "kdTreeMaxLatDelta": maxLatDelta,
+        "kdTreeMaxLngDelta": maxLngDelta,
+      },
+    };
+  }
+}
+
 class LocationService {
   final SharedPreferences prefs;
   final Logger _logger = Logger((LocationService).toString());
@@ -32,11 +72,7 @@ class LocationService {
   static const _kCitiesKdTreeRemotePath =
       "https://assets.ente.com/world_cities.kdtree.bin";
 
-  List<City> _cities = [];
-  List<List<int>> _kdTreeNodes = [];
-  int _kdTreeRoot = -1;
-  double _kdTreeMaxLatDelta = 0;
-  double _kdTreeMaxLngDelta = 0;
+  CitySearchIndex _citySearchIndex = CitySearchIndex.empty;
 
   // TODO: lau: consider actually using this in location section
   List<BaseLocation> baseLocations = [];
@@ -72,22 +108,12 @@ class LocationService {
     List<EnteFile> allFiles,
     String query,
   ) async {
-    if (allFiles.isNotEmpty && _cities.isEmpty && query.isEmpty) {
+    if (allFiles.isNotEmpty && _citySearchIndex.isEmpty && query.isEmpty) {
       reloadLocationDiscoverySection = true;
     }
     final EnteWatch w = EnteWatch("cities_search")..start();
     w.log('start for files ${allFiles.length} and query $query');
-    final args = <String, dynamic>{
-      "query": query,
-      "cities": _cities,
-      "files": allFiles,
-    };
-    if (_kdTreeNodes.isNotEmpty && _kdTreeRoot >= 0) {
-      args["kdTreeNodes"] = _kdTreeNodes;
-      args["kdTreeRoot"] = _kdTreeRoot;
-      args["kdTreeMaxLatDelta"] = _kdTreeMaxLatDelta;
-      args["kdTreeMaxLngDelta"] = _kdTreeMaxLngDelta;
-    }
+    final args = _citySearchIndex.searchArgs(allFiles, query: query);
     final result = await _computer.compute(getCityResults, param: args);
     w.log(
       'end for query: $query  on ${allFiles.length} files, found '
@@ -97,10 +123,14 @@ class LocationService {
   }
 
   Future<List<City>> getCities() async {
-    if (_cities.isEmpty) {
+    return (await getCitySearchIndex()).cities;
+  }
+
+  Future<CitySearchIndex> getCitySearchIndex() async {
+    if (_citySearchIndex.isEmpty) {
       await _loadCities();
     }
-    return _cities;
+    return _citySearchIndex;
   }
 
   Future<Iterable<LocalEntity<LocationTag>>> getLocationTags() {
@@ -241,11 +271,13 @@ class LocationService {
   }
 
   void _applyKdTreeLoadResult(Map<String, dynamic> result) {
-    _cities = result["cities"] as List<City>;
-    _kdTreeNodes = (result["nodes"] as List).cast<List<int>>();
-    _kdTreeRoot = result["root"] as int;
-    _kdTreeMaxLatDelta = (result["maxLatDelta"] as num).toDouble();
-    _kdTreeMaxLngDelta = (result["maxLngDelta"] as num).toDouble();
+    _citySearchIndex = CitySearchIndex(
+      cities: result["cities"] as List<City>,
+      nodes: (result["nodes"] as List).cast<List<int>>(),
+      root: result["root"] as int,
+      maxLatDelta: (result["maxLatDelta"] as num).toDouble(),
+      maxLngDelta: (result["maxLngDelta"] as num).toDouble(),
+    );
   }
 
   Future<void> _loadCities() async {

--- a/mobile/apps/photos/lib/services/location_service.dart
+++ b/mobile/apps/photos/lib/services/location_service.dart
@@ -113,6 +113,16 @@ class LocationService {
     }
     final EnteWatch w = EnteWatch("cities_search")..start();
     w.log('start for files ${allFiles.length} and query $query');
+    final normalizedQuery = query.toLowerCase();
+    if (normalizedQuery.isNotEmpty &&
+        !_citySearchIndex.cities.any(
+          (city) => city.city.toLowerCase().contains(normalizedQuery),
+        )) {
+      w.log(
+        'end for query: $query  on ${allFiles.length} files, found 0 cities',
+      );
+      return {};
+    }
     final args = _citySearchIndex.searchArgs(allFiles, query: query);
     final result = await _computer.compute(getCityResults, param: args);
     w.log(

--- a/mobile/apps/photos/lib/services/memories/memories_computation_context.dart
+++ b/mobile/apps/photos/lib/services/memories/memories_computation_context.dart
@@ -20,7 +20,7 @@ class MemoriesComputationContext {
   final Map<int, int> seenTimes;
   final List<PersonEntity> persons;
   final String? currentUserEmail;
-  final List<City> cities;
+  final CitySearchIndex citySearchIndex;
   final Map<int, List<FaceWithoutEmbedding>> fileIdToFaces;
   final Map<String, int> clusterIdToFaceCount;
   final Map<String, Iterable<String>> clusterIdToFaceIDs;
@@ -42,7 +42,7 @@ class MemoriesComputationContext {
     required this.seenTimes,
     required this.persons,
     required this.currentUserEmail,
-    required this.cities,
+    required this.citySearchIndex,
     required this.fileIdToFaces,
     required this.clusterIdToFaceCount,
     required this.clusterIdToFaceIDs,
@@ -71,7 +71,7 @@ class MemoriesComputationContext {
       seenTimes: Map<int, int>.from(args["seenTimes"] as Map),
       persons: (args["persons"] as List).cast<PersonEntity>(),
       currentUserEmail: args["currentUserEmail"] as String?,
-      cities: (args["cities"] as List).cast<City>(),
+      citySearchIndex: args["citySearchIndex"] as CitySearchIndex,
       fileIdToFaces: Map<int, List<FaceWithoutEmbedding>>.from(
         args["fileIdToFaces"] as Map,
       ),
@@ -107,7 +107,7 @@ class MemoriesComputationContext {
       "seenTimes": seenTimes,
       "persons": persons,
       "currentUserEmail": currentUserEmail,
-      "cities": cities,
+      "citySearchIndex": citySearchIndex,
       "fileIdToFaces": fileIdToFaces,
       "clusterIdToFaceCount": clusterIdToFaceCount,
       "clusterIdToFaceIDs": clusterIdToFaceIDs,

--- a/mobile/apps/photos/lib/services/memories/memory_file_index.dart
+++ b/mobile/apps/photos/lib/services/memories/memory_file_index.dart
@@ -1,0 +1,161 @@
+part of "../smart_memories_service.dart";
+
+typedef _CreationTimeRange = ({int start, int end});
+
+class MemoryFileIndex {
+  final List<EnteFile> files;
+  final int _oldestYear;
+  final int _newestYear;
+
+  factory MemoryFileIndex(Iterable<EnteFile> source) {
+    final files = source.toList();
+    if (!_isCreationTimeDescending(files)) {
+      final indexedFiles =
+          <({EnteFile file, int position})>[
+            for (var i = 0; i < files.length; i++)
+              (file: files[i], position: i),
+          ]..sort((a, b) {
+            final timeCompare = b.file.creationTime!.compareTo(
+              a.file.creationTime!,
+            );
+            return timeCompare != 0
+                ? timeCompare
+                : a.position.compareTo(b.position);
+          });
+      for (var i = 0; i < files.length; i++) {
+        files[i] = indexedFiles[i].file;
+      }
+    }
+    if (files.isEmpty) {
+      return MemoryFileIndex._(files, 0, -1);
+    }
+    return MemoryFileIndex._(
+      files,
+      DateTime.fromMicrosecondsSinceEpoch(files.last.creationTime!).year,
+      DateTime.fromMicrosecondsSinceEpoch(files.first.creationTime!).year,
+    );
+  }
+
+  MemoryFileIndex._(this.files, this._oldestYear, this._newestYear);
+
+  List<EnteFile> filesInDateRanges(
+    Iterable<({DateTime start, DateTime end})> dateRanges,
+  ) {
+    return _filesInRanges(
+      dateRanges.map(
+        (range) => (
+          start: range.start.microsecondsSinceEpoch,
+          end: range.end.microsecondsSinceEpoch,
+        ),
+      ),
+    );
+  }
+
+  List<EnteFile> filesForCalendar({
+    Set<int> monthDays = const <int>{},
+    int? month,
+    int? week,
+  }) {
+    if (files.isEmpty) return <EnteFile>[];
+
+    final yearCount = _newestYear - _oldestYear + 1;
+    if (yearCount <= 0 || yearCount > files.length) {
+      return files;
+    }
+
+    final ranges = <_CreationTimeRange>[];
+    for (var year = _oldestYear; year <= _newestYear; year++) {
+      for (final monthDay in monthDays) {
+        final candidateMonth = monthDay ~/ 100;
+        final candidateDay = monthDay % 100;
+        final start = DateTime(year, candidateMonth, candidateDay);
+        if (start.year != year ||
+            start.month != candidateMonth ||
+            start.day != candidateDay) {
+          continue;
+        }
+        ranges.add((
+          start: start.microsecondsSinceEpoch,
+          end: DateTime(
+            year,
+            candidateMonth,
+            candidateDay + 1,
+          ).microsecondsSinceEpoch,
+        ));
+      }
+
+      if (month != null) {
+        ranges.add((
+          start: DateTime(year, month).microsecondsSinceEpoch,
+          end: DateTime(year, month + 1).microsecondsSinceEpoch,
+        ));
+      }
+
+      if (week != null) {
+        final start = DateTime(year, 1, 1 + (week - 1) * 7);
+        if (start.year == year) {
+          final weekEnd = DateTime(year, 1, 1 + week * 7);
+          final yearEnd = DateTime(year + 1);
+          ranges.add((
+            start: start.microsecondsSinceEpoch,
+            end: min(
+              weekEnd.microsecondsSinceEpoch,
+              yearEnd.microsecondsSinceEpoch,
+            ),
+          ));
+        }
+      }
+    }
+    return _filesInRanges(ranges);
+  }
+
+  List<EnteFile> _filesInRanges(Iterable<_CreationTimeRange> sourceRanges) {
+    final ranges =
+        sourceRanges.where((range) => range.start < range.end).toList()
+          ..sort((a, b) => a.start.compareTo(b.start));
+    if (ranges.isEmpty) return <EnteFile>[];
+
+    final merged = <_CreationTimeRange>[];
+    var current = ranges.first;
+    for (final next in ranges.skip(1)) {
+      if (next.start <= current.end) {
+        current = (start: current.start, end: max(current.end, next.end));
+      } else {
+        merged.add(current);
+        current = next;
+      }
+    }
+    merged.add(current);
+
+    final result = <EnteFile>[];
+    for (final range in merged.reversed) {
+      final firstIndex = _firstFileCreatedBefore(range.end);
+      final endIndex = _firstFileCreatedBefore(range.start);
+      result.addAll(files.getRange(firstIndex, endIndex));
+    }
+    return result;
+  }
+
+  int _firstFileCreatedBefore(int timestamp) {
+    var low = 0;
+    var high = files.length;
+    while (low < high) {
+      final middle = low + ((high - low) >> 1);
+      if (files[middle].creationTime! >= timestamp) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return low;
+  }
+
+  static bool _isCreationTimeDescending(List<EnteFile> files) {
+    for (var i = 1; i < files.length; i++) {
+      if (files[i - 1].creationTime! < files[i].creationTime!) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/mobile/apps/photos/lib/services/search_service.dart
+++ b/mobile/apps/photos/lib/services/search_service.dart
@@ -301,6 +301,37 @@ class SearchService {
     return _cachedFilesForSearch!;
   }
 
+  Future<List<EnteFile>> _getFilesCreatedWithinDurations(
+    List<List<int>> durations,
+  ) async {
+    if (durations.isEmpty) {
+      return [];
+    }
+
+    final files = await getAllFilesForSearch();
+    final matchedFiles = <EnteFile>[];
+    for (final duration in durations.reversed) {
+      final firstIndex = _firstFileCreatedBefore(files, duration[1]);
+      final endIndex = _firstFileCreatedBefore(files, duration[0]);
+      matchedFiles.addAll(files.getRange(firstIndex, endIndex));
+    }
+    return matchedFiles;
+  }
+
+  int _firstFileCreatedBefore(List<EnteFile> files, int timestamp) {
+    var low = 0;
+    var high = files.length;
+    while (low < high) {
+      final middle = low + ((high - low) >> 1);
+      if (files[middle].creationTime! >= timestamp) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return low;
+  }
+
   Future<bool> hasAnyFilesForSearch() async {
     if (_cachedFilesFuture != null && _cachedFilesForSearch != null) {
       return (await _cachedFilesForSearch!).isNotEmpty;
@@ -549,9 +580,9 @@ class SearchService {
     final List<GenericSearchResult> searchResults = [];
     for (var yearData in YearsData.instance.yearsData) {
       if (yearData.year.startsWith(yearFromQuery)) {
-        final List<EnteFile> filesInYear = await _getFilesInYear(
+        final filesInYear = await _getFilesCreatedWithinDurations([
           yearData.duration,
-        );
+        ]);
         if (filesInYear.isNotEmpty) {
           searchResults.add(
             GenericSearchResult(
@@ -596,12 +627,9 @@ class SearchService {
     final List<GenericSearchResult> searchResults = [];
     final matchingMonths = _getMatchingMonths(context, query).toList();
     for (final month in matchingMonths) {
-      final matchedFiles = await FilesDB.instance
-          .getFilesCreatedWithinDurations(
-            _getDurationsOfMonthInEveryYear(month.monthNumber),
-            ignoreCollections(),
-            order: 'DESC',
-          );
+      final matchedFiles = await _getFilesCreatedWithinDurations(
+        _getDurationsOfMonthInEveryYear(month.monthNumber),
+      );
       if (matchedFiles.isNotEmpty) {
         searchResults.add(
           GenericSearchResult(
@@ -634,15 +662,9 @@ class SearchService {
 
     for (var holiday in holidays) {
       if (holiday.name.toLowerCase().contains(query.toLowerCase())) {
-        final matchedFiles = await FilesDB.instance
-            .getFilesCreatedWithinDurations(
-              _getDurationsForCalendarDateInEveryYear(
-                holiday.day,
-                holiday.month,
-              ),
-              ignoreCollections(),
-              order: 'DESC',
-            );
+        final matchedFiles = await _getFilesCreatedWithinDurations(
+          _getDurationsForCalendarDateInEveryYear(holiday.day, holiday.month),
+        );
         if (matchedFiles.isNotEmpty) {
           searchResults.add(
             GenericSearchResult(
@@ -1681,12 +1703,9 @@ class SearchService {
         parsedDate.year != null) {
       final month = parsedDate.month!;
       final year = parsedDate.year!;
-      final monthYearFiles = await FilesDB.instance
-          .getFilesCreatedWithinDurations(
-            [_getDurationForMonthInYear(month, year)],
-            ignoreCollections(),
-            order: 'DESC',
-          );
+      final monthYearFiles = await _getFilesCreatedWithinDurations([
+        _getDurationForMonthInYear(month, year),
+      ]);
       if (monthYearFiles.isNotEmpty) {
         final monthName = DateParseService.instance.getMonthName(month);
         final name = '$monthName $year';
@@ -1710,12 +1729,9 @@ class SearchService {
       final int month = parsedDate.month!;
       final int? year = parsedDate.year; // nullable for generic dates
 
-      final matchedFiles = await FilesDB.instance
-          .getFilesCreatedWithinDurations(
-            _getDurationsForCalendarDateInEveryYear(day, month, year: year),
-            ignoreCollections(),
-            order: 'DESC',
-          );
+      final matchedFiles = await _getFilesCreatedWithinDurations(
+        _getDurationsForCalendarDateInEveryYear(day, month, year: year),
+      );
 
       if (matchedFiles.isNotEmpty) {
         final monthName = DateParseService.instance.getMonthName(month);
@@ -1937,14 +1953,6 @@ class SearchService {
               monthData.name.toLowerCase().startsWith(query.toLowerCase()),
         )
         .toList();
-  }
-
-  Future<List<EnteFile>> _getFilesInYear(List<int> durationOfYear) async {
-    return await FilesDB.instance.getFilesCreatedWithinDurations(
-      [durationOfYear],
-      ignoreCollections(),
-      order: "DESC",
-    );
   }
 
   List<List<int>> _getDurationsForCalendarDateInEveryYear(

--- a/mobile/apps/photos/lib/services/search_service.dart
+++ b/mobile/apps/photos/lib/services/search_service.dart
@@ -75,6 +75,7 @@ class SearchService {
   Future<List<EnteFile>>? _cachedFilesForGenericGallery;
   Future<List<EnteFile>>? _cachedFilesForOfflineGallery;
   Future<List<EnteFile>>? _cachedHiddenFilesFuture;
+  Future<Map<int, EnteFile>>? _cachedFilesByUploadedID;
   final _logger = Logger((SearchService).toString());
   final _collectionService = CollectionsService.instance;
   static const _maximumResultsLimit = 20;
@@ -91,13 +92,18 @@ class SearchService {
         .on<LocalPhotosUpdatedEvent>()
         .listen((event) {
           // Invalidate only; reload on demand.
-          _cachedFilesFuture = null;
-          _cachedFilesForSearch = null;
-          _cachedFilesForHierarchicalSearch = null;
-          _cachedFilesForGenericGallery = null;
-          _cachedFilesForOfflineGallery = null;
-          _cachedHiddenFilesFuture = null;
+          _invalidateFileCaches();
         });
+  }
+
+  void _invalidateFileCaches() {
+    _cachedFilesFuture = null;
+    _cachedFilesForSearch = null;
+    _cachedFilesForHierarchicalSearch = null;
+    _cachedFilesForGenericGallery = null;
+    _cachedFilesForOfflineGallery = null;
+    _cachedHiddenFilesFuture = null;
+    _cachedFilesByUploadedID = null;
   }
 
   Set<int> ignoreCollections() {
@@ -303,6 +309,19 @@ class SearchService {
     return FilesDB.instance.hasAnyFile();
   }
 
+  Future<Map<int, EnteFile>> _getFilesByUploadedID() {
+    return _cachedFilesByUploadedID ??= getAllFilesForSearch().then((files) {
+      final filesByUploadedID = <int, EnteFile>{};
+      for (final file in files) {
+        final uploadedID = file.uploadedFileID;
+        if (uploadedID != null && !filesByUploadedID.containsKey(uploadedID)) {
+          filesByUploadedID[uploadedID] = file;
+        }
+      }
+      return filesByUploadedID;
+    });
+  }
+
   Future<List<GenericSearchResult>> getUploadedFileIDsSearchResults(
     String query,
     Set<int> uploadedFileIDs,
@@ -432,12 +451,7 @@ class SearchService {
   }
 
   void clearCache() {
-    _cachedFilesFuture = null;
-    _cachedFilesForSearch = null;
-    _cachedFilesForHierarchicalSearch = null;
-    _cachedFilesForGenericGallery = null;
-    _cachedFilesForOfflineGallery = null;
-    _cachedHiddenFilesFuture = null;
+    _invalidateFileCaches();
     unawaited(memoriesCacheService.clearMemoriesCache());
   }
 
@@ -1158,14 +1172,7 @@ class SearchService {
     bool includeManualAssigned = true,
     bool sortOnTime = true,
   }) async {
-    final allFiles = await getAllFilesForSearch();
-    final uploadedIdToFile = <int, EnteFile>{};
-    for (final file in allFiles) {
-      final uploadedID = file.uploadedFileID;
-      if (uploadedID != null && !uploadedIdToFile.containsKey(uploadedID)) {
-        uploadedIdToFile[uploadedID] = file;
-      }
-    }
+    final uploadedIdToFile = await _getFilesByUploadedID();
     final Map<int, Set<String>> fileIdToClusterID = await mlDataDB
         .getFileIdToClusterIDSet(personID);
     final files = <EnteFile>[];
@@ -1313,14 +1320,7 @@ class SearchService {
       final Map<String, List<EnteFile>> clusterIdToFiles = {};
       final Map<String, List<EnteFile>> personIdToFiles = {};
       final Map<String, Set<int>> personIdToFileIds = {};
-      final allFiles = await getAllFilesForSearch();
-      final Map<int, EnteFile> uploadedIdToFile = {};
-      for (final file in allFiles) {
-        final uploadedID = file.uploadedFileID;
-        if (uploadedID != null && !uploadedIdToFile.containsKey(uploadedID)) {
-          uploadedIdToFile[uploadedID] = file;
-        }
-      }
+      final uploadedIdToFile = await _getFilesByUploadedID();
 
       for (final entry in fileIdToClusterID.entries) {
         final file = uploadedIdToFile[entry.key];

--- a/mobile/apps/photos/lib/services/search_service.dart
+++ b/mobile/apps/photos/lib/services/search_service.dart
@@ -994,8 +994,10 @@ class SearchService {
       }
     }
     final allFiles = await getAllFilesForSearch();
+    final filesWithLocation = <EnteFile>[];
     for (EnteFile file in allFiles) {
       if (file.hasLocation) {
+        filesWithLocation.add(file);
         for (LocalEntity<LocationTag> tag in result.keys) {
           if (isFileInsideLocationTag(
             tag.item.centerPoint,
@@ -1030,10 +1032,7 @@ class SearchService {
     }
     if (showNoLocationTag) {
       _logger.info("finding photos with no location tag");
-      final noLocationTagFiles = allFiles.where((file) {
-        if (!file.hasLocation) {
-          return false;
-        }
+      final noLocationTagFiles = filesWithLocation.where((file) {
         for (LocalEntity<LocationTag> tag in locationTagEntities) {
           if (isFileInsideLocationTag(
             tag.item.centerPoint,
@@ -1094,7 +1093,10 @@ class SearchService {
     if (allCitiesSearch) {
       query = '';
     }
-    final results = await locationService.getFilesInCity(allFiles, query);
+    final results = await locationService.getFilesInCity(
+      filesWithLocation,
+      query,
+    );
     final List<City> sortedByResultCount = results.keys.toList()
       ..sort((a, b) => results[b]!.length.compareTo(results[a]!.length));
     for (final city in sortedByResultCount) {

--- a/mobile/apps/photos/lib/services/smart_memories_service.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_service.dart
@@ -936,12 +936,8 @@ class SmartMemoriesService {
 
       final List<SmartMemory> memories = [];
 
-      final onThisDayFiles = _collectAvailableFiles(
-        allFileIdsToFile,
-        usedMemoryFileIds,
-      );
       final onThisDayMemories = await _getOnThisDayResults(
-        onThisDayFiles,
+        fullSourceFiles,
         now,
         seenTimes: seenTimes,
         collectionIDsToExclude: collectionIDsToExclude,
@@ -1116,12 +1112,8 @@ class SmartMemoriesService {
 
     final List<SmartMemory> memories = [];
 
-    final onThisDayFiles = _collectAvailableFiles(
-      allFileIdsToFile,
-      usedMemoryFileIds,
-    );
     final onThisDayMemories = await _getOnThisDayResults(
-      onThisDayFiles,
+      allFileIdsToFile.values,
       now,
       seenTimes: seenTimes,
       collectionIDsToExclude: collectionIDsToExclude,

--- a/mobile/apps/photos/lib/services/smart_memories_service.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_service.dart
@@ -68,6 +68,7 @@ typedef _PreparedMemoriesData = ({
   List<PersonEntity> persons,
   Map<String, String> faceIDsToPersonID,
   Map<int, EmbeddingVector> fileIDToImageEmbedding,
+  TripMemoriesAnalysis tripAnalysis,
 });
 
 class SmartMemoriesService {
@@ -353,8 +354,10 @@ class SmartMemoriesService {
         : Configuration.instance.getEmail();
     _logger.info('currentUserEmail: $currentUserEmail $timeLogger');
 
-    final cities = await locationService.getCities();
-    _logger.info('cities has ${cities.length} entries $timeLogger');
+    final citySearchIndex = await locationService.getCitySearchIndex();
+    _logger.info(
+      'cities has ${citySearchIndex.cities.length} entries $timeLogger',
+    );
 
     final Map<int, List<FaceWithoutEmbedding>> fileIdToFaces = mlEnabled
         ? await mlDataDB.getFileIDsToFacesWithoutEmbedding()
@@ -420,7 +423,7 @@ class SmartMemoriesService {
       seenTimes: seenTimes,
       persons: persons,
       currentUserEmail: currentUserEmail,
-      cities: cities,
+      citySearchIndex: citySearchIndex,
       fileIdToFaces: fileIdToFaces,
       clusterIdToFaceCount: unnamedClusterData.clusterIdToFaceCount,
       clusterIdToFaceIDs: unnamedClusterData.clusterIdToFaceIDs,
@@ -848,10 +851,18 @@ class SmartMemoriesService {
     for (final embedding in computationContext.allImageEmbeddings) {
       fileIDToImageEmbedding[embedding.fileID] = embedding;
     }
+    final tripAnalysis = TripMemoriesCalculatorV2.analyze(
+      computationContext.allFileIdsToFile.values,
+      computationContext.allFileIdsToFile,
+      isLocalGalleryMode: computationContext.isLocalGalleryMode,
+      seenTimes: computationContext.seenTimes,
+      citySearchIndex: computationContext.citySearchIndex,
+    );
     return (
       persons: persons,
       faceIDsToPersonID: faceIDsToPersonID,
       fileIDToImageEmbedding: fileIDToImageEmbedding,
+      tripAnalysis: tripAnalysis,
     );
   }
 
@@ -896,7 +907,8 @@ class SmartMemoriesService {
       final Map<int, int> seenTimes = computationContext.seenTimes;
       final List<PersonEntity> persons = preparedData.persons;
       final String? currentUserEmail = computationContext.currentUserEmail;
-      final List<City> cities = computationContext.cities;
+      final CitySearchIndex citySearchIndex =
+          computationContext.citySearchIndex;
       final Map<int, List<FaceWithoutEmbedding>> fileIdToFaces =
           computationContext.fileIdToFaces;
       final Map<String, int> clusterIdToFaceCount =
@@ -978,8 +990,8 @@ class SmartMemoriesService {
         dev.log('ML disabled, skipping people memories $t');
       }
 
-      final (tripMemories, bases) = await _getTripsResults(
-        tripSourceFiles: fullSourceFiles,
+      final (tripMemories, bases) = await _surfaceTrips(
+        tripAnalysis: preparedData.tripAnalysis,
         allFileIdsToFile: allFileIdsToFile,
         currentTime: now,
         shownTrips: oldCache.tripsShownLogs,
@@ -992,7 +1004,7 @@ class SmartMemoriesService {
         faceIDsToPersonID: faceIDsToPersonID,
         fileIDToImageEmbedding: fileIDToImageEmbedding,
         clipPositiveTextVector: clipPositiveTextVector,
-        cities: cities,
+        citySearchIndex: citySearchIndex,
       );
       _markUsedMemories(
         usedMemoryFileIds,
@@ -1245,8 +1257,8 @@ class SmartMemoriesService {
     );
   }
 
-  static Future<(List<TripMemory>, List<BaseLocation>)> _getTripsResults({
-    required Iterable<EnteFile> tripSourceFiles,
+  static Future<(List<TripMemory>, List<BaseLocation>)> _surfaceTrips({
+    required TripMemoriesAnalysis tripAnalysis,
     required Map<int, EnteFile> allFileIdsToFile,
     required DateTime currentTime,
     required List<TripsShownLog> shownTrips,
@@ -1259,10 +1271,10 @@ class SmartMemoriesService {
     required Map<String, String> faceIDsToPersonID,
     required Map<int, EmbeddingVector> fileIDToImageEmbedding,
     required Vector clipPositiveTextVector,
-    required List<City> cities,
+    required CitySearchIndex citySearchIndex,
   }) async {
-    return TripMemoriesCalculatorV2.compute(
-      tripSourceFiles,
+    return TripMemoriesCalculatorV2.surface(
+      tripAnalysis,
       allFileIdsToFile,
       currentTime,
       shownTrips,
@@ -1275,7 +1287,7 @@ class SmartMemoriesService {
       faceIDsToPersonID: faceIDsToPersonID,
       fileIDToImageEmbedding: fileIDToImageEmbedding,
       clipPositiveTextVector: clipPositiveTextVector,
-      cities: cities,
+      citySearchIndex: citySearchIndex,
     );
   }
 
@@ -1414,11 +1426,11 @@ class SmartMemoriesService {
 
   static String? _tryFindLocationName(
     List<Memory> memories,
-    List<City> cities, {
+    CitySearchIndex citySearchIndex, {
     bool base = false,
     Set<String> excludedCountryNames = const {},
   }) {
-    final locationContext = _getLocationNameContext(memories, cities);
+    final locationContext = _getLocationNameContext(memories, citySearchIndex);
     if (locationContext == null) return null;
 
     final files = locationContext.files;
@@ -1437,8 +1449,11 @@ class SmartMemoriesService {
     return null;
   }
 
-  static String? _tryFindCountryName(List<Memory> memories, List<City> cities) {
-    final locationContext = _getLocationNameContext(memories, cities);
+  static String? _tryFindCountryName(
+    List<Memory> memories,
+    CitySearchIndex citySearchIndex,
+  ) {
+    final locationContext = _getLocationNameContext(memories, citySearchIndex);
     return locationContext?.biggestPlace.country;
   }
 
@@ -1447,13 +1462,12 @@ class SmartMemoriesService {
     Map<City, List<EnteFile>> results,
     City biggestPlace,
   })?
-  _getLocationNameContext(List<Memory> memories, List<City> cities) {
+  _getLocationNameContext(
+    List<Memory> memories,
+    CitySearchIndex citySearchIndex,
+  ) {
     final files = Memory.filesFromMemories(memories);
-    final results = getCityResults({
-      "query": '',
-      "cities": cities,
-      "files": files,
-    });
+    final results = getCityResults(citySearchIndex.searchArgs(files));
     final List<City> sortedByResultCount = results.keys.toList()
       ..sort((a, b) => results[b]!.length.compareTo(results[a]!.length));
     if (sortedByResultCount.isEmpty) return null;

--- a/mobile/apps/photos/lib/services/smart_memories_service.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_service.dart
@@ -45,6 +45,7 @@ import "package:photos/services/memories/photo_selector.dart";
 import "package:photos/services/search_service.dart";
 
 part "smart_memories_clip_calculator.dart";
+part "memories/memory_file_index.dart";
 part "smart_memories_people_calculator.dart";
 part "smart_memories_time_calculator.dart";
 part "smart_memories_trip_calculator_v2.dart";
@@ -68,6 +69,7 @@ typedef _PreparedMemoriesData = ({
   List<PersonEntity> persons,
   Map<String, String> faceIDsToPersonID,
   Map<int, EmbeddingVector> fileIDToImageEmbedding,
+  MemoryFileIndex fileIndex,
   TripMemoriesAnalysis tripAnalysis,
 });
 
@@ -851,8 +853,11 @@ class SmartMemoriesService {
     for (final embedding in computationContext.allImageEmbeddings) {
       fileIDToImageEmbedding[embedding.fileID] = embedding;
     }
-    final tripAnalysis = TripMemoriesCalculatorV2.analyze(
+    final fileIndex = MemoryFileIndex(
       computationContext.allFileIdsToFile.values,
+    );
+    final tripAnalysis = TripMemoriesCalculatorV2.analyze(
+      fileIndex.files,
       computationContext.allFileIdsToFile,
       isLocalGalleryMode: computationContext.isLocalGalleryMode,
       seenTimes: computationContext.seenTimes,
@@ -862,6 +867,7 @@ class SmartMemoriesService {
       persons: persons,
       faceIDsToPersonID: faceIDsToPersonID,
       fileIDToImageEmbedding: fileIDToImageEmbedding,
+      fileIndex: fileIndex,
       tripAnalysis: tripAnalysis,
     );
   }
@@ -932,12 +938,13 @@ class SmartMemoriesService {
       // Some memory types need every file, so track used files by ID instead of
       // removing them from the source map.
       final fullSourceFiles = allFileIdsToFile.values;
+      final fileIndex = preparedData.fileIndex;
       final usedMemoryFileIds = <int>{};
 
       final List<SmartMemory> memories = [];
 
       final onThisDayMemories = await _getOnThisDayResults(
-        fullSourceFiles,
+        TimeMemoriesCalculator._filesForHistoricalWindow(fileIndex, now),
         now,
         seenTimes: seenTimes,
         collectionIDsToExclude: collectionIDsToExclude,
@@ -1038,14 +1045,22 @@ class SmartMemoriesService {
         dev.log('ML disabled, skipping clip memories $t');
       }
 
-      final timeFiles = _collectAvailableFiles(
-        allFileIdsToFile,
+      final timeFiles = _collectAvailableCandidates(
+        TimeMemoriesCalculator._filesForTimeMemories(fileIndex, now),
         usedMemoryFileIds,
+        isLocalGalleryMode: isLocalGalleryMode,
       );
       final timeMemories = await _onThisDayOrWeekResults(
         timeFiles,
         now,
-        recentSourceFiles: fullSourceFiles,
+        recentSourceFiles: TimeMemoriesCalculator._filesForRecentTimeMemories(
+          fileIndex,
+          now,
+        ),
+        totalAvailableFileCount: _remainingFilesCount(
+          allFileIdsToFile,
+          usedMemoryFileIds,
+        ),
         isLocalGalleryMode: isLocalGalleryMode,
         mlEnabled: mlEnabled,
         seenTimes: seenTimes,
@@ -1065,9 +1080,10 @@ class SmartMemoriesService {
         "${_remainingFilesCount(allFileIdsToFile, usedMemoryFileIds)} $t",
       );
 
-      final fillerFiles = _collectAvailableFiles(
-        allFileIdsToFile,
+      final fillerFiles = _collectAvailableCandidates(
+        TimeMemoriesCalculator._filesForHistoricalWindow(fileIndex, now),
         usedMemoryFileIds,
+        isLocalGalleryMode: isLocalGalleryMode,
       );
       final fillerMemories = await _getFillerResults(
         fillerFiles,
@@ -1098,6 +1114,7 @@ class SmartMemoriesService {
       useLocalIntIds: isLocalGalleryMode,
       requireLocalId: isLocalGalleryMode,
     );
+    final fileIndex = MemoryFileIndex(allFileIdsToFile.values);
     final usedMemoryFileIds = <int>{};
     final seenTimes = await _memoriesDB.getSeenTimes();
     final collectionIDsToExclude = await getCollectionIDsToExclude();
@@ -1113,7 +1130,7 @@ class SmartMemoriesService {
     final List<SmartMemory> memories = [];
 
     final onThisDayMemories = await _getOnThisDayResults(
-      allFileIdsToFile.values,
+      TimeMemoriesCalculator._filesForHistoricalWindow(fileIndex, now),
       now,
       seenTimes: seenTimes,
       collectionIDsToExclude: collectionIDsToExclude,
@@ -1127,9 +1144,10 @@ class SmartMemoriesService {
       ], isLocalGalleryMode: isLocalGalleryMode);
     }
 
-    final fillerFiles = _collectAvailableFiles(
-      allFileIdsToFile,
+    final fillerFiles = _collectAvailableCandidates(
+      TimeMemoriesCalculator._filesForHistoricalWindow(fileIndex, now),
       usedMemoryFileIds,
+      isLocalGalleryMode: isLocalGalleryMode,
     );
     final fillerMemories = await _getFillerResults(
       fillerFiles,
@@ -1150,16 +1168,21 @@ class SmartMemoriesService {
     return memories;
   }
 
-  static List<EnteFile> _collectAvailableFiles(
-    Map<int, EnteFile> allFileIdsToFile,
-    Set<int> usedMemoryFileIds,
-  ) {
+  static List<EnteFile> _collectAvailableCandidates(
+    Iterable<EnteFile> candidates,
+    Set<int> usedMemoryFileIds, {
+    required bool isLocalGalleryMode,
+  }) {
     final availableFiles = <EnteFile>[];
-    for (final entry in allFileIdsToFile.entries) {
-      if (usedMemoryFileIds.contains(entry.key)) {
+    for (final file in candidates) {
+      final fileID = _memoryFileId(
+        file,
+        isLocalGalleryMode: isLocalGalleryMode,
+      );
+      if (fileID != null && usedMemoryFileIds.contains(fileID)) {
         continue;
       }
-      availableFiles.add(entry.value);
+      availableFiles.add(file);
     }
     return availableFiles;
   }
@@ -1287,6 +1310,7 @@ class SmartMemoriesService {
     Iterable<EnteFile> allFiles,
     DateTime currentTime, {
     required Iterable<EnteFile> recentSourceFiles,
+    required int totalAvailableFileCount,
     required bool isLocalGalleryMode,
     required bool mlEnabled,
     required Map<int, int> seenTimes,
@@ -1299,6 +1323,7 @@ class SmartMemoriesService {
       allFiles,
       currentTime,
       recentSourceFiles: recentSourceFiles,
+      totalAvailableFileCount: totalAvailableFileCount,
       isLocalGalleryMode: isLocalGalleryMode,
       mlEnabled: mlEnabled,
       seenTimes: seenTimes,

--- a/mobile/apps/photos/lib/services/smart_memories_service.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_service.dart
@@ -5,7 +5,7 @@ import "dart:math" show Random, max, min;
 import "package:computer/computer.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_strings/ente_strings.dart";
-import "package:flutter/foundation.dart" show kDebugMode;
+import "package:flutter/foundation.dart" show kDebugMode, visibleForTesting;
 import "package:flutter/material.dart";
 import "package:intl/intl.dart";
 import "package:logging/logging.dart";

--- a/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
@@ -7,6 +7,7 @@ class TimeMemoriesCalculator {
     Iterable<EnteFile> allFiles,
     DateTime currentTime, {
     Iterable<EnteFile>? recentSourceFiles,
+    int? totalAvailableFileCount,
     required bool isLocalGalleryMode,
     required bool mlEnabled,
     required Map<int, int> seenTimes,
@@ -20,8 +21,8 @@ class TimeMemoriesCalculator {
     final availableFiles = allFiles is List<EnteFile>
         ? allFiles
         : allFiles.toList();
-    if (availableFiles.isEmpty) return [];
     final recentCandidates = recentSourceFiles ?? availableFiles;
+    if (availableFiles.isEmpty && recentCandidates.isEmpty) return [];
 
     final startOfCurrentWeek = _startOfWeek(currentTime);
     final startOfPreviousWeek = startOfCurrentWeek.subtract(
@@ -73,7 +74,8 @@ class TimeMemoriesCalculator {
     final currentMonth = currentTime.month;
     final currentYear = currentTime.year;
     final cutOffTime = currentTime.subtract(const Duration(days: 365));
-    final averageDailyPhotos = availableFiles.length / 365;
+    final averageDailyPhotos =
+        (totalAvailableFileCount ?? availableFiles.length) / 365;
     final significantDayThreshold = averageDailyPhotos * 0.25;
     final significantWeekThreshold = averageDailyPhotos * 0.40;
 
@@ -342,6 +344,47 @@ class TimeMemoriesCalculator {
       }
     }
     return showDates;
+  }
+
+  static List<EnteFile> _filesForHistoricalWindow(
+    MemoryFileIndex fileIndex,
+    DateTime currentTime,
+  ) {
+    return fileIndex.filesForCalendar(
+      monthDays: _historicalDayCandidates(currentTime),
+    );
+  }
+
+  static List<EnteFile> _filesForTimeMemories(
+    MemoryFileIndex fileIndex,
+    DateTime currentTime,
+  ) {
+    return fileIndex.filesForCalendar(
+      monthDays: _timeMemoryShowDates(currentTime).keys.toSet(),
+      month: currentTime.month,
+      week: getWeekNumber(currentTime),
+    );
+  }
+
+  static List<EnteFile> _filesForRecentTimeMemories(
+    MemoryFileIndex fileIndex,
+    DateTime currentTime,
+  ) {
+    final startOfCurrentWeek = _startOfWeek(currentTime);
+    final startOfCurrentMonth = _startOfMonth(currentTime);
+    return fileIndex.filesInDateRanges([
+      (
+        start: startOfCurrentWeek.subtract(const Duration(days: 7)),
+        end: startOfCurrentWeek,
+      ),
+      (
+        start: DateTime(
+          startOfCurrentMonth.year,
+          startOfCurrentMonth.month - 1,
+        ),
+        end: startOfCurrentMonth,
+      ),
+    ]);
   }
 
   static Set<int> _historicalDayCandidates(DateTime currentTime) {

--- a/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
@@ -351,7 +351,7 @@ class TimeMemoriesCalculator {
     DateTime currentTime,
   ) {
     return fileIndex.filesForCalendar(
-      monthDays: _historicalDayCandidates(currentTime),
+      monthDays: historicalDayCandidates(currentTime),
     );
   }
 
@@ -387,20 +387,32 @@ class TimeMemoriesCalculator {
     ]);
   }
 
-  static Set<int> _historicalDayCandidates(DateTime currentTime) {
+  @visibleForTesting
+  static Set<int> historicalDayCandidates(DateTime currentTime) {
     final candidates = <int>{};
-    for (var offset = 0; offset <= kMemoriesUpdateFrequency.inDays; offset++) {
-      final targetDate = DateTime(
-        currentTime.year,
-        currentTime.month,
-        currentTime.day + offset,
-      );
+    final windowEnd = currentTime.add(kMemoriesUpdateFrequency);
+    var targetDate = DateTime.utc(
+      currentTime.year,
+      currentTime.month,
+      currentTime.day,
+    );
+    final endDate = DateTime.utc(
+      windowEnd.year,
+      windowEnd.month,
+      windowEnd.day,
+    );
+    while (!targetDate.isAfter(endDate)) {
       candidates.add(targetDate.month * 100 + targetDate.day);
       if (!_isLeapYear(targetDate.year) &&
           targetDate.month == DateTime.march &&
           targetDate.day == 1) {
         candidates.add(DateTime.february * 100 + 29);
       }
+      targetDate = DateTime.utc(
+        targetDate.year,
+        targetDate.month,
+        targetDate.day + 1,
+      );
     }
     return candidates;
   }
@@ -500,7 +512,7 @@ class TimeMemoriesCalculator {
     final cutOffTime = currentTime.subtract(
       const Duration(days: 364) - kMemoriesUpdateFrequency,
     );
-    final historicalDayCandidates = _historicalDayCandidates(currentTime);
+    final historicalCandidates = historicalDayCandidates(currentTime);
 
     final Map<int, List<Memory>> yearsAgoToMemories = {};
     for (final file in allFiles) {
@@ -508,9 +520,7 @@ class TimeMemoriesCalculator {
         continue;
       }
       final fileDate = DateTime.fromMicrosecondsSinceEpoch(file.creationTime!);
-      if (!historicalDayCandidates.contains(
-        fileDate.month * 100 + fileDate.day,
-      )) {
+      if (!historicalCandidates.contains(fileDate.month * 100 + fileDate.day)) {
         continue;
       }
       final dayMatch = _historicalDateMatch(fileDate, currentTime);
@@ -568,7 +578,7 @@ class TimeMemoriesCalculator {
     final cutOffTime = startPoint.subtract(
       const Duration(days: 363) - kMemoriesUpdateFrequency,
     );
-    final historicalDayCandidates = _historicalDayCandidates(startPoint);
+    final historicalCandidates = historicalDayCandidates(startPoint);
 
     final Map<int, List<Memory>> daysToMemories = {};
     final Map<int, Set<int>> daysToYears = {};
@@ -579,9 +589,7 @@ class TimeMemoriesCalculator {
         continue;
       }
       final fileDate = DateTime.fromMicrosecondsSinceEpoch(file.creationTime!);
-      if (!historicalDayCandidates.contains(
-        fileDate.month * 100 + fileDate.day,
-      )) {
+      if (!historicalCandidates.contains(fileDate.month * 100 + fileDate.day)) {
         continue;
       }
       final dayMatch = _historicalDateMatch(fileDate, startPoint);

--- a/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
@@ -78,6 +78,9 @@ class TimeMemoriesCalculator {
     final significantWeekThreshold = averageDailyPhotos * 0.40;
 
     final dayMonthYearGroups = <int, Map<int, List<Memory>>>{};
+    final currentWeekYearGroups = <int, List<Memory>>{};
+    final currentMonthYearGroups = <int, List<Memory>>{};
+    final timeMemoryShowDates = _timeMemoryShowDates(currentTime);
 
     for (final file in availableFiles) {
       if (file.creationTime! > cutOffTime.microsecondsSinceEpoch) continue;
@@ -88,18 +91,28 @@ class TimeMemoriesCalculator {
       final dayMonth = creationTime.month * 100 + creationTime.day;
       final year = creationTime.year;
 
-      dayMonthYearGroups
-          .putIfAbsent(dayMonth, () => {})
-          .putIfAbsent(year, () => [])
-          .add(Memory.fromFile(file, seenTimes));
+      if (timeMemoryShowDates.containsKey(dayMonth)) {
+        dayMonthYearGroups
+            .putIfAbsent(dayMonth, () => {})
+            .putIfAbsent(year, () => [])
+            .add(Memory.fromFile(file, seenTimes));
+      }
+      if (getWeekNumber(creationTime) == currentWeek) {
+        currentWeekYearGroups
+            .putIfAbsent(year, () => [])
+            .add(Memory.fromFile(file, seenTimes));
+      }
+      if (creationTime.month == currentMonth) {
+        currentMonthYearGroups
+            .putIfAbsent(year, () => [])
+            .add(Memory.fromFile(file, seenTimes));
+      }
     }
 
     for (final dayMonth in dayMonthYearGroups.keys) {
       final month = dayMonth ~/ 100;
       final day = dayMonth % 100;
-      final showDate = _nextOccurrence(currentTime, month, day);
-      final dayDiff = _calendarDayDifference(currentTime, showDate);
-      if (dayDiff > kMemoriesUpdateFrequency.inDays) continue;
+      final showDate = timeMemoryShowDates[dayMonth]!;
 
       final yearGroups = dayMonthYearGroups[dayMonth]!;
       final significantDays = yearGroups.entries
@@ -155,22 +168,6 @@ class TimeMemoriesCalculator {
     }
 
     if (historicalMemoryResult.isEmpty) {
-      final currentWeekYearGroups = <int, List<Memory>>{};
-      for (final file in availableFiles) {
-        if (file.creationTime! > cutOffTime.microsecondsSinceEpoch) continue;
-
-        final creationTime = DateTime.fromMicrosecondsSinceEpoch(
-          file.creationTime!,
-        );
-        final week = getWeekNumber(creationTime);
-        if (week != currentWeek) continue;
-        final year = creationTime.year;
-
-        currentWeekYearGroups
-            .putIfAbsent(year, () => [])
-            .add(Memory.fromFile(file, seenTimes));
-      }
-
       if (currentWeekYearGroups.isNotEmpty) {
         final significantWeeks = currentWeekYearGroups.entries
             .where((e) => e.value.length > significantWeekThreshold)
@@ -229,34 +226,22 @@ class TimeMemoriesCalculator {
     }
 
     const monthSelectionSize = 20;
-    final currentMonthYearGroups = <int, List<Memory>>{};
     final historicalMemoryFileIds = <int>{};
     SmartMemoriesService._markUsedMemories(
       historicalMemoryFileIds,
       historicalMemoryResult,
       isLocalGalleryMode: isLocalGalleryMode,
     );
-    for (final file in availableFiles) {
-      final fileId = SmartMemoriesService._memoryFileId(
-        file,
-        isLocalGalleryMode: isLocalGalleryMode,
-      );
-      if (fileId != null && historicalMemoryFileIds.contains(fileId)) {
-        continue;
-      }
-      if (file.creationTime! > cutOffTime.microsecondsSinceEpoch) continue;
-
-      final creationTime = DateTime.fromMicrosecondsSinceEpoch(
-        file.creationTime!,
-      );
-      final month = creationTime.month;
-      if (month != currentMonth) continue;
-      final year = creationTime.year;
-
-      currentMonthYearGroups
-          .putIfAbsent(year, () => [])
-          .add(Memory.fromFile(file, seenTimes));
-    }
+    currentMonthYearGroups.removeWhere((_, memories) {
+      memories.removeWhere((memory) {
+        final fileId = SmartMemoriesService._memoryFileIdFromMemory(
+          memory,
+          isLocalGalleryMode: isLocalGalleryMode,
+        );
+        return fileId != null && historicalMemoryFileIds.contains(fileId);
+      });
+      return memories.isEmpty;
+    });
 
     final sortedYearsForCurrentMonth = currentMonthYearGroups.keys.toList()
       ..sort(
@@ -344,6 +329,44 @@ class TimeMemoriesCalculator {
     return endDate.difference(startDate).inDays;
   }
 
+  static Map<int, DateTime> _timeMemoryShowDates(DateTime currentTime) {
+    final showDates = <int, DateTime>{};
+    for (var month = 1; month <= 12; month++) {
+      final daysInMonth = DateTime.utc(2024, month + 1, 0).day;
+      for (var day = 1; day <= daysInMonth; day++) {
+        final showDate = _nextOccurrence(currentTime, month, day);
+        if (_calendarDayDifference(currentTime, showDate) <=
+            kMemoriesUpdateFrequency.inDays) {
+          showDates[month * 100 + day] = showDate;
+        }
+      }
+    }
+    return showDates;
+  }
+
+  static Map<int, ({int offset, DateTime targetDate})> _historicalDayMatches(
+    DateTime currentTime,
+  ) {
+    final startDate = _startOfDay(currentTime);
+    final matches = <int, ({int offset, DateTime targetDate})>{};
+    for (var offset = 0; offset < kMemoriesUpdateFrequency.inDays; offset++) {
+      final targetDate = startDate.add(Duration(days: offset));
+      matches[targetDate.month * 100 + targetDate.day] = (
+        offset: offset,
+        targetDate: targetDate,
+      );
+      if (!_isLeapYear(targetDate.year) &&
+          targetDate.month == DateTime.march &&
+          targetDate.day == 1) {
+        matches[DateTime.february * 100 + 29] = (
+          offset: offset,
+          targetDate: targetDate,
+        );
+      }
+    }
+    return matches;
+  }
+
   static Future<void> _maybeAddRecentTimeMemory(
     List<TimeMemory> memories,
     Iterable<EnteFile> allFiles, {
@@ -410,12 +433,10 @@ class TimeMemoriesCalculator {
     final windowEnd = currentTime
         .add(kMemoriesUpdateFrequency)
         .microsecondsSinceEpoch;
-    final currentYear = currentTime.year;
     final cutOffTime = currentTime.subtract(
       const Duration(days: 364) - kMemoriesUpdateFrequency,
     );
-    final timeTillYearEnd = DateTime(currentYear + 1).difference(currentTime);
-    final bool almostYearEnd = timeTillYearEnd < kMemoriesUpdateFrequency;
+    final historicalDayMatches = _historicalDayMatches(currentTime);
 
     final Map<int, List<Memory>> yearsAgoToMemories = {};
     for (final file in allFiles) {
@@ -423,42 +444,22 @@ class TimeMemoriesCalculator {
         continue;
       }
       final fileDate = DateTime.fromMicrosecondsSinceEpoch(file.creationTime!);
-      final fileTimeInYear = fileDate.copyWith(year: currentYear);
-      final diff = fileTimeInYear.difference(currentTime);
-      if (!diff.isNegative && diff < kMemoriesUpdateFrequency) {
-        final yearsAgo = currentYear - fileDate.year;
-        yearsAgoToMemories
-            .putIfAbsent(yearsAgo, () => [])
-            .add(
-              Memory.fromFile(
+      final dayMatch =
+          historicalDayMatches[fileDate.month * 100 + fileDate.day];
+      if (dayMatch == null) continue;
+      final yearsAgo = dayMatch.targetDate.year - fileDate.year;
+      yearsAgoToMemories
+          .putIfAbsent(yearsAgo, () => [])
+          .add(
+            Memory.fromFile(
+              file,
+              seenTimes,
+              seenTimeKey: SmartMemoriesService._seenTimeKeyForFile(
                 file,
-                seenTimes,
-                seenTimeKey: SmartMemoriesService._seenTimeKeyForFile(
-                  file,
-                  localIdToIntId,
-                ),
+                localIdToIntId,
               ),
-            );
-      } else if (almostYearEnd) {
-        final altDiff = fileDate
-            .copyWith(year: currentYear + 1)
-            .difference(currentTime);
-        if (!altDiff.isNegative && altDiff < kMemoriesUpdateFrequency) {
-          final yearsAgo = currentYear - fileDate.year + 1;
-          yearsAgoToMemories
-              .putIfAbsent(yearsAgo, () => [])
-              .add(
-                Memory.fromFile(
-                  file,
-                  seenTimes,
-                  seenTimeKey: SmartMemoriesService._seenTimeKeyForFile(
-                    file,
-                    localIdToIntId,
-                  ),
-                ),
-              );
-        }
-      }
+            ),
+          );
     }
     for (
       var yearAgo = 1;
@@ -499,13 +500,10 @@ class TimeMemoriesCalculator {
     final cutOffTime = startPoint.subtract(
       const Duration(days: 363) - kMemoriesUpdateFrequency,
     );
-    final diffThreshold = Duration(days: daysToCompute);
+    final historicalDayMatches = _historicalDayMatches(startPoint);
 
     final Map<int, List<Memory>> daysToMemories = {};
-    final Map<int, List<int>> daysToYears = {};
-
-    final timeTillYearEnd = DateTime(currentYear + 1).difference(startPoint);
-    final bool almostYearEnd = timeTillYearEnd < diffThreshold;
+    final Map<int, Set<int>> daysToYears = {};
 
     for (final file in allFiles) {
       if (collectionIDsToExclude.contains(file.collectionID)) continue;
@@ -513,42 +511,22 @@ class TimeMemoriesCalculator {
         continue;
       }
       final fileDate = DateTime.fromMicrosecondsSinceEpoch(file.creationTime!);
-      final fileTimeInYear = fileDate.copyWith(year: currentYear);
-      final diff = fileTimeInYear.difference(startPoint);
-      if (!diff.isNegative && diff < diffThreshold) {
-        daysToMemories
-            .putIfAbsent(diff.inDays, () => [])
-            .add(
-              Memory.fromFile(
+      final dayMatch =
+          historicalDayMatches[fileDate.month * 100 + fileDate.day];
+      if (dayMatch == null) continue;
+      daysToMemories
+          .putIfAbsent(dayMatch.offset, () => [])
+          .add(
+            Memory.fromFile(
+              file,
+              seenTimes,
+              seenTimeKey: SmartMemoriesService._seenTimeKeyForFile(
                 file,
-                seenTimes,
-                seenTimeKey: SmartMemoriesService._seenTimeKeyForFile(
-                  file,
-                  localIdToIntId,
-                ),
+                localIdToIntId,
               ),
-            );
-        daysToYears.putIfAbsent(diff.inDays, () => []).add(fileDate.year);
-      } else if (almostYearEnd) {
-        final altDiff = fileDate
-            .copyWith(year: currentYear + 1)
-            .difference(startPoint);
-        if (!altDiff.isNegative && altDiff < diffThreshold) {
-          daysToMemories
-              .putIfAbsent(altDiff.inDays, () => [])
-              .add(
-                Memory.fromFile(
-                  file,
-                  seenTimes,
-                  seenTimeKey: SmartMemoriesService._seenTimeKeyForFile(
-                    file,
-                    localIdToIntId,
-                  ),
-                ),
-              );
-          daysToYears.putIfAbsent(altDiff.inDays, () => []).add(fileDate.year);
-        }
-      }
+            ),
+          );
+      daysToYears.putIfAbsent(dayMatch.offset, () => {}).add(fileDate.year);
     }
 
     for (var day = 0; day < daysToCompute; day++) {
@@ -556,7 +534,7 @@ class TimeMemoriesCalculator {
       if (memories == null) continue;
       if (memories.length < 5) continue;
       final years = daysToYears[day]!;
-      if (years.toSet().length < 2) continue;
+      if (years.length < 2) continue;
 
       final filteredMemories = <Memory>[];
       if (memories.length > 20) {
@@ -616,9 +594,29 @@ class TimeMemoriesCalculator {
   }
 
   static int getWeekNumber(DateTime date) {
-    final int dayOfYear = int.parse(DateFormat('D').format(date));
+    const daysBeforeMonth = [
+      0,
+      31,
+      59,
+      90,
+      120,
+      151,
+      181,
+      212,
+      243,
+      273,
+      304,
+      334,
+    ];
+    final leapDay = _isLeapYear(date.year) && date.month > DateTime.february
+        ? 1
+        : 0;
+    final dayOfYear = daysBeforeMonth[date.month - 1] + date.day + leapDay;
     return ((dayOfYear - 1) ~/ 7) + 1;
   }
+
+  static bool _isLeapYear(int year) =>
+      year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
 
   static DateTime _startOfDay(DateTime date) {
     return DateTime(date.year, date.month, date.day);

--- a/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_time_calculator.dart
@@ -344,27 +344,48 @@ class TimeMemoriesCalculator {
     return showDates;
   }
 
-  static Map<int, ({int offset, DateTime targetDate})> _historicalDayMatches(
-    DateTime currentTime,
-  ) {
-    final startDate = _startOfDay(currentTime);
-    final matches = <int, ({int offset, DateTime targetDate})>{};
-    for (var offset = 0; offset < kMemoriesUpdateFrequency.inDays; offset++) {
-      final targetDate = startDate.add(Duration(days: offset));
-      matches[targetDate.month * 100 + targetDate.day] = (
-        offset: offset,
-        targetDate: targetDate,
+  static Set<int> _historicalDayCandidates(DateTime currentTime) {
+    final candidates = <int>{};
+    for (var offset = 0; offset <= kMemoriesUpdateFrequency.inDays; offset++) {
+      final targetDate = DateTime(
+        currentTime.year,
+        currentTime.month,
+        currentTime.day + offset,
       );
+      candidates.add(targetDate.month * 100 + targetDate.day);
       if (!_isLeapYear(targetDate.year) &&
           targetDate.month == DateTime.march &&
           targetDate.day == 1) {
-        matches[DateTime.february * 100 + 29] = (
-          offset: offset,
-          targetDate: targetDate,
-        );
+        candidates.add(DateTime.february * 100 + 29);
       }
     }
-    return matches;
+    return candidates;
+  }
+
+  static ({int dayOffset, int targetYear})? _historicalDateMatch(
+    DateTime fileDate,
+    DateTime currentTime,
+  ) {
+    final currentYearDiff = fileDate
+        .copyWith(year: currentTime.year)
+        .difference(currentTime);
+    if (!currentYearDiff.isNegative &&
+        currentYearDiff < kMemoriesUpdateFrequency) {
+      return (dayOffset: currentYearDiff.inDays, targetYear: currentTime.year);
+    }
+
+    final timeTillYearEnd = DateTime(
+      currentTime.year + 1,
+    ).difference(currentTime);
+    if (timeTillYearEnd >= kMemoriesUpdateFrequency) return null;
+
+    final nextYearDiff = fileDate
+        .copyWith(year: currentTime.year + 1)
+        .difference(currentTime);
+    if (!nextYearDiff.isNegative && nextYearDiff < kMemoriesUpdateFrequency) {
+      return (dayOffset: nextYearDiff.inDays, targetYear: currentTime.year + 1);
+    }
+    return null;
   }
 
   static Future<void> _maybeAddRecentTimeMemory(
@@ -436,7 +457,7 @@ class TimeMemoriesCalculator {
     final cutOffTime = currentTime.subtract(
       const Duration(days: 364) - kMemoriesUpdateFrequency,
     );
-    final historicalDayMatches = _historicalDayMatches(currentTime);
+    final historicalDayCandidates = _historicalDayCandidates(currentTime);
 
     final Map<int, List<Memory>> yearsAgoToMemories = {};
     for (final file in allFiles) {
@@ -444,10 +465,14 @@ class TimeMemoriesCalculator {
         continue;
       }
       final fileDate = DateTime.fromMicrosecondsSinceEpoch(file.creationTime!);
-      final dayMatch =
-          historicalDayMatches[fileDate.month * 100 + fileDate.day];
+      if (!historicalDayCandidates.contains(
+        fileDate.month * 100 + fileDate.day,
+      )) {
+        continue;
+      }
+      final dayMatch = _historicalDateMatch(fileDate, currentTime);
       if (dayMatch == null) continue;
-      final yearsAgo = dayMatch.targetDate.year - fileDate.year;
+      final yearsAgo = dayMatch.targetYear - fileDate.year;
       yearsAgoToMemories
           .putIfAbsent(yearsAgo, () => [])
           .add(
@@ -500,7 +525,7 @@ class TimeMemoriesCalculator {
     final cutOffTime = startPoint.subtract(
       const Duration(days: 363) - kMemoriesUpdateFrequency,
     );
-    final historicalDayMatches = _historicalDayMatches(startPoint);
+    final historicalDayCandidates = _historicalDayCandidates(startPoint);
 
     final Map<int, List<Memory>> daysToMemories = {};
     final Map<int, Set<int>> daysToYears = {};
@@ -511,11 +536,15 @@ class TimeMemoriesCalculator {
         continue;
       }
       final fileDate = DateTime.fromMicrosecondsSinceEpoch(file.creationTime!);
-      final dayMatch =
-          historicalDayMatches[fileDate.month * 100 + fileDate.day];
+      if (!historicalDayCandidates.contains(
+        fileDate.month * 100 + fileDate.day,
+      )) {
+        continue;
+      }
+      final dayMatch = _historicalDateMatch(fileDate, startPoint);
       if (dayMatch == null) continue;
       daysToMemories
-          .putIfAbsent(dayMatch.offset, () => [])
+          .putIfAbsent(dayMatch.dayOffset, () => [])
           .add(
             Memory.fromFile(
               file,
@@ -526,7 +555,7 @@ class TimeMemoriesCalculator {
               ),
             ),
           );
-      daysToYears.putIfAbsent(dayMatch.offset, () => {}).add(fileDate.year);
+      daysToYears.putIfAbsent(dayMatch.dayOffset, () => {}).add(fileDate.year);
     }
 
     for (var day = 0; day < daysToCompute; day++) {

--- a/mobile/apps/photos/lib/services/smart_memories_trip_calculator_v2.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_trip_calculator_v2.dart
@@ -187,8 +187,10 @@ class TripMemoriesCalculatorV2 {
       );
     }
 
+    final filesWithLocation = allFiles.where((f) => f.hasLocation).toList()
+      ..sort((a, b) => a.creationTime!.compareTo(b.creationTime!));
     final baseLocations = _detectBaseLocations(
-      allFiles,
+      filesWithLocation,
       isLocalGalleryMode: isLocalGalleryMode,
     );
     final baseCountriesToExclude = _baseCountriesToExcludeFromTripTitles(
@@ -197,9 +199,6 @@ class TripMemoriesCalculatorV2 {
       citySearchIndex,
       seenTimes,
     );
-
-    final filesWithLocation = allFiles.where((f) => f.hasLocation).toList()
-      ..sort((a, b) => a.creationTime!.compareTo(b.creationTime!));
 
     if (filesWithLocation.isEmpty) {
       return TripMemoriesAnalysis(
@@ -335,12 +334,9 @@ class TripMemoriesCalculatorV2 {
   }
 
   static List<BaseLocation> _detectBaseLocations(
-    Iterable<EnteFile> allFiles, {
+    List<EnteFile> filesWithLocation, {
     required bool isLocalGalleryMode,
   }) {
-    final filesWithLocation =
-        allFiles.where((file) => file.hasLocation).toList()
-          ..sort((a, b) => a.creationTime!.compareTo(b.creationTime!));
     final smallRadiusClusters = _mergeNearbyLocationClusters(
       _clusterByLocation(filesWithLocation, radius: baseRadius),
       radius: _baseMergeRadius,
@@ -965,7 +961,7 @@ class TripMemoriesCalculatorV2 {
         excludedCountryNames: baseCountriesToExclude,
       );
       final photoSelection = await SmartMemoriesService._bestSelection(
-        trip.memories,
+        List<Memory>.of(trip.memories),
         isLocalGalleryMode: isLocalGalleryMode,
         mlEnabled: mlEnabled,
         fileIdToFaces: fileIdToFaces,
@@ -1114,7 +1110,7 @@ class TripMemoriesCalculatorV2 {
         excludedCountryNames: baseCountriesToExclude,
       );
       final photoSelection = await SmartMemoriesService._bestSelection(
-        trip.memories,
+        List<Memory>.of(trip.memories),
         isLocalGalleryMode: isLocalGalleryMode,
         mlEnabled: mlEnabled,
         fileIdToFaces: fileIdToFaces,

--- a/mobile/apps/photos/lib/services/smart_memories_trip_calculator_v2.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_trip_calculator_v2.dart
@@ -84,6 +84,18 @@ class _TripSurfaceCandidate {
   });
 }
 
+class TripMemoriesAnalysis {
+  final List<BaseLocation> baseLocations;
+  final Set<String> baseCountriesToExclude;
+  final List<TripMemory> tripCandidates;
+
+  const TripMemoriesAnalysis({
+    required this.baseLocations,
+    required this.baseCountriesToExclude,
+    required this.tripCandidates,
+  });
+}
+
 class TripMemoriesCalculatorV2 {
   static const _maxTemporalGapDays = 15;
 
@@ -133,15 +145,47 @@ class TripMemoriesCalculatorV2 {
     required Map<String, String> faceIDsToPersonID,
     required Map<int, EmbeddingVector> fileIDToImageEmbedding,
     required Vector clipPositiveTextVector,
-    required List<City> cities,
+    required CitySearchIndex citySearchIndex,
   }) async {
-    if (allFiles.isEmpty) return (<TripMemory>[], <BaseLocation>[]);
+    final analysis = analyze(
+      allFiles,
+      allFileIdsToFile,
+      isLocalGalleryMode: isLocalGalleryMode,
+      seenTimes: seenTimes,
+      citySearchIndex: citySearchIndex,
+    );
+    return surface(
+      analysis,
+      allFileIdsToFile,
+      currentTime,
+      shownTrips,
+      surfaceAll: surfaceAll,
+      cachedTripMemories: cachedTripMemories,
+      isLocalGalleryMode: isLocalGalleryMode,
+      mlEnabled: mlEnabled,
+      seenTimes: seenTimes,
+      fileIdToFaces: fileIdToFaces,
+      faceIDsToPersonID: faceIDsToPersonID,
+      fileIDToImageEmbedding: fileIDToImageEmbedding,
+      clipPositiveTextVector: clipPositiveTextVector,
+      citySearchIndex: citySearchIndex,
+    );
+  }
 
-    final nowInMicroseconds = currentTime.microsecondsSinceEpoch;
-    final windowEnd = currentTime
-        .add(kMemoriesUpdateFrequency)
-        .microsecondsSinceEpoch;
-    final cutOffTime = currentTime.subtract(const Duration(days: 365));
+  static TripMemoriesAnalysis analyze(
+    Iterable<EnteFile> allFiles,
+    Map<int, EnteFile> allFileIdsToFile, {
+    required bool isLocalGalleryMode,
+    required Map<int, int> seenTimes,
+    required CitySearchIndex citySearchIndex,
+  }) {
+    if (allFiles.isEmpty) {
+      return const TripMemoriesAnalysis(
+        baseLocations: <BaseLocation>[],
+        baseCountriesToExclude: <String>{},
+        tripCandidates: <TripMemory>[],
+      );
+    }
 
     final baseLocations = _detectBaseLocations(
       allFiles,
@@ -150,7 +194,7 @@ class TripMemoriesCalculatorV2 {
     final baseCountriesToExclude = _baseCountriesToExcludeFromTripTitles(
       baseLocations,
       allFileIdsToFile,
-      cities,
+      citySearchIndex,
       seenTimes,
     );
 
@@ -158,7 +202,11 @@ class TripMemoriesCalculatorV2 {
       ..sort((a, b) => a.creationTime!.compareTo(b.creationTime!));
 
     if (filesWithLocation.isEmpty) {
-      return (<TripMemory>[], baseLocations);
+      return TripMemoriesAnalysis(
+        baseLocations: baseLocations,
+        baseCountriesToExclude: baseCountriesToExclude,
+        tripCandidates: const <TripMemory>[],
+      );
     }
 
     // Returning to a base separates otherwise nearby trips.
@@ -167,7 +215,7 @@ class TripMemoriesCalculatorV2 {
       baseLocations,
     );
 
-    final tripCandidates = <TripMemory>[];
+    final rawTripCandidates = <TripMemory>[];
     for (final block in temporalBlocks) {
       var spatialClusters = _clusterByLocation(
         block,
@@ -182,7 +230,7 @@ class TripMemoriesCalculatorV2 {
 
         if (!_isValidTrip(files, location, baseLocations)) continue;
 
-        tripCandidates.add(
+        rawTripCandidates.add(
           TripMemory(
             Memory.fromFiles(files, seenTimes),
             0,
@@ -200,15 +248,48 @@ class TripMemoriesCalculatorV2 {
       }
     }
 
-    final mergedTrips = _mergeNearbyTrips(tripCandidates);
+    final mergedTrips = _mergeNearbyTrips(rawTripCandidates);
 
-    final validTrips = mergedTrips
-        .where(
-          (t) =>
-              t.memories.length >= _minTripPhotos &&
-              t.averageCreationTime() < cutOffTime.microsecondsSinceEpoch,
-        )
+    final tripCandidates = mergedTrips
+        .where((trip) => trip.memories.length >= _minTripPhotos)
         .map(_ensureTripKey)
+        .toList();
+
+    return TripMemoriesAnalysis(
+      baseLocations: baseLocations,
+      baseCountriesToExclude: baseCountriesToExclude,
+      tripCandidates: tripCandidates,
+    );
+  }
+
+  static Future<(List<TripMemory>, List<BaseLocation>)> surface(
+    TripMemoriesAnalysis analysis,
+    Map<int, EnteFile> allFileIdsToFile,
+    DateTime currentTime,
+    List<TripsShownLog> shownTrips, {
+    bool surfaceAll = false,
+    required Iterable<ToShowMemory> cachedTripMemories,
+    required bool isLocalGalleryMode,
+    required bool mlEnabled,
+    required Map<int, int> seenTimes,
+    required Map<int, List<FaceWithoutEmbedding>> fileIdToFaces,
+    required Map<String, String> faceIDsToPersonID,
+    required Map<int, EmbeddingVector> fileIDToImageEmbedding,
+    required Vector clipPositiveTextVector,
+    required CitySearchIndex citySearchIndex,
+  }) async {
+    final nowInMicroseconds = currentTime.microsecondsSinceEpoch;
+    final windowEnd = currentTime
+        .add(kMemoriesUpdateFrequency)
+        .microsecondsSinceEpoch;
+    final cutOffTime = currentTime.subtract(const Duration(days: 365));
+    final baseLocations = analysis.baseLocations;
+    final baseCountriesToExclude = analysis.baseCountriesToExclude;
+    final validTrips = analysis.tripCandidates
+        .where(
+          (trip) =>
+              trip.averageCreationTime() < cutOffTime.microsecondsSinceEpoch,
+        )
         .toList();
 
     final List<TripMemory> memoryResults = [];
@@ -229,7 +310,7 @@ class TripMemoriesCalculatorV2 {
         faceIDsToPersonID: faceIDsToPersonID,
         fileIDToImageEmbedding: fileIDToImageEmbedding,
         clipPositiveTextVector: clipPositiveTextVector,
-        cities: cities,
+        citySearchIndex: citySearchIndex,
       );
     }
 
@@ -249,7 +330,7 @@ class TripMemoriesCalculatorV2 {
       faceIDsToPersonID: faceIDsToPersonID,
       fileIDToImageEmbedding: fileIDToImageEmbedding,
       clipPositiveTextVector: clipPositiveTextVector,
-      cities: cities,
+      citySearchIndex: citySearchIndex,
     );
   }
 
@@ -848,7 +929,7 @@ class TripMemoriesCalculatorV2 {
     required Map<String, String> faceIDsToPersonID,
     required Map<int, EmbeddingVector> fileIDToImageEmbedding,
     required Vector clipPositiveTextVector,
-    required List<City> cities,
+    required CitySearchIndex citySearchIndex,
   }) async {
     for (final baseLocation in baseLocations) {
       String name = "Base (${baseLocation.isCurrentBase ? 'current' : 'old'})";
@@ -857,7 +938,7 @@ class TripMemoriesCalculatorV2 {
           .toList();
       final String? locationName = SmartMemoriesService._tryFindLocationName(
         Memory.fromFiles(files, seenTimes),
-        cities,
+        citySearchIndex,
         base: true,
       );
       if (locationName != null) {
@@ -880,7 +961,7 @@ class TripMemoriesCalculatorV2 {
       ).year;
       final String? locationName = SmartMemoriesService._tryFindLocationName(
         trip.memories,
-        cities,
+        citySearchIndex,
         excludedCountryNames: baseCountriesToExclude,
       );
       final photoSelection = await SmartMemoriesService._bestSelection(
@@ -921,7 +1002,7 @@ class TripMemoriesCalculatorV2 {
     required Map<String, String> faceIDsToPersonID,
     required Map<int, EmbeddingVector> fileIDToImageEmbedding,
     required Vector clipPositiveTextVector,
-    required List<City> cities,
+    required CitySearchIndex citySearchIndex,
   }) async {
     final activeTripIdentityKeys = _activeCachedTripIdentityKeys(
       cachedTripMemories,
@@ -1029,7 +1110,7 @@ class TripMemoriesCalculatorV2 {
       ).year;
       final String? locationName = SmartMemoriesService._tryFindLocationName(
         trip.memories,
-        cities,
+        citySearchIndex,
         excludedCountryNames: baseCountriesToExclude,
       );
       final photoSelection = await SmartMemoriesService._bestSelection(
@@ -1057,7 +1138,7 @@ class TripMemoriesCalculatorV2 {
   static Set<String> _baseCountriesToExcludeFromTripTitles(
     List<BaseLocation> baseLocations,
     Map<int, EnteFile> allFileIdsToFile,
-    List<City> cities,
+    CitySearchIndex citySearchIndex,
     Map<int, int> seenTimes,
   ) {
     final excludedCountries = <String>{};
@@ -1072,7 +1153,7 @@ class TripMemoriesCalculatorV2 {
 
       final countryName = SmartMemoriesService._tryFindCountryName(
         Memory.fromFiles(files, seenTimes),
-        cities,
+        citySearchIndex,
       );
       if (countryName == null) {
         continue;

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -156,7 +156,7 @@ void main() {
     );
 
     test(
-      "Filler memories preserve year-boundary and leap-day matching",
+      "Filler memories preserve year-boundary, leap-day, and time-window matching",
       () async {
         final yearBoundaryMemories =
             await TimeMemoriesCalculator.computeFillerMemories(
@@ -198,6 +198,23 @@ void main() {
             );
         expect(leapDayMemories.single.yearsAgo, 1);
         expect(leapDayMemories.single.memories.single.file.uploadedFileID, 4);
+
+        final sameDayMemories =
+            await TimeMemoriesCalculator.computeFillerMemories(
+              [
+                _file(id: 5, createdAt: DateTime(2025, 8, 18, 10)),
+                _file(id: 6, createdAt: DateTime(2025, 8, 18, 14)),
+                _file(id: 7, createdAt: DateTime(2025, 8, 21, 11)),
+              ],
+              DateTime(2026, 8, 18, 12),
+              seenTimes: const <int, int>{},
+            );
+        expect(
+          sameDayMemories.single.memories.map(
+            (memory) => memory.file.uploadedFileID,
+          ),
+          [6, 7],
+        );
       },
     );
 

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -54,6 +54,22 @@ void main() {
         final allFileIdsToFile = {
           for (final file in fullSourceFiles) file.uploadedFileID!: file,
         };
+        final citySearchIndex = CitySearchIndex(
+          cities: [
+            City.fromMap({
+              "city": "Paris",
+              "country": "France",
+              "lat": tripLocation.latitude,
+              "lng": tripLocation.longitude,
+            }),
+          ],
+          nodes: const [
+            [0, -1, -1, 0],
+          ],
+          root: 0,
+          maxLatDelta: 1,
+          maxLngDelta: 1,
+        );
 
         final (fullTrips, _) = await TripMemoriesCalculatorV2.compute(
           fullSourceFiles,
@@ -69,7 +85,7 @@ void main() {
           faceIDsToPersonID: const <String, String>{},
           fileIDToImageEmbedding: const <int, EmbeddingVector>{},
           clipPositiveTextVector: _positiveTextVector,
-          cities: const <City>[],
+          citySearchIndex: citySearchIndex,
         );
 
         final (remainingTrips, _) = await TripMemoriesCalculatorV2.compute(
@@ -86,11 +102,12 @@ void main() {
           faceIDsToPersonID: const <String, String>{},
           fileIDToImageEmbedding: const <int, EmbeddingVector>{},
           clipPositiveTextVector: _positiveTextVector,
-          cities: const <City>[],
+          citySearchIndex: citySearchIndex,
         );
 
         expect(fullTrips, hasLength(1));
         expect(fullTrips.first.memories, hasLength(10));
+        expect(fullTrips.first.locationName, "Paris");
         expect(remainingTrips, isEmpty);
       },
     );

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -6,11 +6,14 @@ import "package:photos/models/location/location.dart";
 import "package:photos/models/memories/clip_memory.dart";
 import "package:photos/models/memories/filler_memory.dart";
 import "package:photos/models/memories/memories_cache.dart";
+import "package:photos/models/memories/smart_memory_constants.dart";
 import "package:photos/models/memories/time_memory.dart";
 import "package:photos/models/ml/face/face_with_embedding.dart";
 import "package:photos/models/ml/vector.dart";
 import "package:photos/services/location_service.dart";
 import "package:photos/services/smart_memories_service.dart";
+import "package:timezone/data/latest.dart" as tzdata;
+import "package:timezone/timezone.dart" as timezone;
 
 EnteFile _file({
   required int id,
@@ -266,6 +269,21 @@ void main() {
         );
       },
     );
+
+    test("historical prefilter covers a DST-expanded date window", () {
+      tzdata.initializeTimeZones();
+      final location = timezone.getLocation("America/New_York");
+      final currentTime = timezone.TZDateTime(location, 2026, 3, 7, 23, 30);
+
+      expect(
+        currentTime.add(kMemoriesUpdateFrequency),
+        timezone.TZDateTime(location, 2026, 3, 11, 0, 30),
+      );
+      expect(
+        TimeMemoriesCalculator.historicalDayCandidates(currentTime),
+        contains(311),
+      );
+    });
 
     test("memory week numbers retain seven-day buckets", () {
       expect(TimeMemoriesCalculator.getWeekNumber(DateTime.utc(2024, 1, 1)), 1);

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -156,6 +156,62 @@ void main() {
     );
 
     test(
+      "Filler memories preserve year-boundary and leap-day matching",
+      () async {
+        final yearBoundaryMemories =
+            await TimeMemoriesCalculator.computeFillerMemories(
+              [
+                _file(id: 1, createdAt: DateTime.utc(2025, 12, 31)),
+                _file(id: 2, createdAt: DateTime.utc(2025, 1, 1)),
+                _file(id: 3, createdAt: DateTime.utc(2025, 1, 3)),
+              ],
+              DateTime.utc(2026, 12, 31),
+              seenTimes: const <int, int>{},
+            );
+
+        expect(
+          yearBoundaryMemories
+              .singleWhere((memory) => memory.yearsAgo == 1)
+              .memories
+              .map((memory) => memory.file.uploadedFileID),
+          [1],
+        );
+        expect(
+          yearBoundaryMemories
+              .singleWhere((memory) => memory.yearsAgo == 2)
+              .memories
+              .map((memory) => memory.file.uploadedFileID),
+          [2],
+        );
+        expect(
+          yearBoundaryMemories
+              .expand((memory) => memory.memories)
+              .map((memory) => memory.file.uploadedFileID),
+          isNot(contains(3)),
+        );
+
+        final leapDayMemories =
+            await TimeMemoriesCalculator.computeFillerMemories(
+              [_file(id: 4, createdAt: DateTime.utc(2024, 2, 29))],
+              DateTime.utc(2025, 3, 1),
+              seenTimes: const <int, int>{},
+            );
+        expect(leapDayMemories.single.yearsAgo, 1);
+        expect(leapDayMemories.single.memories.single.file.uploadedFileID, 4);
+      },
+    );
+
+    test("memory week numbers retain seven-day buckets", () {
+      expect(TimeMemoriesCalculator.getWeekNumber(DateTime.utc(2024, 1, 1)), 1);
+      expect(TimeMemoriesCalculator.getWeekNumber(DateTime.utc(2024, 1, 7)), 1);
+      expect(TimeMemoriesCalculator.getWeekNumber(DateTime.utc(2024, 1, 8)), 2);
+      expect(
+        TimeMemoriesCalculator.getWeekNumber(DateTime.utc(2024, 12, 31)),
+        53,
+      );
+    });
+
+    test(
       "ClipMemoriesCalculator surfaces a memory from the full source set",
       () async {
         final currentTime = DateTime.utc(2026, 4, 10);

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -4,6 +4,7 @@ import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/location/location.dart";
 import "package:photos/models/memories/clip_memory.dart";
+import "package:photos/models/memories/filler_memory.dart";
 import "package:photos/models/memories/memories_cache.dart";
 import "package:photos/models/memories/time_memory.dart";
 import "package:photos/models/ml/face/face_with_embedding.dart";
@@ -113,7 +114,7 @@ void main() {
     );
 
     test(
-      "TimeMemoriesCalculator uses the full recent source for last week",
+      "TimeMemoriesCalculator uses the recent source without historical candidates",
       () async {
         final currentTime = DateTime.utc(2026, 4, 10);
         final fullRecentSource = <EnteFile>[
@@ -124,10 +125,8 @@ void main() {
                 createdAt: DateTime.utc(2026, 4, 1 + dayOffset, 9 + photoIndex),
               ),
         ];
-        final depletedRemainingFiles = fullRecentSource.take(6).toList();
-
         final memories = await TimeMemoriesCalculator.computeTimeMemories(
-          depletedRemainingFiles,
+          const <EnteFile>[],
           currentTime,
           recentSourceFiles: fullRecentSource,
           isLocalGalleryMode: false,
@@ -152,6 +151,56 @@ void main() {
 
         expect(lastWeekMemory.memories, hasLength(10));
         expect(distinctDays.length, greaterThanOrEqualTo(4));
+      },
+    );
+
+    test("MemoryFileIndex merges ranges and preserves descending order", () {
+      final index = MemoryFileIndex([
+        _file(id: 2, createdAt: DateTime(2024, 1, 2)),
+        _file(id: 4, createdAt: DateTime(2024, 1, 4)),
+        _file(id: 1, createdAt: DateTime(2024, 1, 1)),
+        _file(id: 3, createdAt: DateTime(2024, 1, 3)),
+      ]);
+
+      final files = index.filesInDateRanges([
+        (start: DateTime(2024, 1, 1), end: DateTime(2024, 1, 3)),
+        (start: DateTime(2024, 1, 2), end: DateTime(2024, 1, 4)),
+      ]);
+
+      expect(files.map((file) => file.uploadedFileID), [3, 2, 1]);
+    });
+
+    test(
+      "MemoryFileIndex is a broad prefilter for exact date windows",
+      () async {
+        final currentTime = DateTime(2026, 8, 18, 12);
+        final source = [
+          _file(id: 1, createdAt: DateTime(2025, 8, 18, 10)),
+          _file(id: 2, createdAt: DateTime(2025, 8, 18, 14)),
+          _file(id: 3, createdAt: DateTime(2025, 8, 21, 11)),
+          _file(id: 4, createdAt: DateTime(2025, 9, 1)),
+        ];
+        final indexedCandidates = MemoryFileIndex(
+          source,
+        ).filesForCalendar(monthDays: const {818, 819, 820, 821});
+
+        final fullResult = await TimeMemoriesCalculator.computeFillerMemories(
+          source,
+          currentTime,
+          seenTimes: const <int, int>{},
+        );
+        final indexedResult =
+            await TimeMemoriesCalculator.computeFillerMemories(
+              indexedCandidates,
+              currentTime,
+              seenTimes: const <int, int>{},
+            );
+
+        Iterable<int?> selectedIDs(List<FillerMemory> memories) => memories
+            .expand((memory) => memory.memories)
+            .map((memory) => memory.file.uploadedFileID);
+        expect(selectedIDs(indexedResult), selectedIDs(fullResult));
+        expect(selectedIDs(indexedResult), [2, 3]);
       },
     );
 


### PR DESCRIPTION
## Summary

### Search

- Reuses the creation-time-sorted in-memory file list for year, month, holiday, and parsed-date searches, and removes the redundant database date-range method.
- Reuses one uploaded-ID lookup for people searches.
- Filters city grouping to files with locations and skips isolate work when no city name matches. On the benchmark account this reduces city-worker input from 95,141 files to 10,743 location files (89%).

### Smart Memories

- Reuses trip analysis across the current and next periods.
- Uses binary creation-time ranges to prefilter calendar candidates while retaining the existing exact time, leap-day, year-boundary, exclusion, and used-file checks.
- Reuses the existing downloaded world-city KD-tree for trip location names; this does not add another city index.

## Smart Memories benchmark

Debug iOS simulator, 95,124 files, with 98,270 CLIP embeddings for the ML-enabled runs.

| Mode | Before | Earlier PR head | Final | Total reduction |
| --- | ---: | ---: | ---: | ---: |
| ML enabled | 30.5s | 8.1s | 5.8s | 81% |
| ML disabled | 29.3s | 6.7s | 5.1s | 83% |

Final warm samples were 5.83s, 5.79s, and 5.63s with ML enabled; 5.27s, 5.09s, and 5.05s with ML disabled. The final range layer is another 29% and 24% reduction respectively over the earlier PR head.

## Memory and GC

The earlier in-app optimization reduced peak RSS from 3.34GB to 3.19GB and young-generation collections from 683 to 371 with ML enabled. The final range layer adds no per-file date cache; a standalone 95k-file JIT benchmark kept peak RSS at 166-167MB and reduced young collections from about 34 to 0.8 per calculation.

## Validation

- Focused Smart Memories source-selection and calendar regression tests
- Static analysis for the changed Search, location, and Smart Memories files