### PR TITLE
[server] Roll back file registration when cleanup wins

### DIFF
--- a/server/pkg/controller/file.go
+++ b/server/pkg/controller/file.go
@@ -303,20 +303,15 @@ func (c *FileController) Update(ctx context.Context, userID int64, file ente.Fil
 	if err != nil {
 		return response, stacktrace.Propagate(err, "")
 	}
-	// iOS may retry after backgrounding before receiving a successful response.
-	// Only matching object keys and total size make the update a duplicate.
-	isDuplicateRequest := false
-	if existingThumbnailObjectKey == file.Thumbnail.ObjectKey &&
-		existingFileObjectKey == file.File.ObjectKey &&
-		diff == 0 {
-		isDuplicateRequest = true
-	}
-	oldObjects := make([]string, 0)
+	oldObjects := make([]string, 0, 2)
+	stagedObjects := make([]string, 0, 2)
 	if existingThumbnailObjectKey != file.Thumbnail.ObjectKey {
 		oldObjects = append(oldObjects, existingThumbnailObjectKey)
+		stagedObjects = append(stagedObjects, file.Thumbnail.ObjectKey)
 	}
 	if existingFileObjectKey != file.File.ObjectKey {
 		oldObjects = append(oldObjects, existingFileObjectKey)
+		stagedObjects = append(stagedObjects, file.File.ObjectKey)
 	}
 	if file.Info != nil {
 		file.Info.FileSize = fileSize
@@ -327,7 +322,7 @@ func (c *FileController) Update(ctx context.Context, userID int64, file ente.Fil
 			ThumbnailSize: thumbnailSize,
 		}
 	}
-	err = c.FileRepo.Update(file, fileSize, thumbnailSize, diff, oldObjects, isDuplicateRequest)
+	err = c.FileRepo.Update(file, fileSize, thumbnailSize, diff, oldObjects, stagedObjects)
 	if err != nil {
 		return response, stacktrace.Propagate(err, "")
 	}

--- a/server/pkg/controller/object_cleanup_test.go
+++ b/server/pkg/controller/object_cleanup_test.go
@@ -1,0 +1,195 @@
+package controller
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/internal/testutil"
+	"github.com/ente/museum/pkg/repo"
+	"github.com/ente/museum/pkg/utils/config"
+	"github.com/ente/museum/pkg/utils/s3config"
+	"github.com/spf13/viper"
+)
+
+func TestFileRegistrationRollsBackWhenCleanupWins(t *testing.T) {
+	cleanupDeleting := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	var blockCleanup sync.Once
+	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			blockCleanup.Do(func() {
+				close(cleanupDeleting)
+				<-releaseCleanup
+			})
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodHead:
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(s3Server.Close)
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseCleanup) }) }
+
+	cleanupController, fileRepo, db := setupObjectCleanupRaceTest(t, s3Server.URL)
+	t.Cleanup(release)
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{
+		UserID:       1,
+		Email:        "cleanup-race-owner@ente.com",
+		CreationTime: 1,
+	})
+	collectionID := insertObjectCleanupTestCollection(t, db, ownerID)
+	const fileObjectKey = "1/cleanup-race-file"
+	const thumbnailObjectKey = "1/cleanup-race-thumbnail"
+	if _, err := db.Exec(`
+		INSERT INTO temp_objects(object_key, expiration_time, bucket_id)
+		VALUES ($1, 0, 'b2-eu-cen'), ($2, 0, 'b2-eu-cen')`, fileObjectKey, thumbnailObjectKey); err != nil {
+		t.Fatalf("failed to stage objects: %v", err)
+	}
+
+	cleanupDone := make(chan int, 1)
+	go func() { cleanupDone <- cleanupController.removeUnreportedObjects() }()
+	select {
+	case <-cleanupDeleting:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup did not reach object deletion")
+	}
+
+	registrationDone := make(chan error, 1)
+	go func() {
+		_, _, err := fileRepo.Create(ente.File{
+			OwnerID:            ownerID,
+			CollectionID:       collectionID,
+			EncryptedKey:       "encrypted-key",
+			KeyDecryptionNonce: "key-nonce",
+			File: ente.FileAttributes{
+				ObjectKey:        fileObjectKey,
+				DecryptionHeader: "file-header",
+			},
+			Thumbnail: ente.FileAttributes{
+				ObjectKey:        thumbnailObjectKey,
+				DecryptionHeader: "thumbnail-header",
+			},
+			Metadata: ente.FileAttributes{
+				EncryptedData:    "encrypted-metadata",
+				DecryptionHeader: "metadata-header",
+			},
+			UpdationTime: 1,
+			Info:         &ente.FileInfo{FileSize: 100, ThumbnailSize: 10},
+		}, 100, 10, 110, ownerID, ente.Photos)
+		registrationDone <- err
+	}()
+	waitForTempObjectDeleteLock(t, db)
+	release()
+
+	select {
+	case count := <-cleanupDone:
+		if count != 2 {
+			t.Fatalf("cleanup removed %d objects, want 2", count)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup did not finish")
+	}
+	select {
+	case err := <-registrationDone:
+		var apiErr *ente.ApiError
+		if !errors.As(err, &apiErr) || apiErr.Message != "staged upload not found" {
+			t.Fatalf("registration error = %v, want staged upload not found", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("registration did not finish")
+	}
+
+	var files, objectKeys, collectionFiles, tempObjects int
+	if err := db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM files WHERE owner_id = $1),
+		(SELECT COUNT(*) FROM object_keys WHERE object_key IN ($2, $3)),
+		(SELECT COUNT(*) FROM collection_files WHERE collection_id = $4),
+		(SELECT COUNT(*) FROM temp_objects WHERE object_key IN ($2, $3))`,
+		ownerID, fileObjectKey, thumbnailObjectKey, collectionID,
+	).Scan(&files, &objectKeys, &collectionFiles, &tempObjects); err != nil {
+		t.Fatalf("failed to read registration state: %v", err)
+	}
+	if files != 0 || objectKeys != 0 || collectionFiles != 0 || tempObjects != 0 {
+		t.Fatalf("unexpected registration state: files=%d object_keys=%d collection_files=%d temp_objects=%d",
+			files, objectKeys, collectionFiles, tempObjects)
+	}
+}
+
+func waitForTempObjectDeleteLock(t *testing.T, db *sql.DB) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var waiting bool
+		err := db.QueryRow(`SELECT EXISTS(
+			SELECT 1 FROM pg_stat_activity
+			WHERE datname = current_database()
+			  AND pid <> pg_backend_pid()
+			  AND wait_event_type = 'Lock'
+			  AND query LIKE '%DELETE FROM temp_objects%'
+		)`).Scan(&waiting)
+		if err != nil {
+			t.Fatalf("failed to inspect registration lock wait: %v", err)
+		}
+		if waiting {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("registration did not wait for the temporary-object lock")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func setupObjectCleanupRaceTest(t *testing.T, endpoint string) (*ObjectCleanupController, *repo.FileRepository, *sql.DB) {
+	t.Helper()
+	testutil.WithServerRoot(t)
+	viper.Reset()
+	if err := config.ConfigureViper("local"); err != nil {
+		t.Fatal(err)
+	}
+	viper.Set("s3.b2-eu-cen.key", "test-key")
+	viper.Set("s3.b2-eu-cen.secret", "test-secret")
+	viper.Set("s3.b2-eu-cen.endpoint", endpoint)
+	viper.Set("s3.b2-eu-cen.region", "us-east-1")
+	viper.Set("s3.b2-eu-cen.bucket", "test-bucket")
+	viper.Set("s3.b2-eu-cen.disable_ssl", true)
+	viper.Set("s3.use_path_style_urls", true)
+	t.Cleanup(viper.Reset)
+
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() { testutil.ResetTables(t, db) })
+	s3Config := s3config.NewS3Config()
+	objectRepo := &repo.ObjectRepository{DB: db}
+	objectCleanupRepo := &repo.ObjectCleanupRepository{DB: db}
+	return NewObjectCleanupController(objectCleanupRepo, objectRepo, s3Config), &repo.FileRepository{
+		DB:                db,
+		S3Config:          s3Config,
+		QueueRepo:         &repo.QueueRepository{DB: db},
+		ObjectRepo:        objectRepo,
+		ObjectCleanupRepo: objectCleanupRepo,
+		ObjectCopiesRepo:  &repo.ObjectCopiesRepository{DB: db},
+	}, db
+}
+
+func insertObjectCleanupTestCollection(t *testing.T, db *sql.DB, ownerID int64) int64 {
+	t.Helper()
+	var collectionID int64
+	err := db.QueryRow(`
+		INSERT INTO collections(owner_id, encrypted_key, key_decryption_nonce, name, type, attributes, updation_time, app)
+		VALUES($1, 'encrypted-key', 'key-nonce', 'Cleanup race', 'album', '{}', 1, 'photos')
+		RETURNING collection_id`, ownerID).Scan(&collectionID)
+	if err != nil {
+		t.Fatalf("failed to insert collection: %v", err)
+	}
+	return collectionID
+}

--- a/server/pkg/repo/file.go
+++ b/server/pkg/repo/file.go
@@ -256,9 +256,12 @@ func (repo *FileRepository) ResetNeedsReplication(file ente.File, hotDC string) 
 	}
 }
 
-func (repo *FileRepository) Update(file ente.File, fileSize int64, thumbnailSize int64, usageDiff int64, oldObjects []string, isDuplicateRequest bool) error {
+func (repo *FileRepository) Update(file ente.File, fileSize int64, thumbnailSize int64, usageDiff int64, oldObjects []string, stagedObjects []string) error {
 	hotDC := repo.S3Config.GetHotDataCenter()
 	dcsForNewEntry := pq.StringArray{hotDC}
+	// iOS may retry after backgrounding before receiving a successful response.
+	// Only matching object keys and total size make the update a duplicate.
+	isDuplicateRequest := len(stagedObjects) == 0 && usageDiff == 0
 
 	ctx := context.Background()
 	tx, err := repo.DB.BeginTx(ctx, nil)
@@ -323,15 +326,11 @@ func (repo *FileRepository) Update(file ente.File, fileSize int64, thumbnailSize
 		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
-	err = repo.ObjectCleanupRepo.RemoveTempObjectKey(ctx, tx, file.File.ObjectKey, hotDC)
-	if err != nil {
-		tx.Rollback()
-		return stacktrace.Propagate(err, "")
-	}
-	err = repo.ObjectCleanupRepo.RemoveTempObjectKey(ctx, tx, file.Thumbnail.ObjectKey, hotDC)
-	if err != nil {
-		tx.Rollback()
-		return stacktrace.Propagate(err, "")
+	for _, objectKey := range stagedObjects {
+		if err = repo.ObjectCleanupRepo.RemoveTempObjectKey(ctx, tx, objectKey, hotDC); err != nil {
+			tx.Rollback()
+			return stacktrace.Propagate(err, "")
+		}
 	}
 	if isDuplicateRequest {
 		// Re-inserting object_copies on a duplicate request violates its primary
@@ -481,10 +480,11 @@ func (repo *FileRepository) UpdateThumbnail(ctx context.Context, fileID int64, u
 		return stacktrace.Propagate(err, "")
 	}
 
-	err = repo.ObjectCleanupRepo.RemoveTempObjectKey(ctx, tx, thumbnail.ObjectKey, hotDC)
-	if err != nil {
-		tx.Rollback()
-		return stacktrace.Propagate(err, "")
+	if oldThumbnailObject != nil {
+		if err = repo.ObjectCleanupRepo.RemoveTempObjectKey(ctx, tx, thumbnail.ObjectKey, hotDC); err != nil {
+			tx.Rollback()
+			return stacktrace.Propagate(err, "")
+		}
 	}
 	err = repo.markThumbnailAsNeedingReplication(ctx, tx, thumbnail.ObjectKey, hotDC)
 	if err != nil {

--- a/server/pkg/repo/object_cleanup.go
+++ b/server/pkg/repo/object_cleanup.go
@@ -35,8 +35,18 @@ func (repo *ObjectCleanupRepository) AddTempObject(tempObject ente.TempObject, e
 }
 
 func (repo *ObjectCleanupRepository) RemoveTempObjectKey(ctx context.Context, tx *sql.Tx, objectKey string, dc string) error {
-	_, err := tx.ExecContext(ctx, `DELETE FROM temp_objects WHERE object_key = $1`, objectKey)
-	return stacktrace.Propagate(err, "")
+	res, err := tx.ExecContext(ctx, `DELETE FROM temp_objects WHERE object_key = $1`, objectKey)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	if rowsAffected != 1 {
+		return stacktrace.Propagate(ente.NewBadRequestWithMessage("staged upload not found"), "")
+	}
+	return nil
 }
 
 func (repo *ObjectCleanupRepository) RemoveTempObjectFromDC(ctx context.Context, tx *sql.Tx, objectKey string, dc string) error {


### PR DESCRIPTION
File and thumbnail registration could race with background cleanup. Their database writes were transactional, but cleanup could lock and delete an expired temporary object before registration reached its own delete. Registration did not check whether that delete removed a row, so it could then commit a reference to an object already deleted from storage.

This change requires fresh file creation to remove the temporary rows for both objects. File updates remove exactly one temporary row for each object key that changed; unchanged objects and recognized duplicate requests do not require an already-consumed temporary row. If cleanup wins for a changed object, registration returns “staged upload not found” and rolls back the transaction. File-data and contact-attachment registration already enforce the deletion check and are unchanged.

The full-flow test uses real PostgreSQL and the real cleanup and file-creation paths; only S3 is replaced by a local HTTP server. It verifies that registration waits while cleanup owns the expired file and thumbnail rows. After cleanup wins, registration fails, no file, object-key, or collection-file rows are committed, and both temporary rows are gone.

This fixes an existing risk for ordinary uploads and is required before #12320 can safely delete completed multipart uploads.