### PR TITLE
[web][photos] Handle onAuthenticateUser closing error handling

### DIFF
--- a/web/apps/photos/src/components/DeleteAccount.tsx
+++ b/web/apps/photos/src/components/DeleteAccount.tsx
@@ -47,7 +47,7 @@ import React, { useState } from "react";
 import { Trans } from "react-i18next";
 
 type DeleteAccountProps = ModalVisibilityProps & {
-    onAuthenticateUser: () => Promise<void>;
+    onAuthenticateUser: () => Promise<boolean>;
 };
 
 type SummaryPhase = "loading" | "ready" | "failed";
@@ -174,15 +174,7 @@ const DeleteAccountDialogContents: React.FC<
                     await getAccountDeleteChallenge();
 
                 if (allowDelete && encryptedChallenge) {
-                    try {
-                        await onAuthenticateUser();
-                    } catch (e) {
-                        const wasCancelled =
-                            e == undefined ||
-                            (e instanceof Error &&
-                                e.message ===
-                                    "app_lock_reauthentication_cancelled");
-                        if (!wasCancelled) onGenericError(e);
+                    if (!(await onAuthenticateUser())) {
                         setLoading(false);
                         return;
                     }

--- a/web/apps/photos/src/components/DeleteAccount.tsx
+++ b/web/apps/photos/src/components/DeleteAccount.tsx
@@ -174,7 +174,18 @@ const DeleteAccountDialogContents: React.FC<
                     await getAccountDeleteChallenge();
 
                 if (allowDelete && encryptedChallenge) {
-                    await onAuthenticateUser();
+                    try {
+                        await onAuthenticateUser();
+                    } catch (e) {
+                        const wasCancelled =
+                            e == undefined ||
+                            (e instanceof Error &&
+                                e.message ===
+                                    "app_lock_reauthentication_cancelled");
+                        if (!wasCancelled) onGenericError(e);
+                        setLoading(false);
+                        return;
+                    }
                     const decryptedChallenge =
                         await decryptDeleteAccountChallenge(encryptedChallenge);
                     await deleteAccount(

--- a/web/apps/photos/src/components/Sidebar.tsx
+++ b/web/apps/photos/src/components/Sidebar.tsx
@@ -149,8 +149,7 @@ type SidebarProps = ModalVisibilityProps & {
         isHiddenCollectionSummary?: boolean,
     ) => Promise<void>;
     onShowExport: () => void;
-    // Cancellation or failure deliberately leaves this promise unsettled.
-    onAuthenticateUser: () => Promise<void>;
+    onAuthenticateUser: () => Promise<boolean>;
 };
 
 type AccountAction = Extract<
@@ -192,14 +191,6 @@ type FreeUpSpaceAction = Extract<
     SidebarActionID,
     "freeUpSpace.deduplicate" | "freeUpSpace.largeFiles"
 >;
-
-const appLockReauthenticationCancelledMessage =
-    "app_lock_reauthentication_cancelled";
-
-const isReauthenticationCancellation = (error: unknown) =>
-    error == undefined ||
-    (error instanceof Error &&
-        error.message === appLockReauthenticationCancelledMessage);
 
 export const Sidebar: React.FC<SidebarProps> = ({
     open,
@@ -265,10 +256,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
         void (async () => {
             try {
-                await onAuthenticateUser();
+                if (!(await onAuthenticateUser())) return;
                 onShowExport();
-            } catch {
-                // User cancelled reauthentication.
+            } catch (error) {
+                log.error("Failed to authenticate before export", error);
             }
         })();
     }, [onAuthenticateUser, onShowExport, showMiniDialog]);
@@ -1007,9 +998,10 @@ const Account: React.FC<AccountProps> = ({
         if (isDesktop) {
             const reauthResult = await reauthenticateWithAppLock();
             if (reauthResult === "cancelled") return;
-            if (reauthResult === "fallback") await onAuthenticateUser();
+            if (reauthResult === "fallback" && !(await onAuthenticateUser()))
+                return;
         } else {
-            await onAuthenticateUser();
+            if (!(await onAuthenticateUser())) return;
         }
         showRecoveryKey();
     }, [onAuthenticateUser, showRecoveryKey]);
@@ -1026,9 +1018,10 @@ const Account: React.FC<AccountProps> = ({
         if (isDesktop) {
             const reauthResult = await reauthenticateWithAppLock();
             if (reauthResult === "cancelled") return;
-            if (reauthResult === "fallback") await onAuthenticateUser();
+            if (reauthResult === "fallback" && !(await onAuthenticateUser()))
+                return;
         } else {
-            await onAuthenticateUser();
+            if (!(await onAuthenticateUser())) return;
         }
         showSessions();
     }, [onAuthenticateUser, showSessions]);
@@ -1167,10 +1160,9 @@ const DesktopAppLockSettings: React.FC<
 
     const handleOpen = useCallback(async () => {
         try {
-            await onAuthenticateUser();
+            if (!(await onAuthenticateUser())) return;
             show();
         } catch (error) {
-            if (isReauthenticationCancellation(error)) return;
             log.error("Failed to open app lock settings", error);
         }
     }, [onAuthenticateUser, show]);

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -320,16 +320,14 @@ const Page: React.FC = () => {
         url?: string;
     }>({ open: false });
 
-    const onAuthenticateCallback = useRef<(() => void) | undefined>(undefined);
-    const onAuthenticateCancelCallback = useRef<(() => void) | undefined>(
-        undefined,
-    );
+    const onAuthenticateCallback = useRef<
+        ((didAuthenticate: boolean) => void) | undefined
+    >(undefined);
 
     const authenticateUserWithPasswordModal = useCallback(
         () =>
-            new Promise<void>((resolve, reject) => {
+            new Promise<boolean>((resolve) => {
                 onAuthenticateCallback.current = resolve;
-                onAuthenticateCancelCallback.current = reject;
                 showAuthenticateUser();
             }),
         [],
@@ -339,27 +337,23 @@ const Page: React.FC = () => {
         if (!isDesktop) return authenticateUserWithPasswordModal();
 
         const reauthResult = await reauthenticateWithAppLock();
-        if (reauthResult === "authenticated") return;
-        if (reauthResult === "cancelled") {
-            throw new Error("app_lock_reauthentication_cancelled");
-        }
+        if (reauthResult === "authenticated") return true;
+        if (reauthResult === "cancelled") return false;
 
         return authenticateUserWithPasswordModal();
     }, [authenticateUserWithPasswordModal]);
 
     const handleCloseAuthenticateUser = useCallback(() => {
         authenticateUserVisibilityProps.onClose();
-        // Reject the suspended caller when the modal is dismissed.
-        if (onAuthenticateCancelCallback.current) {
-            onAuthenticateCancelCallback.current();
-            onAuthenticateCancelCallback.current = undefined;
+        if (onAuthenticateCallback.current) {
+            onAuthenticateCallback.current(false);
+            onAuthenticateCallback.current = undefined;
         }
     }, [authenticateUserVisibilityProps.onClose]);
 
     const handleAuthenticate = useCallback(() => {
-        onAuthenticateCancelCallback.current = undefined;
         if (onAuthenticateCallback.current) {
-            onAuthenticateCallback.current();
+            onAuthenticateCallback.current(true);
             onAuthenticateCallback.current = undefined;
         }
     }, []);
@@ -1337,7 +1331,7 @@ const Page: React.FC = () => {
                 Date.now() - lastAuthAt > 5 * 60 * 1e3
             ) {
                 try {
-                    await authenticateUser();
+                    if (!(await authenticateUser())) return;
                     lastAuthenticationForHiddenTimestamp.current = Date.now();
                 } catch {
                     return;


### PR DESCRIPTION
 ## Description

  Authentication cancellation was treated as an error, causing Delete Account to show “Something went wrong.”

  This change returns a boolean authentication result, allowing callers to handle cancellation without triggering generic error handling.