### PR TITLE
[mobile][photos] Fix crash when opening Ente Trash

### DIFF
--- a/mobile/apps/photos/changes/fix-trash-gallery-grouping-crash.md
+++ b/mobile/apps/photos/changes/fix-trash-gallery-grouping-crash.md
@@ -1,0 +1,1 @@
+- Fixed a crash when opening Ente Trash.

--- a/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
+++ b/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
@@ -314,7 +314,7 @@ class GalleryGroups {
     if (groupType.showGroupHeader()) {
       var start = 0;
       for (final end in _timeGroupEndIndexes()) {
-        _createNewGroup(allFiles.sublist(start, end), yearsInGroups);
+        _createNewGroup(_copyFilesInRange(start, end), yearsInGroups);
         start = end;
       }
     } else {
@@ -324,7 +324,7 @@ class GalleryGroups {
         final end = (i + 10 * crossAxisCount < allFiles.length)
             ? i + 10 * crossAxisCount
             : allFiles.length;
-        final subGroup = allFiles.sublist(i, end);
+        final subGroup = _copyFilesInRange(i, end);
         _createNewGroup(subGroup, yearsInGroups);
       }
     }
@@ -333,6 +333,12 @@ class GalleryGroups {
       "Built ${_groupIds.length} groups for group type ${groupType.name} in ${stopwatch.elapsedMilliseconds} ms",
     );
     stopwatch.stop();
+  }
+
+  List<EnteFile> _copyFilesInRange(int start, int end) {
+    // sublist preserves a covariant source list's runtime element type, which
+    // can reject DummyFile placeholders added by _createNewGroup.
+    return List<EnteFile>.from(allFiles.getRange(start, end));
   }
 
   List<int> _timeGroupEndIndexes() {

--- a/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
+++ b/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
@@ -336,8 +336,8 @@ class GalleryGroups {
   }
 
   List<EnteFile> _copyFilesInRange(int start, int end) {
-    // sublist preserves a covariant source list's runtime element type, which
-    // can reject DummyFile placeholders added by _createNewGroup.
+    // Create a real List<EnteFile> so _createNewGroup can add DummyFiles.
+    // A sublist of List<EnteTrashFile>, for example, only accepts EnteTrashFile.
     return List<EnteFile>.from(allFiles.getRange(start, end));
   }
 


### PR DESCRIPTION
## Description

Ente Trash can provide a runtime `List<EnteTrashFile>` to gallery grouping. When a group has an incomplete row, adding `DummyFile` placeholders to that list causes a runtime type error.

Create each group as a real `List<EnteFile>` using `getRange()` before adding placeholders. This fixes the crash while retaining the single-allocation gallery grouping optimization added in #12256 .