### PR TITLE
[server] Clean up completed multipart uploads

### DIFF
--- a/server/pkg/controller/object_cleanup.go
+++ b/server/pkg/controller/object_cleanup.go
@@ -146,9 +146,11 @@ func (c *ObjectCleanupController) removeUnreportedObject(tx *sql.Tx, t ente.Temp
 
 	if t.IsMultipart {
 		err = c.abortMultipartUpload(t.ObjectKey, t.UploadID, dc)
-	} else {
-		err = c.DeleteObjectFromDataCenter(t.ObjectKey, dc)
+		if err != nil {
+			return skip(err)
+		}
 	}
+	err = c.DeleteObjectFromDataCenter(t.ObjectKey, dc)
 	if err != nil {
 		return skip(err)
 	}


### PR DESCRIPTION
Completed multipart uploads cannot be removed by aborting them, so cleanup must also delete the object before removing its temporary-object row.

The registration rollback merged in #12324 now makes this safe when cleanup and registration overlap: if cleanup wins the temporary-row race, registration rolls back instead of committing a reference to the deleted object.