### PR TITLE
[mobile] Stream multipart checksum calculation

### DIFF
--- a/mobile/apps/photos/changes/reduce-upload-memory.md
+++ b/mobile/apps/photos/changes/reduce-upload-memory.md
@@ -1,0 +1,1 @@
+- Reduced memory usage during large file uploads.

--- a/mobile/apps/photos/plugins/ente_crypto/lib/src/crypto.dart
+++ b/mobile/apps/photos/plugins/ente_crypto/lib/src/crypto.dart
@@ -137,12 +137,12 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
   final logger = Logger("ChaChaEncryptWithMD5");
   final sourceFile = File(args["sourceFilePath"]);
   final destinationFile = File(args["destinationFilePath"]);
-  final int? multiPartChunkSizeInBytes = args["multiPartChunkSizeInBytes"];
+  final int? partSize = args["multiPartChunkSizeInBytes"];
   final sourceFileLength = await sourceFile.length();
 
   logger.info("Encrypting file of size $sourceFileLength");
-  if (multiPartChunkSizeInBytes != null) {
-    logger.info("Using multipart chunk size: $multiPartChunkSizeInBytes bytes");
+  if (partSize != null) {
+    logger.info("Using multipart chunk size: $partSize bytes");
   }
 
   final inputFile = sourceFile.openSync(mode: FileMode.read);
@@ -158,21 +158,16 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
     key,
   );
 
-  AccumulatorSink<Digest>? fullAccumulator;
-  ChunkedConversionSink<List<int>>? fullMd5Sink;
-  AccumulatorSink<Digest>? partAccumulator;
-  ChunkedConversionSink<List<int>>? partMd5Sink;
+  var md5Accumulator = AccumulatorSink<Digest>();
+  var md5Sink = md5.startChunkedConversion(md5Accumulator);
+
+  String finishMd5() {
+    md5Sink.close();
+    return base64.encode(md5Accumulator.events.single.bytes);
+  }
 
   final List<String> partMd5s = [];
   var bytesInPart = 0;
-
-  if (multiPartChunkSizeInBytes == null) {
-    fullAccumulator = AccumulatorSink<Digest>();
-    fullMd5Sink = md5.startChunkedConversion(fullAccumulator);
-  } else {
-    partAccumulator = AccumulatorSink<Digest>();
-    partMd5Sink = md5.startChunkedConversion(partAccumulator);
-  }
 
   var bytesRead = 0;
   var totalEncryptedBytes = 0;
@@ -235,19 +230,18 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
       }
 
       totalEncryptedBytes += encryptedData.length;
+      outSink.add(encryptedData);
 
-      if (multiPartChunkSizeInBytes == null) {
-        fullMd5Sink!.add(encryptedData);
-        outSink.add(encryptedData);
+      if (partSize == null) {
+        md5Sink.add(encryptedData);
       } else {
-        outSink.add(encryptedData);
         var offset = 0;
         while (offset < encryptedData.length) {
-          final bytesToPartBoundary = multiPartChunkSizeInBytes - bytesInPart;
+          final bytesToPartBoundary = partSize - bytesInPart;
           final end = offset + bytesToPartBoundary < encryptedData.length
               ? offset + bytesToPartBoundary
               : encryptedData.length;
-          partMd5Sink!.add(
+          md5Sink.add(
             offset == 0 && end == encryptedData.length
                 ? encryptedData
                 : Uint8List.sublistView(encryptedData, offset, end),
@@ -255,29 +249,23 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
           bytesInPart += end - offset;
           offset = end;
 
-          if (bytesInPart == multiPartChunkSizeInBytes) {
-            partMd5Sink.close();
-            final digest = partAccumulator!.events.single;
-            partMd5s.add(base64.encode(digest.bytes));
+          if (bytesInPart == partSize) {
+            partMd5s.add(finishMd5());
 
-            logger.info(
-              "Part ${partMd5s.length}: $multiPartChunkSizeInBytes bytes",
-            );
+            logger.info("Part ${partMd5s.length}: $partSize bytes");
 
             bytesInPart = 0;
             if (offset < encryptedData.length ||
                 tag != Sodium.cryptoSecretstreamXchacha20poly1305TagFinal) {
-              partAccumulator = AccumulatorSink<Digest>();
-              partMd5Sink = md5.startChunkedConversion(partAccumulator);
+              md5Accumulator = AccumulatorSink<Digest>();
+              md5Sink = md5.startChunkedConversion(md5Accumulator);
             }
           }
         }
 
         if (tag == Sodium.cryptoSecretstreamXchacha20poly1305TagFinal &&
             bytesInPart > 0) {
-          partMd5Sink!.close();
-          final digest = partAccumulator!.events.single;
-          partMd5s.add(base64.encode(digest.bytes));
+          partMd5s.add(finishMd5());
         }
       }
     }
@@ -285,10 +273,8 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
     await inputFile.close();
 
     String? finalFileMd5;
-    if (multiPartChunkSizeInBytes == null && fullMd5Sink != null) {
-      fullMd5Sink.close();
-      final digest = fullAccumulator!.events.single;
-      finalFileMd5 = base64.encode(digest.bytes);
+    if (partSize == null) {
+      finalFileMd5 = finishMd5();
       logger.info("File MD5: $finalFileMd5");
     }
 
@@ -299,9 +285,7 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
         (DateTime.now().millisecondsSinceEpoch -
             encryptionStartTime.millisecondsSinceEpoch) /
         1000;
-    final partsInfo = multiPartChunkSizeInBytes != null
-        ? " Parts: ${partMd5s.length}"
-        : "";
+    final partsInfo = partSize != null ? " Parts: ${partMd5s.length}" : "";
     debugPrint(
       "FileEncryption: Time: ${encryptionTimeSeconds}s "
       "Total encrypted: $totalEncryptedBytes bytes$partsInfo",
@@ -311,10 +295,8 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
       key: key,
       header: initPushResult.header,
       fileMd5: finalFileMd5,
-      partMd5s: multiPartChunkSizeInBytes != null && partMd5s.isNotEmpty
-          ? partMd5s
-          : null,
-      partSize: multiPartChunkSizeInBytes,
+      partMd5s: partSize == null ? null : partMd5s,
+      partSize: partSize,
     );
   } catch (e) {
     try {

--- a/mobile/apps/photos/plugins/ente_crypto/lib/src/crypto.dart
+++ b/mobile/apps/photos/plugins/ente_crypto/lib/src/crypto.dart
@@ -1,6 +1,5 @@
 import "dart:convert";
 import "dart:io";
-import 'dart:typed_data';
 
 import "package:computer/computer.dart";
 import "package:convert/convert.dart";
@@ -165,7 +164,7 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
   ChunkedConversionSink<List<int>>? partMd5Sink;
 
   final List<String> partMd5s = [];
-  final BytesBuilder partBuffer = BytesBuilder();
+  var bytesInPart = 0;
 
   if (multiPartChunkSizeInBytes == null) {
     fullAccumulator = AccumulatorSink<Digest>();
@@ -241,50 +240,44 @@ Future<FileEncryptResult> chachaEncryptFileWithVerification(
         fullMd5Sink!.add(encryptedData);
         outSink.add(encryptedData);
       } else {
-        partBuffer.add(encryptedData);
-
-        final bool isLastChunk =
-            tag == Sodium.cryptoSecretstreamXchacha20poly1305TagFinal;
-
-        while (partBuffer.length >= multiPartChunkSizeInBytes) {
-          final partBytes = partBuffer.toBytes().sublist(
-            0,
-            multiPartChunkSizeInBytes,
+        outSink.add(encryptedData);
+        var offset = 0;
+        while (offset < encryptedData.length) {
+          final bytesToPartBoundary = multiPartChunkSizeInBytes - bytesInPart;
+          final end = offset + bytesToPartBoundary < encryptedData.length
+              ? offset + bytesToPartBoundary
+              : encryptedData.length;
+          partMd5Sink!.add(
+            offset == 0 && end == encryptedData.length
+                ? encryptedData
+                : Uint8List.sublistView(encryptedData, offset, end),
           );
+          bytesInPart += end - offset;
+          offset = end;
 
-          partMd5Sink!.add(partBytes);
-          partMd5Sink.close();
-          final digest = partAccumulator!.events.single;
-          partMd5s.add(base64.encode(digest.bytes));
+          if (bytesInPart == multiPartChunkSizeInBytes) {
+            partMd5Sink.close();
+            final digest = partAccumulator!.events.single;
+            partMd5s.add(base64.encode(digest.bytes));
 
-          logger.info(
-            "Part ${partMd5s.length}: $multiPartChunkSizeInBytes bytes",
-          );
+            logger.info(
+              "Part ${partMd5s.length}: $multiPartChunkSizeInBytes bytes",
+            );
 
-          outSink.add(partBytes);
-
-          final remaining = partBuffer.toBytes().sublist(
-            multiPartChunkSizeInBytes,
-          );
-          partBuffer.clear();
-          partBuffer.add(remaining);
-
-          if (!isLastChunk || partBuffer.isNotEmpty) {
-            partAccumulator = AccumulatorSink<Digest>();
-            partMd5Sink = md5.startChunkedConversion(partAccumulator);
+            bytesInPart = 0;
+            if (offset < encryptedData.length ||
+                tag != Sodium.cryptoSecretstreamXchacha20poly1305TagFinal) {
+              partAccumulator = AccumulatorSink<Digest>();
+              partMd5Sink = md5.startChunkedConversion(partAccumulator);
+            }
           }
         }
 
-        if (isLastChunk && partBuffer.isNotEmpty) {
-          final lastPartBytes = partBuffer.toBytes();
-
-          partMd5Sink!.add(lastPartBytes);
-          partMd5Sink.close();
+        if (tag == Sodium.cryptoSecretstreamXchacha20poly1305TagFinal &&
+            bytesInPart > 0) {
+          partMd5Sink!.close();
           final digest = partAccumulator!.events.single;
           partMd5s.add(base64.encode(digest.bytes));
-
-          outSink.add(lastPartBytes);
-          partBuffer.clear();
         }
       }
     }


### PR DESCRIPTION
Streams multipart checksum calculation directly from encrypted chunks instead of buffering and copying each complete part.

At the current 20 MiB part size, an isolated checksum benchmark on 512 MiB of data reduced peak memory from ~132 MiB to ~46 MiB (65%) and processing time by ~9%.

Checksums matched the buffered implementation at exact and partial part boundaries, and the encrypted output decrypted successfully.