### PR TITLE
Update ONNX Runtime to 1.28.1

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -4,7 +4,6 @@ on:
     pull_request:
         paths:
             - ".github/workflows/rust-test.yml"
-            - "infra/ml/test/ml_indexing/assets.json"
             - "rust/**"
             - "server/**"
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -4,6 +4,7 @@ on:
     pull_request:
         paths:
             - ".github/workflows/rust-test.yml"
+            - "infra/ml/test/ml_indexing/assets.json"
             - "rust/**"
             - "server/**"
 

--- a/android/apps/ensu/gradle/verification-metadata.xml
+++ b/android/apps/ensu/gradle/verification-metadata.xml
@@ -18,9 +18,9 @@
       </trusted-artifacts>
    </configuration>
    <components>
-      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.0-r3">
-         <artifact name="onnxruntime-webgpu-android-1.28.0-r3.aar">
-            <sha256 value="1d268652c6c8392581a06eef889a2823f88ce006633cd76106ca27aade27f193"/>
+      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.1-r1">
+         <artifact name="onnxruntime-webgpu-android-1.28.1-r1.aar">
+            <sha256 value="c7926c66eb7eee75b95297b20fa28c76417f06cba2d20f6877817fd7efd2e2bd"/>
          </artifact>
       </component>
    </components>

--- a/android/apps/ensu/rust/build.gradle.kts
+++ b/android/apps/ensu/rust/build.gradle.kts
@@ -135,5 +135,5 @@ dependencies {
     // Custom WebGPU/XNNPACK build; the Rust runtime dynamically loads its
     // libonnxruntime.so. Resolved from the Ivy repository declared in
     // settings.gradle.kts and SHA-256 pinned in gradle/verification-metadata.xml.
-    api("io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.0-r3@aar")
+    api("io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.1-r1@aar")
 }

--- a/apple/packages/EnteOnnxRuntime/EnteOnnxRuntime.podspec
+++ b/apple/packages/EnteOnnxRuntime/EnteOnnxRuntime.podspec
@@ -5,14 +5,14 @@
 # XCFramework's static archive for the active platform via ORT_LIB_PATH.
 Pod::Spec.new do |s|
   s.name     = 'EnteOnnxRuntime'
-  s.version  = '1.28.0-r3'
+  s.version  = '1.28.1-r1'
   s.summary  = "Ente's custom prebuilt ONNX Runtime static-library XCFramework for iOS."
   s.homepage = 'https://github.com/ente/ort-packaging'
   s.authors  = { 'Ente' => 'engineering@ente.io' }
   s.license  = { :type => 'MIT', :file => 'ONNXRUNTIME-LICENSE' }
   s.source   = {
-    :http   => 'https://github.com/ente/ort-packaging/releases/download/ort-1.28.0-r3/onnxruntime-coreml-ios-1.28.0-r3.zip',
-    :sha256 => 'cb9d2ca4ad1b463c8396882d878787918343da087dfc150cc09f067d0ea92834',
+    :http   => 'https://github.com/ente/ort-packaging/releases/download/ort-1.28.1-r1/onnxruntime-coreml-ios-1.28.1-r1.zip',
+    :sha256 => '774b986bdd8a9f729a3e80ce7f7e7e695f0387be6f66633feaa9835c05e8557e',
   }
 
   s.platform = :ios, '15.1'

--- a/apple/packages/EnteOnnxRuntime/Package.swift
+++ b/apple/packages/EnteOnnxRuntime/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "onnxruntime",
-            url: "https://github.com/ente/ort-packaging/releases/download/ort-1.28.0-r3/onnxruntime-coreml-ios-1.28.0-r3.zip",
-            checksum: "cb9d2ca4ad1b463c8396882d878787918343da087dfc150cc09f067d0ea92834"
+            url: "https://github.com/ente/ort-packaging/releases/download/ort-1.28.1-r1/onnxruntime-coreml-ios-1.28.1-r1.zip",
+            checksum: "774b986bdd8a9f729a3e80ce7f7e7e695f0387be6f66633feaa9835c05e8557e"
         )
     ]
 )

--- a/desktop/scripts/ort.js
+++ b/desktop/scripts/ort.js
@@ -3,7 +3,7 @@ const fsp = require("node:fs/promises");
 const path = require("node:path");
 const { execFileSync } = require("node:child_process");
 
-const ortVersion = "1.28.0-r3";
+const ortVersion = "1.28.1-r1";
 
 // Our packaging enables CoreML on macOS and WebGPU elsewhere.
 const ortReleaseURL = `https://github.com/ente/ort-packaging/releases/download/ort-${ortVersion}`;
@@ -12,17 +12,17 @@ const ortReleaseURL = `https://github.com/ente/ort-packaging/releases/download/o
 // release's .sha256 sidecars.
 const ortAssetSHA256s = {
     "darwin-arm64":
-        "5f5bf25a65756c25ab13b331c90d5b4324e59bb669dfc1b3bf2d060a8760c0f3",
+        "12890a871d0e658dd064be187fa63d27c6b692e69f94d4750532fd8f4d179c1e",
     "darwin-x64":
-        "8be0681d58f0398cf8fbc52cf5a10aa5ee0f7976c45dca81598dd562575a8cdc",
+        "8c96da8568343b5ab496e93d112a5d6126c01e5dcc4e6719219aa678ad6abe25",
     "linux-arm64":
-        "343572e7a09565d517bb2802fed5b27c8a950337dafa99a4d8bc4fe06acb5485",
+        "2eb71ced50e16b4e2d4ab20b924276d50d123417962a7d874a0cdb7f0171c63d",
     "linux-x64":
-        "8478974b222df6ce9069976a4bbf99a89f0604565c350bb9a40565a3ec43e05d",
+        "94e55336214e891e9f648901f0c815f113d1534cecae82ecef9c3828cd73d4f4",
     "win32-arm64":
-        "bb31227878d7684ff1ef80a90bea7e95d4868db91e4751dfa5af6ae9b3b6adcd",
+        "88f6d088a76d6708e34ba769362f298911c53362f1ee5d3c8b918027d85d2028",
     "win32-x64":
-        "d6984f7fafd1d4cd7b3969654e919e148c0b697ffffa64d4f203549615d59877",
+        "88747ac8b6870041c0e09410d1202b4e8911f07150b7d397f66952688d8be5a1",
 };
 
 const ortAssetName = (platform, arch) => {

--- a/desktop/src/main/services/ml-native.ts
+++ b/desktop/src/main/services/ml-native.ts
@@ -30,9 +30,9 @@ const napiTriple = () => {
 const onnxRuntimeLibraryName = () => {
     switch (process.platform) {
         case "darwin":
-            return "libonnxruntime.1.28.0.dylib";
+            return "libonnxruntime.1.28.1.dylib";
         case "linux":
-            return "libonnxruntime.so.1.28.0";
+            return "libonnxruntime.so.1.28.1";
         case "win32":
             return "onnxruntime.dll";
         default:

--- a/infra/ml/test/ml_indexing/assets.json
+++ b/infra/ml/test/ml_indexing/assets.json
@@ -13,25 +13,25 @@
     "sha256": "2def6506e098234abc2e6e10febd820b8e3e66d6ad4c9525cb4f1cec3418f9b6"
   },
   "onnx_runtime": {
-    "version": "1.28.1",
+    "version": "1.28.1-r1",
     "archives": {
       "aarch64-apple-darwin": {
-        "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.28.1/onnxruntime-osx-arm64-1.28.1.tgz",
-        "sha256": "18c853e5c5deba90e244e1b953a65121f23747ba2c04e6743885caa6ce1ea12f",
-        "library_path": "onnxruntime-osx-arm64-1.28.1/lib/libonnxruntime.dylib",
-        "library_sha256": "0686a33bf7a9fa93062ca4827e4e1d06e1cd5ea6f0f37dbe948187df3376ee20"
+        "url": "https://github.com/ente/ort-packaging/releases/download/ort-1.28.1-r1/onnxruntime-coreml-macos-arm64-1.28.1-r1.tar.gz",
+        "sha256": "12890a871d0e658dd064be187fa63d27c6b692e69f94d4750532fd8f4d179c1e",
+        "library_path": "./libonnxruntime.1.28.1.dylib",
+        "library_sha256": "11a4bb659860e56448aae6dfac2cd31eaddf2218588d435eb26d6f79a07b91bc"
       },
       "x86_64-unknown-linux-gnu": {
-        "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.28.1/onnxruntime-linux-x64-1.28.1.tgz",
-        "sha256": "2529aef968d0ad0603365054bc46ebefa7f0fe3bc12f28c5f729c99ddffe2a81",
-        "library_path": "onnxruntime-linux-x64-1.28.1/lib/libonnxruntime.so.1.28.1",
-        "library_sha256": "e38d2cec3d582c41786bdd428865fc017145599666cb7c82410e52496e7e066d"
+        "url": "https://github.com/ente/ort-packaging/releases/download/ort-1.28.1-r1/onnxruntime-webgpu-linux-x64-1.28.1-r1.tar.gz",
+        "sha256": "94e55336214e891e9f648901f0c815f113d1534cecae82ecef9c3828cd73d4f4",
+        "library_path": "./libonnxruntime.so.1.28.1",
+        "library_sha256": "1750d82f5b8c3c4924fd0301de7ac92747e33d852f4748e1e9da97406f257bed"
       },
       "aarch64-unknown-linux-gnu": {
-        "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.28.1/onnxruntime-linux-aarch64-1.28.1.tgz",
-        "sha256": "53bab9a5c6ae198b7be75663b780c64caa388d30257fac458c71fbff0a82e98e",
-        "library_path": "onnxruntime-linux-aarch64-1.28.1/lib/libonnxruntime.so.1.28.1",
-        "library_sha256": "0ce5f75809ba44fdc766b64edf8961014f0ab7ea3686b1be466a61f1474918ac"
+        "url": "https://github.com/ente/ort-packaging/releases/download/ort-1.28.1-r1/onnxruntime-webgpu-linux-arm64-1.28.1-r1.tar.gz",
+        "sha256": "2eb71ced50e16b4e2d4ab20b924276d50d123417962a7d874a0cdb7f0171c63d",
+        "library_path": "./libonnxruntime.so.1.28.1",
+        "library_sha256": "5d801e125ca434b5b699e900ee841d44bf5dbb5a660645265f2fcf71d7dd7bec"
       }
     }
   },

--- a/infra/ml/test/ml_indexing/assets.json
+++ b/infra/ml/test/ml_indexing/assets.json
@@ -13,25 +13,25 @@
     "sha256": "2def6506e098234abc2e6e10febd820b8e3e66d6ad4c9525cb4f1cec3418f9b6"
   },
   "onnx_runtime": {
-    "version": "1.28.0",
+    "version": "1.28.1",
     "archives": {
       "aarch64-apple-darwin": {
-        "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.28.0/onnxruntime-osx-arm64-1.28.0.tgz",
-        "sha256": "1268b359718099bde2cedb55787f182a130067bc4f31e8c88478c445b850d3d8",
-        "library_path": "onnxruntime-osx-arm64-1.28.0/lib/libonnxruntime.dylib",
-        "library_sha256": "dc19bbcb2f5c9fb3c68b4f9248aa0a35065ff702c5dbeae75eac54a74da97b6d"
+        "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.28.1/onnxruntime-osx-arm64-1.28.1.tgz",
+        "sha256": "18c853e5c5deba90e244e1b953a65121f23747ba2c04e6743885caa6ce1ea12f",
+        "library_path": "onnxruntime-osx-arm64-1.28.1/lib/libonnxruntime.dylib",
+        "library_sha256": "0686a33bf7a9fa93062ca4827e4e1d06e1cd5ea6f0f37dbe948187df3376ee20"
       },
       "x86_64-unknown-linux-gnu": {
-        "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.28.0/onnxruntime-linux-x64-1.28.0.tgz",
-        "sha256": "a3e1b79d7bb1bf09696ce675f49e4064e6c81f6202b8225624fff0e93f8d6407",
-        "library_path": "onnxruntime-linux-x64-1.28.0/lib/libonnxruntime.so.1.28.0",
-        "library_sha256": "1461ef7cc3d9e49982591721683cc3e3a55580aeca9a5254e7aac47b75ee4bab"
+        "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.28.1/onnxruntime-linux-x64-1.28.1.tgz",
+        "sha256": "2529aef968d0ad0603365054bc46ebefa7f0fe3bc12f28c5f729c99ddffe2a81",
+        "library_path": "onnxruntime-linux-x64-1.28.1/lib/libonnxruntime.so.1.28.1",
+        "library_sha256": "e38d2cec3d582c41786bdd428865fc017145599666cb7c82410e52496e7e066d"
       },
       "aarch64-unknown-linux-gnu": {
-        "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.28.0/onnxruntime-linux-aarch64-1.28.0.tgz",
-        "sha256": "e15ff8b5d85afe6c144d97c6fd432254bf76a219daaf17658087d6ecb3e8f0bb",
-        "library_path": "onnxruntime-linux-aarch64-1.28.0/lib/libonnxruntime.so.1.28.0",
-        "library_sha256": "f1ec1a08eb99bd6e5401340f0a2b101381bf4694415480291dc13bcaa30f9ec7"
+        "url": "https://github.com/microsoft/onnxruntime/releases/download/v1.28.1/onnxruntime-linux-aarch64-1.28.1.tgz",
+        "sha256": "53bab9a5c6ae198b7be75663b780c64caa388d30257fac458c71fbff0a82e98e",
+        "library_path": "onnxruntime-linux-aarch64-1.28.1/lib/libonnxruntime.so.1.28.1",
+        "library_sha256": "0ce5f75809ba44fdc766b64edf8961014f0ab7ea3686b1be466a61f1474918ac"
       }
     }
   },

--- a/mobile/apps/locker/android/app/build.gradle
+++ b/mobile/apps/locker/android/app/build.gradle
@@ -116,5 +116,5 @@ dependencies {
     // Needed at runtime for Tink since R8 strips these annotations otherwise.
     implementation 'com.google.errorprone:error_prone_annotations:2.24.0'
     // Loaded at runtime via dlopen by the Rust document scanner.
-    implementation 'io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.0-r3@aar'
+    implementation 'io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.1-r1@aar'
 }

--- a/mobile/apps/locker/android/gradle/verification-metadata.xml
+++ b/mobile/apps/locker/android/gradle/verification-metadata.xml
@@ -18,9 +18,9 @@
       </trusted-artifacts>
    </configuration>
    <components>
-      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.0-r3">
-         <artifact name="onnxruntime-webgpu-android-1.28.0-r3.aar">
-            <sha256 value="1d268652c6c8392581a06eef889a2823f88ce006633cd76106ca27aade27f193"/>
+      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.1-r1">
+         <artifact name="onnxruntime-webgpu-android-1.28.1-r1.aar">
+            <sha256 value="c7926c66eb7eee75b95297b20fa28c76417f06cba2d20f6877817fd7efd2e2bd"/>
          </artifact>
       </component>
    </components>

--- a/mobile/apps/locker/ios/Podfile.lock
+++ b/mobile/apps/locker/ios/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
     - Flutter
   - ente_screen_cover (0.0.1):
     - Flutter
-  - EnteOnnxRuntime (1.28.0-r3)
+  - EnteOnnxRuntime (1.28.1-r1)
   - file_picker (0.0.1):
     - DKImagePickerController/PhotoGallery
     - Flutter
@@ -194,7 +194,7 @@ SPEC CHECKSUMS:
   ente_locker_frb: 4509a99affb6399cec6d61bcf7af9676063b091d
   ente_mail: 90753dd584f49ee092759a32d4143ca51db69641
   ente_screen_cover: 6792566774f1c83939f9c1d03ed0a1f1ded45ae4
-  EnteOnnxRuntime: c994300f7ef809dd318664cfd85868ca69b3cd1a
+  EnteOnnxRuntime: 7baa83a95717a6c9c8d0d4599f9f2c90b72d2905
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467

--- a/mobile/apps/photos/android/app/build.gradle
+++ b/mobile/apps/photos/android/app/build.gradle
@@ -199,7 +199,7 @@ dependencies {
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
     // Custom WebGPU/XNNPACK build required by Rust ML, which dynamically
     // loads libonnxruntime.so.
-    implementation 'io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.0-r3@aar'
+    implementation 'io.ente.onnxruntime:onnxruntime-webgpu-android:1.28.1-r1@aar'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/mobile/apps/photos/android/gradle/verification-metadata.xml
+++ b/mobile/apps/photos/android/gradle/verification-metadata.xml
@@ -18,9 +18,9 @@
       </trusted-artifacts>
    </configuration>
    <components>
-      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.0-r3">
-         <artifact name="onnxruntime-webgpu-android-1.28.0-r3.aar">
-            <sha256 value="1d268652c6c8392581a06eef889a2823f88ce006633cd76106ca27aade27f193"/>
+      <component group="io.ente.onnxruntime" name="onnxruntime-webgpu-android" version="1.28.1-r1">
+         <artifact name="onnxruntime-webgpu-android-1.28.1-r1.aar">
+            <sha256 value="c7926c66eb7eee75b95297b20fa28c76417f06cba2d20f6877817fd7efd2e2bd"/>
          </artifact>
       </component>
    </components>

--- a/mobile/apps/photos/ios/Podfile.lock
+++ b/mobile/apps/photos/ios/Podfile.lock
@@ -30,7 +30,7 @@ PODS:
     - Flutter
   - ente_screen_cover (0.0.1):
     - Flutter
-  - EnteOnnxRuntime (1.28.0-r3)
+  - EnteOnnxRuntime (1.28.1-r1)
   - ffmpeg_kit_custom (6.0.3)
   - ffmpeg_kit_flutter (6.0.3):
     - ffmpeg_kit_custom
@@ -456,7 +456,7 @@ SPEC CHECKSUMS:
   ente_qr: 86beaf5d2644705db9b565b32dd8b82c05fb36af
   ente_screen_brightness: 7dd13c361508ee6098a2578908ebf35e9f567e28
   ente_screen_cover: 6792566774f1c83939f9c1d03ed0a1f1ded45ae4
-  EnteOnnxRuntime: c994300f7ef809dd318664cfd85868ca69b3cd1a
+  EnteOnnxRuntime: 7baa83a95717a6c9c8d0d4599f9f2c90b72d2905
   ffmpeg_kit_custom: 682b4f2f1ff1f8abae5a92f6c3540f2441d5be99
   ffmpeg_kit_flutter: 915b345acc97d4142e8a9a8549d177ff10f043f5
   file_saver: 6cdbcddd690cb02b0c1a0c225b37cd805c2bf8b6


### PR DESCRIPTION
## Summary

- update apps to ORT v1.28.1
- Make sure Rust ML parity tests run using the matching Ente ORT builds

## Note

PyPI does not publish an `onnxruntime==1.28.1` package, so the Python ground-truth harness and playground remain on Microsoft’s official `1.28.0` wheel.

## Validation

- `cargo test -p ente-ml --test ml_indexing --features ml-assets -- --nocapture`