### PR TITLE
[mob][auth] Use Ente Auth as Linux launcher name

### DIFF
--- a/mobile/apps/auth/linux/packaging/enteauth.desktop
+++ b/mobile/apps/auth/linux/packaging/enteauth.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Auth
+Name=Ente Auth
 GenericName=Ente Authenticator
 Exec=enteauth %U
 Icon=io.ente.auth


### PR DESCRIPTION
Fixes #3487