### PR TITLE
[mobile][photos] Add local gallery ID diagnostics

### DIFF
--- a/mobile/apps/photos/lib/services/search_service.dart
+++ b/mobile/apps/photos/lib/services/search_service.dart
@@ -391,6 +391,41 @@ class SearchService {
     }
   }
 
+  Future<List<GenericSearchResult>> getLocalFileIDsSearchResults(
+    String query,
+    Set<String> localFileIDs,
+  ) async {
+    if (!isLocalGalleryMode || localFileIDs.isEmpty) {
+      return [];
+    }
+
+    try {
+      final files = (await getAllFilesForSearch())
+          .where((file) => localFileIDs.contains(file.localID))
+          .toList();
+      if (files.isEmpty) {
+        return [];
+      }
+
+      return [
+        GenericSearchResult(
+          ResultType.file,
+          query.trim(),
+          files,
+          hierarchicalSearchFilter: TopLevelGenericFilter(
+            filterName: query.trim(),
+            occurrence: kMostRelevantFilter,
+            filterResultType: ResultType.file,
+            matchedUploadedIDs: filesToUploadedFileIDs(files),
+          ),
+        ),
+      ];
+    } catch (e, s) {
+      _logger.severe("Failed to search by local file IDs", e, s);
+      return [];
+    }
+  }
+
   Future<List<EnteFile>> getAllFilesForHierarchicalSearch() async {
     if (_cachedFilesFuture != null &&
         _cachedFilesForHierarchicalSearch != null) {

--- a/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/search/search_widget.dart
@@ -31,6 +31,7 @@ class SearchWidget extends StatefulWidget {
 }
 
 class SearchWidgetState extends State<SearchWidget> {
+  static const _localFileIDsSearchPrefix = "local_ids:";
   static const _uploadedFileIDsSearchPrefix = "uploaded_ids:";
   static final ValueNotifier<Stream<List<SearchResult>>?>
   searchResultsStreamNotifier = ValueNotifier(null);
@@ -217,6 +218,18 @@ class SearchWidgetState extends State<SearchWidget> {
           .toSet();
       return Stream.fromFuture(
         _searchService.getUploadedFileIDsSearchResults(query, uploadedFileIDs),
+      );
+    }
+
+    if (query.startsWith(_localFileIDsSearchPrefix)) {
+      final localFileIDs = query
+          .substring(_localFileIDsSearchPrefix.length)
+          .split(",")
+          .map((value) => value.trim())
+          .where((id) => id.isNotEmpty)
+          .toSet();
+      return Stream.fromFuture(
+        _searchService.getLocalFileIDsSearchResults(query, localFileIDs),
       );
     }
 

--- a/mobile/apps/photos/lib/utils/ml_util.dart
+++ b/mobile/apps/photos/lib/utils/ml_util.dart
@@ -751,8 +751,11 @@ Future<String> getImagePathForML(EnteFile enteFile) async {
   );
 
   if (imagePath == null) {
+    final fileIdentifier = isLocalGalleryMode
+        ? "localID ${enteFile.localID}"
+        : "uploadedFileID ${enteFile.uploadedFileID}";
     _logger.severe(
-      "Failed to get any data for enteFile with uploadedFileID ${enteFile.uploadedFileID} and format ${enteFile.displayName.split('.').last} and size ${enteFile.fileSize} since its file path is null (isVideo: $isVideo)",
+      "Failed to get any data for enteFile with $fileIdentifier and format ${enteFile.displayName.split('.').last} and size ${enteFile.fileSize} since its file path is null (isVideo: $isVideo)",
     );
     throw CouldNotRetrieveAnyFileData();
   }


### PR DESCRIPTION
## Summary

- Log the local ID when ML indexing cannot retrieve file data in local-gallery mode.
- Add a local_ids: search prefix for locating one or more local-gallery files.
- Restrict local-ID lookup to local-gallery mode to avoid unsupported hierarchical filtering for unuploaded files.

## Validation

- flutter analyze lib/services/search_service.dart lib/ui/viewer/search/search_widget.dart
- dart format on all changed Dart files
- git diff --check

Focused analysis of ml_util.dart remains blocked by the existing missing generated ml_indexing_api.dart binding.