### PR TITLE
[server] Improve authentication request handling

### DIFF
--- a/server/pkg/controller/user/twofactor.go
+++ b/server/pkg/controller/user/twofactor.go
@@ -142,6 +142,9 @@ func (c *UserController) VerifyTwoFactor(context *gin.Context, sessionID string,
 		go c.DiscordController.NotifyPotentialAbuse(msg)
 		return ente.TwoFactorAuthorizationResponse{}, stacktrace.Propagate(ente.ErrIncorrectTOTP, "OTP code has already been used")
 	}
+	if err = c.TwoFactorRepo.ConsumeTwoFactorSession(sessionID); err != nil {
+		return ente.TwoFactorAuthorizationResponse{}, stacktrace.Propagate(err, "")
+	}
 
 	response, err := c.GetKeyAttributeAndToken(context, userID)
 	if err != nil {
@@ -184,6 +187,9 @@ func (c *UserController) RemoveTOTPTwoFactor(context *gin.Context, sessionID str
 	}
 	if !exists {
 		return nil, stacktrace.Propagate(ente.ErrPermissionDenied, "")
+	}
+	if err = c.TwoFactorRepo.ConsumeTwoFactorSession(sessionID); err != nil {
+		return nil, stacktrace.Propagate(err, "")
 	}
 	err = c.TwoFactorRepo.UpdateTwoFactorStatus(userID, false)
 	if err != nil {

--- a/server/pkg/controller/user/twofactor_session_test.go
+++ b/server/pkg/controller/user/twofactor_session_test.go
@@ -1,0 +1,119 @@
+package user
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/internal/testutil"
+	"github.com/ente/museum/pkg/repo"
+	"github.com/ente/museum/pkg/utils/crypto"
+	enteTime "github.com/ente/museum/pkg/utils/time"
+	"github.com/gin-gonic/gin"
+	"github.com/pquerna/otp/totp"
+	"golang.org/x/crypto/nacl/box"
+)
+
+func TestTwoFactorSessionIsConsumedOnlyAfterSuccessfulAuthorization(t *testing.T) {
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() { testutil.ResetTables(t, db) })
+
+	const (
+		userID     int64 = 12345
+		totpSecret       = "JBSWY3DPEHPK3PXP"
+	)
+	testutil.InsertUser(t, db, testutil.UserFixture{UserID: userID, Email: "totp@example.com", CreationTime: 1})
+	if _, err := db.Exec(`UPDATE users SET email_mfa = true WHERE user_id = $1`, userID); err != nil {
+		t.Fatal(err)
+	}
+
+	publicKey, _, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userRepo := &repo.UserRepository{
+		DB:                  db,
+		SecretEncryptionKey: testutil.SecretEncryptionKey(),
+		HashingKey:          testutil.HashingKey(),
+	}
+	if err = userRepo.SetKeyAttributes(userID, ente.KeyAttributes{
+		KEKSalt: "salt", KEKHash: "hash", EncryptedKey: "key", KeyDecryptionNonce: "nonce",
+		PublicKey: base64.StdEncoding.EncodeToString(publicKey[:]), EncryptedSecretKey: "secret-key",
+		SecretKeyDecryptionNonce: "secret-nonce", MemLimit: 1, OpsLimit: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	encryptedSecret, err := crypto.Encrypt(totpSecret, testutil.SecretEncryptionKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secretHash, err := crypto.GetHash(totpSecret, testutil.HashingKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = userRepo.SetTwoFactorSecret(userID, encryptedSecret, secretHash, "recovery-secret", "recovery-nonce"); err != nil {
+		t.Fatal(err)
+	}
+
+	twoFactorRepo := &repo.TwoFactorRepository{DB: db, SecretEncryptionKey: testutil.SecretEncryptionKey()}
+	if err = twoFactorRepo.UpdateTwoFactorStatus(userID, true); err != nil {
+		t.Fatal(err)
+	}
+	controller := &UserController{
+		UserRepo:      userRepo,
+		UserAuthRepo:  &repo.UserAuthRepository{DB: db},
+		TwoFactorRepo: twoFactorRepo,
+		HashingKey:    testutil.HashingKey(),
+	}
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/users/two-factor/verify", nil)
+
+	const verifySessionID = "verify-session"
+	if err = twoFactorRepo.AddTwoFactorSession(userID, verifySessionID, enteTime.Microseconds()+TwoFactorValidityDurationInMicroSeconds); err != nil {
+		t.Fatal(err)
+	}
+	code, err := totp.GenerateCode(totpSecret, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = controller.VerifyTwoFactor(context, verifySessionID, code); err != nil {
+		t.Fatalf("verification failed: %v", err)
+	}
+	var sessionExists bool
+	if err = db.QueryRow(`SELECT EXISTS(SELECT 1 FROM two_factor_sessions WHERE session_id = $1)`, verifySessionID).Scan(&sessionExists); err != nil {
+		t.Fatal(err)
+	}
+	if sessionExists {
+		t.Fatal("verification session was not consumed")
+	}
+
+	const recoverySessionID = "recovery-session"
+	if err = twoFactorRepo.AddTwoFactorSession(userID, recoverySessionID, enteTime.Microseconds()+TwoFactorValidityDurationInMicroSeconds); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = controller.VerifyTwoFactor(context, recoverySessionID, "invalid"); !errors.Is(err, ente.ErrIncorrectTOTP) {
+		t.Fatalf("invalid verification error = %v, want incorrect TOTP", err)
+	}
+	if err = db.QueryRow(`SELECT EXISTS(SELECT 1 FROM two_factor_sessions WHERE session_id = $1)`, recoverySessionID).Scan(&sessionExists); err != nil {
+		t.Fatal(err)
+	}
+	if !sessionExists {
+		t.Fatal("failed verification consumed the session")
+	}
+	if _, err = controller.RemoveTOTPTwoFactor(context, recoverySessionID, totpSecret); err != nil {
+		t.Fatalf("recovery failed: %v", err)
+	}
+	if err = db.QueryRow(`SELECT EXISTS(SELECT 1 FROM two_factor_sessions WHERE session_id = $1)`, recoverySessionID).Scan(&sessionExists); err != nil {
+		t.Fatal(err)
+	}
+	if sessionExists {
+		t.Fatal("recovery session was not consumed")
+	}
+}

--- a/server/pkg/middleware/event_test.go
+++ b/server/pkg/middleware/event_test.go
@@ -34,6 +34,12 @@ func TestAccountRecoveryTokensAreNotLogged(t *testing.T) {
 	require.False(t, shouldSkipBodyLog(http.MethodGet, "/users/recover-account"))
 }
 
+func TestAuthenticationSecretsAreNotLogged(t *testing.T) {
+	require.True(t, shouldSkipBodyLog(http.MethodPost, "/users/verify-email"))
+	require.True(t, shouldSkipBodyLog(http.MethodPost, "/users/change-email"))
+	require.True(t, shouldSkipBodyLog(http.MethodPost, "/users/two-factor/verify"))
+}
+
 func TestEventsShareGlobalRateLimitAcrossPublicAndAuthenticatedRoutes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rateLimiter := &RateLimitMiddleware{

--- a/server/pkg/middleware/event_test.go
+++ b/server/pkg/middleware/event_test.go
@@ -34,12 +34,6 @@ func TestAccountRecoveryTokensAreNotLogged(t *testing.T) {
 	require.False(t, shouldSkipBodyLog(http.MethodGet, "/users/recover-account"))
 }
 
-func TestAuthenticationSecretsAreNotLogged(t *testing.T) {
-	require.True(t, shouldSkipBodyLog(http.MethodPost, "/users/verify-email"))
-	require.True(t, shouldSkipBodyLog(http.MethodPost, "/users/change-email"))
-	require.True(t, shouldSkipBodyLog(http.MethodPost, "/users/two-factor/verify"))
-}
-
 func TestEventsShareGlobalRateLimitAcrossPublicAndAuthenticatedRoutes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rateLimiter := &RateLimitMiddleware{

--- a/server/pkg/middleware/recover.go
+++ b/server/pkg/middleware/recover.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -49,25 +48,16 @@ func PanicRecover() gin.HandlerFunc {
 					}
 				}
 
-				httpRequest, _ := httputil.DumpRequest(c.Request, false)
-				requestData := strings.Split(string(httpRequest), "\r\n")
-				for idx, header := range requestData {
-					current := strings.Split(header, ":")
-					if current[0] == "Authorization" || current[0] == "X-Auth-Token" || current[0] == "X-Space-Session-Token" || current[0] == "X-Ente-Space-Link-Auth" {
-						requestData[idx] = current[0] + ": *"
-					}
-				}
-				reqDataWithoutAuthHeaders := strings.Join(requestData, "\r\n")
-				var logWithAttributes = log.WithFields(log.Fields{
-					"request_data": reqDataWithoutAuthHeaders,
-					"req_id":       requestid.Get(c),
-					"req_uri":      c.Request.URL.Path,
-					"panic":        err,
-					"broken_pipe":  brokenPipe,
-					"stack":        string(debug.Stack()),
+				logWithAttributes := log.WithFields(log.Fields{
+					"req_id":      requestid.Get(c),
+					"req_method":  c.Request.Method,
+					"req_uri":     c.Request.URL.Path,
+					"panic":       err,
+					"broken_pipe": brokenPipe,
+					"stack":       string(debug.Stack()),
 				})
 				if brokenPipe {
-					log.Warn("Panic Recovery: Broken pipe")
+					logWithAttributes.Warn("Panic Recovery: Broken pipe")
 					// If the connection is dead, we can't write a status to it.
 					c.Error(err.(error)) // nolint: errcheck
 					c.Abort()

--- a/server/pkg/middleware/request_logger.go
+++ b/server/pkg/middleware/request_logger.go
@@ -44,11 +44,14 @@ func shouldSkipBodyLog(method string, path string) bool {
 	isReadOnly := method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	if !isReadOnly {
 		switch path {
-		case "/users/srp/setup",
+		case "/users/change-email",
+			"/users/srp/setup",
+			"/users/two-factor/verify",
 			"/users/two-factor/remove",
 			"/users/two-factor/passkeys/begin",
 			"/users/two-factor/passkeys/finish",
 			"/users/two-factor/passkeys/configure-recovery",
+			"/users/verify-email",
 			"/emergency-contacts/init-change-password",
 			"/legacy-kits/recovery/open",
 			"/legacy-kits/recovery/session",

--- a/server/pkg/middleware/request_logger.go
+++ b/server/pkg/middleware/request_logger.go
@@ -44,8 +44,12 @@ func shouldSkipBodyLog(method string, path string) bool {
 	isReadOnly := method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions
 	if !isReadOnly {
 		switch path {
-		case "/users/change-email",
+		case "/users/attributes",
+			"/users/change-email",
 			"/users/srp/setup",
+			"/users/srp/update",
+			"/users/srp/verify-session",
+			"/users/two-factor/enable",
 			"/users/two-factor/verify",
 			"/users/two-factor/remove",
 			"/users/two-factor/passkeys/begin",

--- a/server/pkg/repo/twofactor.go
+++ b/server/pkg/repo/twofactor.go
@@ -55,6 +55,14 @@ func (repo *TwoFactorRepository) GetUserIDWithTwoFactorSession(sessionID string)
 	return id, nil
 }
 
+func (repo *TwoFactorRepository) ConsumeTwoFactorSession(sessionID string) error {
+	var userID int64
+	err := repo.DB.QueryRow(`DELETE FROM two_factor_sessions
+		WHERE session_id = $1 AND expiration_time > $2
+		RETURNING user_id`, sessionID, time.Microseconds()).Scan(&userID)
+	return stacktrace.Propagate(err, "Failed to consume two-factor session")
+}
+
 func (repo *TwoFactorRepository) GetRecoveryKeyEncryptedTwoFactorSecret(userID int64) (ente.TwoFactorRecoveryResponse, error) {
 	var response ente.TwoFactorRecoveryResponse
 	row := repo.DB.QueryRow(`SELECT recovery_encrypted_two_factor_secret, recovery_two_factor_secret_decryption_nonce FROM two_factor WHERE user_id = $1`, userID)


### PR DESCRIPTION
Avoid logging request data for panic paths and additional authentication endpoints, and complete TOTP sessions after successful authorization.