### PR TITLE
[mobile][photos] Bump Cloudflare upload rollout to 50%

### DIFF
--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -16,7 +16,7 @@ class FlagService {
   static const int _videoStreamingFlag = 1 << 3;
   static const int _castSessionsV2Flag = 1 << 5;
   static const int _librarySharingFlag = 1 << 7;
-  static const int _cfUploadWorkerRolloutPercent = 20;
+  static const int _cfUploadWorkerRolloutPercent = 50;
 
   static const String _userIdKey = "user_id";
 


### PR DESCRIPTION
## Summary

- Increase the Photos mobile Cloudflare upload worker rollout from 20% to 50%.
- Expand faster uploads to a larger user cohort.

## Testing

- `flutter analyze` in `mobile/apps/photos/plugins/ente_feature_flag`
