### PR TITLE
[mobile][photos] Fix and optimize week grouping

### DIFF
--- a/mobile/apps/photos/changes/fix-week-grouping-performance.md
+++ b/mobile/apps/photos/changes/fix-week-grouping-performance.md
@@ -1,0 +1,1 @@
+- Fixed week grouping and improved timeline loading performance.

--- a/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
+++ b/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
@@ -341,19 +341,6 @@ class GalleryGroups {
       return ends;
     }
 
-    if (groupType == GroupType.week) {
-      var previousFile = allFiles.first;
-      for (var index = 1; index < allFiles.length; index++) {
-        final file = allFiles[index];
-        if (!groupType.areFromSameGroup(previousFile, file)) {
-          ends.add(index);
-        }
-        previousFile = file;
-      }
-      ends.add(allFiles.length);
-      return ends;
-    }
-
     var groupRange = groupType.getGroupRange(allFiles.first);
     for (var index = 1; index < allFiles.length; index++) {
       final creationTime = allFiles[index].creationTime!;

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/group/type.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/group/type.dart
@@ -78,12 +78,8 @@ extension GroupTypeExtension on GroupType {
         );
       case GroupType.week:
         final date = DateTime.fromMicrosecondsSinceEpoch(file.creationTime!);
-        final startOfWeek = DateTime(
-          date.year,
-          date.month,
-          date.day,
-        ).subtract(Duration(days: date.weekday - 1));
-        final endOfWeek = startOfWeek.add(const Duration(days: 7));
+        final startOfWeek = startOfISOWeek(date);
+        final endOfWeek = startOfNextISOWeek(date);
         return (
           startOfWeek.microsecondsSinceEpoch,
           endOfWeek.microsecondsSinceEpoch - 1,
@@ -104,33 +100,6 @@ extension GroupTypeExtension on GroupType {
           startOfYear.microsecondsSinceEpoch,
           endOfYear.microsecondsSinceEpoch - 1,
         );
-      default:
-        throw UnimplementedError("not implemented for $this");
-    }
-  }
-
-  bool areFromSameGroup(EnteFile first, EnteFile second) {
-    switch (this) {
-      case GroupType.day:
-        return areFromSameDay(first.creationTime!, second.creationTime!);
-      case GroupType.month:
-        return DateTime.fromMicrosecondsSinceEpoch(first.creationTime!).year ==
-                DateTime.fromMicrosecondsSinceEpoch(
-                  second.creationTime!,
-                ).year &&
-            DateTime.fromMicrosecondsSinceEpoch(first.creationTime!).month ==
-                DateTime.fromMicrosecondsSinceEpoch(second.creationTime!).month;
-      case GroupType.year:
-        return DateTime.fromMicrosecondsSinceEpoch(first.creationTime!).year ==
-            DateTime.fromMicrosecondsSinceEpoch(second.creationTime!).year;
-      case GroupType.week:
-        final firstDate = DateTime.fromMicrosecondsSinceEpoch(
-          first.creationTime!,
-        );
-        final secondDate = DateTime.fromMicrosecondsSinceEpoch(
-          second.creationTime!,
-        );
-        return areDatesInSameWeek(firstDate, secondDate);
       default:
         throw UnimplementedError("not implemented for $this");
     }
@@ -161,23 +130,25 @@ extension GroupTypeExtension on GroupType {
     final date = DateTime.fromMicrosecondsSinceEpoch(timestamp);
     final now = DateTime.now();
 
-    final startOfWeek = date.subtract(Duration(days: date.weekday - 1));
-    final nowStartOfWeek = now.subtract(Duration(days: now.weekday - 1));
+    final startOfWeek = startOfISOWeek(date);
+    final nowStartOfWeek = startOfISOWeek(now);
 
-    if (startOfWeek.year == nowStartOfWeek.year &&
-        startOfWeek.month == nowStartOfWeek.month &&
-        startOfWeek.day == nowStartOfWeek.day) {
+    if (startOfWeek == nowStartOfWeek) {
       return context.strings.thisWeek;
     }
 
-    final lastWeekStart = nowStartOfWeek.subtract(const Duration(days: 7));
-    if (startOfWeek.year == lastWeekStart.year &&
-        startOfWeek.month == lastWeekStart.month &&
-        startOfWeek.day == lastWeekStart.day) {
+    final lastWeekStart = startOfISOWeek(
+      DateTime(now.year, now.month, now.day - 7),
+    );
+    if (startOfWeek == lastWeekStart) {
       return context.strings.lastWeek;
     }
 
-    final endOfWeek = startOfWeek.add(const Duration(days: 6));
+    final endOfWeek = DateTime(
+      startOfWeek.year,
+      startOfWeek.month,
+      startOfWeek.day + 6,
+    );
     return "${DateFormat.MMMd(Localizations.localeOf(context).languageCode).format(startOfWeek)} - ${DateFormat.MMMd(Localizations.localeOf(context).languageCode).format(endOfWeek)}, ${endOfWeek.year}";
   }
 

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/group/type.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/group/type.dart
@@ -66,52 +66,6 @@ extension GroupTypeExtension on GroupType {
     }
   }
 
-  bool areModifiedFilesPartOfGroup(
-    List<EnteFile> modifiedFiles,
-    EnteFile fistFile, {
-    EnteFile? lastFile,
-  }) {
-    switch (this) {
-      case GroupType.day:
-        return modifiedFiles.any(
-          (file) => areFromSameDay(fistFile.creationTime!, file.creationTime!),
-        );
-      case GroupType.week:
-        return modifiedFiles.any((file) {
-          final firstDate = DateTime.fromMicrosecondsSinceEpoch(
-            fistFile.creationTime!,
-          );
-          final fileDate = DateTime.fromMicrosecondsSinceEpoch(
-            file.creationTime!,
-          );
-          return areDatesInSameWeek(firstDate, fileDate);
-        });
-      case GroupType.month:
-        return modifiedFiles.any((file) {
-          final firstDate = DateTime.fromMicrosecondsSinceEpoch(
-            fistFile.creationTime!,
-          );
-          final fileDate = DateTime.fromMicrosecondsSinceEpoch(
-            file.creationTime!,
-          );
-          return firstDate.year == fileDate.year &&
-              firstDate.month == fileDate.month;
-        });
-      case GroupType.year:
-        return modifiedFiles.any((file) {
-          final firstDate = DateTime.fromMicrosecondsSinceEpoch(
-            fistFile.creationTime!,
-          );
-          final fileDate = DateTime.fromMicrosecondsSinceEpoch(
-            file.creationTime!,
-          );
-          return firstDate.year == fileDate.year;
-        });
-      default:
-        throw UnimplementedError("not implemented for $this");
-    }
-  }
-
   (int, int) getGroupRange(EnteFile file) {
     switch (this) {
       case GroupType.day:

--- a/mobile/apps/photos/test/models/gallery_group_type_test.dart
+++ b/mobile/apps/photos/test/models/gallery_group_type_test.dart
@@ -1,0 +1,63 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/models/file/file.dart";
+import "package:photos/ui/viewer/gallery/component/group/type.dart";
+
+void main() {
+  group("week group range", () {
+    test("includes Monday through the final microsecond of Sunday", () {
+      final monday = DateTime(2026, 8, 17);
+      final nextMonday = DateTime(2026, 8, 24);
+      final sundayFinalMicrosecond = nextMonday.subtract(
+        const Duration(microseconds: 1),
+      );
+
+      final range = GroupType.week.getGroupRange(
+        _fileAt(sundayFinalMicrosecond),
+      );
+
+      expect(range, (
+        monday.microsecondsSinceEpoch,
+        sundayFinalMicrosecond.microsecondsSinceEpoch,
+      ));
+    });
+
+    test("excludes the previous Sunday and following Monday", () {
+      final monday = DateTime(2026, 8, 17);
+      final previousSundayFinalMicrosecond = monday.subtract(
+        const Duration(microseconds: 1),
+      );
+      final nextMonday = DateTime(2026, 8, 24);
+      final range = GroupType.week.getGroupRange(_fileAt(monday));
+
+      expect(
+        previousSundayFinalMicrosecond.microsecondsSinceEpoch,
+        lessThan(range.$1),
+      );
+      expect(nextMonday.microsecondsSinceEpoch, greaterThan(range.$2));
+    });
+
+    test("groups Monday morning and Sunday evening together", () {
+      final mondayMorning = DateTime(2026, 8, 17, 9);
+      final sundayEvening = DateTime(2026, 8, 23, 18);
+
+      expect(
+        GroupType.week.getGroupRange(_fileAt(mondayMorning)),
+        GroupType.week.getGroupRange(_fileAt(sundayEvening)),
+      );
+    });
+
+    test("normalizes weeks across year boundaries", () {
+      final sunday = DateTime(2026, 1, 4, 23, 59, 59, 999, 999);
+      final range = GroupType.week.getGroupRange(_fileAt(sunday));
+
+      expect(range, (
+        DateTime(2025, 12, 29).microsecondsSinceEpoch,
+        DateTime(2026, 1, 5).microsecondsSinceEpoch - 1,
+      ));
+    });
+  });
+}
+
+EnteFile _fileAt(DateTime date) {
+  return EnteFile()..creationTime = date.microsecondsSinceEpoch;
+}

--- a/mobile/packages/ente_pure_utils/lib/src/date_time_util.dart
+++ b/mobile/packages/ente_pure_utils/lib/src/date_time_util.dart
@@ -262,23 +262,18 @@ bool areFromSameDay(int firstCreationTime, int secondCreationTime) {
       firstDate.day == secondDate.day;
 }
 
-bool areDatesInSameWeek(DateTime date1, DateTime date2) {
-  if (date1.year == date2.year &&
-      date1.month == date2.month &&
-      date1.day == date2.day) {
-    return true;
-  }
-  final int dayOfWeek1 = date1.weekday;
-  final int dayOfWeek2 = date2.weekday;
-  final DateTime startOfWeek1 = date1.subtract(Duration(days: dayOfWeek1 - 1));
-  final DateTime endOfWeek1 = startOfWeek1.add(const Duration(days: 6));
-  final DateTime startOfWeek2 = date2.subtract(Duration(days: dayOfWeek2 - 1));
-  final DateTime endOfWeek2 = startOfWeek2.add(const Duration(days: 6));
-  if ((date1.isAfter(startOfWeek2) && date1.isBefore(endOfWeek2)) ||
-      (date2.isAfter(startOfWeek1) && date2.isBefore(endOfWeek1))) {
-    return true;
-  }
-  return false;
+DateTime startOfISOWeek(DateTime date) {
+  final mondayDay = date.day - (date.weekday - DateTime.monday);
+  return date.isUtc
+      ? DateTime.utc(date.year, date.month, mondayDay)
+      : DateTime(date.year, date.month, mondayDay);
+}
+
+DateTime startOfNextISOWeek(DateTime date) {
+  final start = startOfISOWeek(date);
+  return start.isUtc
+      ? DateTime.utc(start.year, start.month, start.day + 7)
+      : DateTime(start.year, start.month, start.day + 7);
 }
 
 String getNameForDateRange(int firstCreationTime, int secondCreationTime) {

--- a/mobile/packages/ente_pure_utils/test/date_time_util_test.dart
+++ b/mobile/packages/ente_pure_utils/test/date_time_util_test.dart
@@ -3,6 +3,36 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('ISO week boundaries', () {
+    test('use Monday midnight regardless of the original time', () {
+      final mondayMorning = DateTime(2026, 8, 17, 9);
+      final sundayEvening = DateTime(2026, 8, 23, 18);
+
+      expect(startOfISOWeek(mondayMorning), DateTime(2026, 8, 17));
+      expect(startOfISOWeek(sundayEvening), DateTime(2026, 8, 17));
+      expect(startOfNextISOWeek(mondayMorning), DateTime(2026, 8, 24));
+      expect(startOfNextISOWeek(sundayEvening), DateTime(2026, 8, 24));
+    });
+
+    test('normalize weeks across year boundaries', () {
+      final sunday = DateTime(2026, 1, 4, 23, 59, 59, 999, 999);
+
+      expect(startOfISOWeek(sunday), DateTime(2025, 12, 29));
+      expect(startOfNextISOWeek(sunday), DateTime(2026, 1, 5));
+    });
+
+    test('preserve UTC dates', () {
+      final sunday = DateTime.utc(2026, 8, 23, 18);
+      final start = startOfISOWeek(sunday);
+      final nextStart = startOfNextISOWeek(sunday);
+
+      expect(start, DateTime.utc(2026, 8, 17));
+      expect(nextStart, DateTime.utc(2026, 8, 24));
+      expect(start.isUtc, isTrue);
+      expect(nextStart.isUtc, isTrue);
+    });
+  });
+
   test("parseDateTimeFromFile", () {
     final List<String> validParsing = [
       "IMG-20221109-WA0000",


### PR DESCRIPTION
## Summary

- Fix week boundaries to consistently use ISO Monday-to-Sunday ranges.
- Apply the cached range scan from #12256 to week groups.
- Align week titles, remove obsolete comparison helpers, and add regression tests.

