### PR TITLE
[mobile][photos] use media kit video player for device trash files

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget.dart
@@ -161,7 +161,9 @@ class _VideoWidgetState extends State<VideoWidget> {
     }
 
     final shouldUseNativeVideoPlayer =
-        useNativeVideoPlayer && (!playPreview || Platform.isAndroid);
+        useNativeVideoPlayer &&
+        !widget.file.isDeviceTrash &&
+        (!playPreview || Platform.isAndroid);
 
     if (shouldUseNativeVideoPlayer) {
       return VideoWidgetNative(


### PR DESCRIPTION
native media player does not support playing trashed files on Android due to permission denied.