### PR TITLE
[server] Support session preferences during account recovery

### DIFF
--- a/server/pkg/controller/emergency/recovery.go
+++ b/server/pkg/controller/emergency/recovery.go
@@ -61,7 +61,8 @@ func (c *Controller) ChangePassword(ctx *gin.Context, userID int64, request ente
 	if disableErr := c.PasskeyController.RemovePasskey2FA(contact.UserID); disableErr != nil {
 		return nil, stacktrace.Propagate(disableErr, "failed to disable passkey")
 	}
-	resp, err := c.UserCtrl.UpdateSrpAndKeyAttributes(ctx, contact.UserID, request.UpdateSrp, false)
+	logOutAllSessions := request.UpdateSrp.LogOutOtherDevices == nil || *request.UpdateSrp.LogOutOtherDevices
+	resp, err := c.UserCtrl.RecoverSrpAndKeyAttributes(ctx, contact.UserID, request.UpdateSrp, logOutAllSessions)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}

--- a/server/pkg/controller/legacy_kit/controller.go
+++ b/server/pkg/controller/legacy_kit/controller.go
@@ -298,7 +298,8 @@ func (c *Controller) ChangePassword(ctx *gin.Context, req ente.LegacyKitRecovery
 	if err := c.PasskeyController.RemovePasskey2FA(session.UserID); err != nil {
 		return nil, stacktrace.Propagate(err, "failed to disable passkeys")
 	}
-	resp, err := c.UserCtrl.UpdateSrpAndKeyAttributes(ctx, session.UserID, req.UpdateSrpAndKeysRequest, false)
+	logOutAllSessions := req.UpdateSrpAndKeysRequest.LogOutOtherDevices == nil || *req.UpdateSrpAndKeysRequest.LogOutOtherDevices
+	resp, err := c.UserCtrl.RecoverSrpAndKeyAttributes(ctx, session.UserID, req.UpdateSrpAndKeysRequest, logOutAllSessions)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to update password via legacy kit")
 	}

--- a/server/pkg/controller/user/srp.go
+++ b/server/pkg/controller/user/srp.go
@@ -27,6 +27,13 @@ const (
 	FakeVerifier = "RNYLOgdzKsbhRWN8OoD05kNpfbqb9uASHYpaLrYLYVemCV0pf4fBgo+25jeu8SaVMQhlkyIF2BgGXX4uzy8Pmwq1ocqt8DsGk0DrlOE1AV9ogaY3myoTjXTQG5dU/hTywylKJYdpWSEyzMMLbWcuO8ldS6uzYXqK+jbfEDDj8k4PqLx1715BPgigNydCbD7/VtwaMhQ8MEygiW/2PbieeqUzuCqEWfwu0uytPM9LiuHH7DT3k2fELFOoPWs3KQAhk6rmM17JOLm8Qvt+xGU6nJZKzTNPxw9o4H4FvlGmsEYUdTP+WPdWpzcton6BowCXKN9G3hZx10OUzBuePHFNKjDlaSLpJXVclLWmza6aDBpjKahayW2UvdQw1tSonyFUjJOanocrPEoHthHUjUGXkeRqcaU4CV9KLQFaHqnHTYc9uJKuYl/tcYoWXuHrZ0cFYRpc6qf/gBCuuwkhTXXsJxTlepe5x0gqgQb7mD5y+dvINks/gpO/3x4T4RkQcyoonsOZv2uLIBr3D6Ede9/aJstIkMh3dTEpDWdw8tEaO7ZjqEwKXVA+/fquJ7P8B3fcIvPy8UZOpwAYtWSPh3OYzijG7WFXu+ajPBqkVI1OBSCYOlTQlPXyrv7myiD8/FXJep5IDPeuJsmGrLPJXBZjPKWR0ISBWol5KTYWE2EllYQ="
 )
 
+type sessionRevocationScope int
+
+const (
+	revokeOtherSessions sessionRevocationScope = iota
+	revokeAllSessions
+)
+
 func (c *UserController) SetupSRP(context *gin.Context, userID int64, req ente.SetupSRPRequest) (*ente.SetupSRPResponse, error) {
 	srpB, sessionID, err := c.createAndInsertSRPSession(context, req.SrpUserID, req.SRPVerifier, req.SRPA)
 	if err != nil {
@@ -68,6 +75,23 @@ func (c *UserController) UpdateSrpAndKeyAttributes(context *gin.Context,
 	req ente.UpdateSRPAndKeysRequest,
 	shouldClearTokens bool,
 ) (*ente.UpdateSRPSetupResponse, error) {
+	return c.updateSrpAndKeyAttributes(context, userID, req, shouldClearTokens, revokeOtherSessions)
+}
+
+func (c *UserController) RecoverSrpAndKeyAttributes(context *gin.Context,
+	userID int64,
+	req ente.UpdateSRPAndKeysRequest,
+	logOutAllSessions bool,
+) (*ente.UpdateSRPSetupResponse, error) {
+	return c.updateSrpAndKeyAttributes(context, userID, req, logOutAllSessions, revokeAllSessions)
+}
+
+func (c *UserController) updateSrpAndKeyAttributes(context *gin.Context,
+	userID int64,
+	req ente.UpdateSRPAndKeysRequest,
+	shouldClearTokens bool,
+	revocationScope sessionRevocationScope,
+) (*ente.UpdateSRPSetupResponse, error) {
 	setup, err := c.UserAuthRepo.GetTempSRPSetupEntity(context, req.SetupID)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
@@ -87,8 +111,11 @@ func (c *UserController) UpdateSrpAndKeyAttributes(context *gin.Context,
 	}
 
 	if shouldClearTokens {
-		token := auth.GetToken(context)
-		err = c.RemoveAllOtherTokens(userID, token)
+		if revocationScope == revokeAllSessions {
+			err = c.RemoveAllTokens(userID)
+		} else {
+			err = c.RemoveAllOtherTokens(userID, auth.GetToken(context))
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Allow emergency contact and Legacy Kit recovery requests to choose whether existing sessions remain signed in. Existing sessions are signed out by default when the preference is omitted.