### PR TITLE
[server] Improve request validation and transaction handling

### DIFF
--- a/server/ente/file_link.go
+++ b/server/ente/file_link.go
@@ -16,6 +16,10 @@ type CreateFileUrl struct {
 	EncryptedShareKey     *string `json:"encryptedShareKey,omitempty"`
 }
 
+func (r *CreateFileUrl) Validate() error {
+	return validatePublicLinkKDFParams(r.KdfMemLimit, r.KdfOpsLimit)
+}
+
 type UpdateFileUrl struct {
 	LinkID          string `json:"linkID" binding:"required"`
 	FileID          int64  `json:"fileID" binding:"required"`

--- a/server/ente/public_collection.go
+++ b/server/ente/public_collection.go
@@ -60,6 +60,9 @@ func (ut *UpdatePublicAccessTokenRequest) Validate() error {
 	if !(allPassParamsMissing || allPassParamsPresent) {
 		return NewBadRequestWithMessage("all password params should be either present or missing")
 	}
+	if err := validatePublicLinkKDFParams(ut.MemLimit, ut.OpsLimit); err != nil {
+		return err
+	}
 
 	if allPassParamsPresent && ut.DisablePassword != nil && *ut.DisablePassword {
 		return NewBadRequestWithMessage("can not set and disable password in same request")
@@ -74,6 +77,16 @@ func (ut *UpdatePublicAccessTokenRequest) Validate() error {
 func validatePublicLinkDeviceLimit(deviceLimit int) error {
 	if deviceLimit < 0 || deviceLimit > 50 {
 		return NewBadRequestWithMessage(fmt.Sprintf("device limit: %d out of range [0-50]", deviceLimit))
+	}
+	return nil
+}
+
+func validatePublicLinkKDFParams(memLimit, opsLimit *int64) error {
+	if memLimit == nil && opsLimit == nil {
+		return nil
+	}
+	if memLimit == nil || opsLimit == nil || *memLimit != 67108864 || *opsLimit != 2 {
+		return NewBadRequestWithMessage("invalid KDF parameters")
 	}
 	return nil
 }

--- a/server/pkg/controller/public/file_link.go
+++ b/server/pkg/controller/public/file_link.go
@@ -22,6 +22,9 @@ type FileLinkController struct {
 }
 
 func (c *FileLinkController) CreateLink(ctx *gin.Context, req ente.CreateFileUrl) (*ente.FileUrl, error) {
+	if err := req.Validate(); err != nil {
+		return nil, stacktrace.Propagate(err, "invalid request")
+	}
 	actorUserID := auth.GetUserID(ctx.Request.Header)
 	app := auth.GetApp(ctx)
 	if req.App != app {

--- a/server/pkg/controller/user/srp.go
+++ b/server/pkg/controller/user/srp.go
@@ -282,34 +282,37 @@ func (c *UserController) verifySRPSession(ctx context.Context,
 	if len(srpM1Bytes) != 32 {
 		return nil, ente.NewBadRequestWithMessage(fmt.Sprintf("srpM1 size is %d, expected 32", len(srpM1Bytes)))
 	}
-	srpSession, err := c.UserAuthRepo.GetSrpSessionEntity(ctx, sessionID)
+	srpSession, err := c.UserAuthRepo.ReserveSrpSessionAttempt(ctx, sessionID, 5)
 	if err != nil {
-		// Do not reveal whether the session exists.
-		if errors.Is(err, sql.ErrNoRows) {
-			// Match normal verification timing.
-			time.Sleep(time.Duration(10+mathRand.Intn(20)) * time.Millisecond)
-			return nil, stacktrace.Propagate(ente.ErrInvalidPassword, "session not found")
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, stacktrace.Propagate(err, "")
 		}
-		return nil, stacktrace.Propagate(err, "")
-	}
-
-	if srpSession.IsFake {
-		// Match real-session timing and attempt bookkeeping.
-		time.Sleep(time.Duration(20+mathRand.Intn(30)) * time.Millisecond)
-		_ = c.UserAuthRepo.IncrementSrpSessionAttemptCount(ctx, sessionID)
-		return nil, stacktrace.Propagate(ente.ErrInvalidPassword, "fake session verification")
-	}
-
-	if srpSession.IsVerified {
-		return nil, stacktrace.Propagate(&ente.ApiError{
-			Code:           "SESSION_ALREADY_VERIFIED",
-			HttpStatusCode: http.StatusGone,
-		}, "")
-	} else if srpSession.AttemptCount >= 5 {
+		srpSession, err = c.UserAuthRepo.GetSrpSessionEntity(ctx, sessionID)
+		if err != nil {
+			// Do not reveal whether the session exists.
+			if errors.Is(err, sql.ErrNoRows) {
+				// Match normal verification timing.
+				time.Sleep(time.Duration(10+mathRand.Intn(20)) * time.Millisecond)
+				return nil, stacktrace.Propagate(ente.ErrInvalidPassword, "session not found")
+			}
+			return nil, stacktrace.Propagate(err, "")
+		}
+		if srpSession.IsVerified {
+			return nil, stacktrace.Propagate(&ente.ApiError{
+				Code:           "SESSION_ALREADY_VERIFIED",
+				HttpStatusCode: http.StatusGone,
+			}, "")
+		}
 		return nil, stacktrace.Propagate(&ente.ApiError{
 			Code:           "TOO_MANY_WRONG_ATTEMPTS",
 			HttpStatusCode: http.StatusGone,
 		}, "")
+	}
+
+	if srpSession.IsFake {
+		// Match real-session timing.
+		time.Sleep(time.Duration(20+mathRand.Intn(30)) * time.Millisecond)
+		return nil, stacktrace.Propagate(ente.ErrInvalidPassword, "fake session verification")
 	}
 
 	srpParams := srp.GetParams(Srp4096Params)
@@ -336,16 +339,17 @@ func (c *UserController) verifySRPSession(ctx context.Context,
 	srpM2Bytes, err := srpServer.CheckM1(srpM1Bytes)
 
 	if err != nil {
-		err2 := c.UserAuthRepo.IncrementSrpSessionAttemptCount(ctx, sessionID)
-		if err2 != nil {
-			return nil, stacktrace.Propagate(err2, "")
-		}
 		return nil, stacktrace.Propagate(ente.ErrInvalidPassword, "failed to verify srp session")
-	} else {
-		err2 := c.UserAuthRepo.SetSrpSessionVerified(ctx, sessionID)
-		if err2 != nil {
-			return nil, stacktrace.Propagate(err2, "")
-		}
+	}
+	claimed, err := c.UserAuthRepo.TrySetSrpSessionVerified(ctx, sessionID)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	if !claimed {
+		return nil, stacktrace.Propagate(&ente.ApiError{
+			Code:           "SESSION_ALREADY_VERIFIED",
+			HttpStatusCode: http.StatusGone,
+		}, "")
 	}
 	srpM2 := convertBytesToString(srpM2Bytes)
 	return &srpM2, nil

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -267,20 +267,14 @@ func (c *UserController) verifyEmailOtt(context *gin.Context, email string, ott 
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	wrongAttempt, err := c.UserAuthRepo.GetMaxWrongAttempts(emailHash, app)
+	otts, limited, err := c.UserAuthRepo.ReserveOTTVerificationAttempt(emailHash, app, OTTWrongAttemptLimit)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-
-	if wrongAttempt >= OTTWrongAttemptLimit {
+	if limited {
 		msg := fmt.Sprintf("Too many wrong ott verification attemp for app %s", app)
 		go c.DiscordController.NotifyPotentialAbuse(msg)
 		return stacktrace.Propagate(ente.ErrTooManyBadRequest, "User needs to wait before active ott are expired")
-	}
-
-	otts, err := c.UserAuthRepo.GetValidOTTs(emailHash, app)
-	if err != nil {
-		return stacktrace.Propagate(err, "")
 	}
 	if len(otts) < 1 {
 		return stacktrace.Propagate(ente.ErrExpiredOTT, "")
@@ -292,9 +286,6 @@ func (c *UserController) verifyEmailOtt(context *gin.Context, email string, ott 
 		}
 	}
 	if !isValidOTT {
-		if err = c.UserAuthRepo.RecordWrongAttemptForActiveOtt(emailHash, app); err != nil {
-			log.WithError(err).Warn("Failed to track wrong attempt")
-		}
 		return stacktrace.Propagate(ente.ErrIncorrectOTT, "")
 	}
 	removed, err := c.UserAuthRepo.RemoveOTT(emailHash, ott, app)

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -267,7 +267,7 @@ func (c *UserController) verifyEmailOtt(context *gin.Context, email string, ott 
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	otts, limited, err := c.UserAuthRepo.ReserveOTTVerificationAttempt(emailHash, app, OTTWrongAttemptLimit)
+	otts, limited, err := c.UserAuthRepo.ReserveOTTVerificationAttempt(emailHash, app, ott, OTTWrongAttemptLimit)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}

--- a/server/pkg/repo/collection.go
+++ b/server/pkg/repo/collection.go
@@ -493,6 +493,7 @@ func (repo *CollectionRepository) Share(
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	if role != ente.VIEWER && role != ente.COLLABORATOR && role != ente.ADMIN {
 		err = fmt.Errorf("invalid role %s", string(role))
 		return stacktrace.Propagate(err, "")

--- a/server/pkg/repo/family.go
+++ b/server/pkg/repo/family.go
@@ -55,6 +55,7 @@ func (repo *FamilyRepository) CloseFamily(ctx context.Context, adminID int64) er
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	_, err = tx.ExecContext(ctx, `DELETE FROM families WHERE admin_id = $1`, adminID)
 	if err != nil {
 		tx.Rollback()

--- a/server/pkg/repo/file.go
+++ b/server/pkg/repo/file.go
@@ -431,6 +431,7 @@ func (repo *FileRepository) UpdateThumbnail(ctx context.Context, fileID int64, u
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	updationTime := time.Microseconds()
 	_, err = tx.ExecContext(ctx, `UPDATE files SET 
 			thumbnail_decryption_header = $1, 

--- a/server/pkg/repo/srp.go
+++ b/server/pkg/repo/srp.go
@@ -166,14 +166,28 @@ func (repo *UserAuthRepository) GetSrpSessionEntity(ctx context.Context, session
 	return &result, nil
 }
 
-func (repo *UserAuthRepository) IncrementSrpSessionAttemptCount(ctx context.Context, sessionID uuid.UUID) error {
-	_, err := repo.DB.ExecContext(ctx, `UPDATE srp_sessions SET attempt_count = attempt_count + 1 WHERE id = $1`, sessionID)
-	return stacktrace.Propagate(err, "")
+func (repo *UserAuthRepository) ReserveSrpSessionAttempt(ctx context.Context, sessionID uuid.UUID, limit int) (*ente.SRPSessionEntity, error) {
+	result := ente.SRPSessionEntity{}
+	row := repo.DB.QueryRowContext(ctx, `UPDATE srp_sessions SET attempt_count = attempt_count + 1
+		WHERE id = $1 AND has_verified = false AND attempt_count < $2
+		RETURNING id, srp_user_id, server_key, srp_a, has_verified, attempt_count, COALESCE(is_fake, false)`, sessionID, limit)
+	err := row.Scan(&result.ID, &result.SRPUserID, &result.ServerKey, &result.SRP_A, &result.IsVerified, &result.AttemptCount, &result.IsFake)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	return &result, nil
 }
 
-func (repo *UserAuthRepository) SetSrpSessionVerified(ctx context.Context, sessionID uuid.UUID) error {
-	_, err := repo.DB.ExecContext(ctx, `UPDATE srp_sessions SET has_verified = true WHERE id = $1`, sessionID)
-	return stacktrace.Propagate(err, "")
+func (repo *UserAuthRepository) TrySetSrpSessionVerified(ctx context.Context, sessionID uuid.UUID) (bool, error) {
+	result, err := repo.DB.ExecContext(ctx, `UPDATE srp_sessions SET has_verified = true WHERE id = $1 AND has_verified = false`, sessionID)
+	if err != nil {
+		return false, stacktrace.Propagate(err, "")
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, stacktrace.Propagate(err, "")
+	}
+	return rowsAffected == 1, nil
 }
 
 func (repo *UserAuthRepository) CleanupOldFakeSessions(ctx context.Context) (int64, error) {

--- a/server/pkg/repo/userauth.go
+++ b/server/pkg/repo/userauth.go
@@ -111,7 +111,7 @@ func (repo *UserAuthRepository) GetValidOTTs(emailHash string, app ente.App) ([]
 	return otts, nil
 }
 
-func (repo *UserAuthRepository) ReserveOTTVerificationAttempt(emailHash string, app ente.App, limit int) ([]string, bool, error) {
+func (repo *UserAuthRepository) ReserveOTTVerificationAttempt(emailHash string, app ente.App, submittedOTT string, limit int) ([]string, bool, error) {
 	tx, err := repo.DB.Begin()
 	if err != nil {
 		return nil, false, stacktrace.Propagate(err, "")
@@ -128,6 +128,7 @@ func (repo *UserAuthRepository) ReserveOTTVerificationAttempt(emailHash string, 
 
 	otts := make([]string, 0)
 	limited := false
+	matched := false
 	for rows.Next() {
 		var ott string
 		var wrongAttempt int
@@ -136,11 +137,12 @@ func (repo *UserAuthRepository) ReserveOTTVerificationAttempt(emailHash string, 
 		}
 		otts = append(otts, ott)
 		limited = limited || wrongAttempt >= limit
+		matched = matched || ott == submittedOTT
 	}
 	if err := rows.Err(); err != nil {
 		return nil, false, stacktrace.Propagate(err, "")
 	}
-	if limited || len(otts) == 0 {
+	if limited || len(otts) == 0 || matched {
 		return otts, limited, nil
 	}
 

--- a/server/pkg/repo/userauth.go
+++ b/server/pkg/repo/userauth.go
@@ -111,25 +111,48 @@ func (repo *UserAuthRepository) GetValidOTTs(emailHash string, app ente.App) ([]
 	return otts, nil
 }
 
-func (repo *UserAuthRepository) GetMaxWrongAttempts(emailHash string, app ente.App) (int, error) {
-	row := repo.DB.QueryRow(`SELECT COALESCE(MAX(wrong_attempt),0) FROM otts WHERE email_hash = $1 AND expiration_time > $2 AND app = $3`,
-		emailHash, time.Microseconds(), app)
-	var wrongAttempt int
-	if err := row.Scan(&wrongAttempt); err != nil {
-		return 0, stacktrace.Propagate(err, "Failed to scan row")
-	}
-	return wrongAttempt, nil
-}
-
-// RecordWrongAttemptForActiveOtt increases the wrong_attempt count for given emailHash and active ott.
-// Assuming tha we keep deleting expired OTT, max(wrong_attempt) can be used to track brute-force attack
-func (repo *UserAuthRepository) RecordWrongAttemptForActiveOtt(emailHash string, app ente.App) error {
-	_, err := repo.DB.Exec(`UPDATE otts SET wrong_attempt = otts.wrong_attempt + 1
-				WHERE email_hash = $1  AND expiration_time > $2 AND app=$3`, emailHash, time.Microseconds(), app)
+func (repo *UserAuthRepository) ReserveOTTVerificationAttempt(emailHash string, app ente.App, limit int) ([]string, bool, error) {
+	tx, err := repo.DB.Begin()
 	if err != nil {
-		return stacktrace.Propagate(err, "Failed to update wrong attempt count")
+		return nil, false, stacktrace.Propagate(err, "")
 	}
-	return nil
+	defer tx.Rollback()
+
+	rows, err := tx.Query(`SELECT ott, wrong_attempt FROM otts
+		WHERE email_hash = $1 AND app = $2 AND expiration_time > $3
+		ORDER BY ott FOR UPDATE`, emailHash, app, time.Microseconds())
+	if err != nil {
+		return nil, false, stacktrace.Propagate(err, "")
+	}
+	defer rows.Close()
+
+	otts := make([]string, 0)
+	limited := false
+	for rows.Next() {
+		var ott string
+		var wrongAttempt int
+		if err := rows.Scan(&ott, &wrongAttempt); err != nil {
+			return nil, false, stacktrace.Propagate(err, "")
+		}
+		otts = append(otts, ott)
+		limited = limited || wrongAttempt >= limit
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, stacktrace.Propagate(err, "")
+	}
+	if limited || len(otts) == 0 {
+		return otts, limited, nil
+	}
+
+	_, err = tx.Exec(`UPDATE otts SET wrong_attempt = wrong_attempt + 1
+		WHERE email_hash = $1 AND app = $2 AND ott = ANY($3)`, emailHash, app, pq.Array(otts))
+	if err != nil {
+		return nil, false, stacktrace.Propagate(err, "")
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, false, stacktrace.Propagate(err, "")
+	}
+	return otts, false, nil
 }
 
 func (repo *UserAuthRepository) AddToken(userID int64, app ente.App, token string, ip string, userAgent string) error {


### PR DESCRIPTION
- Make SRP and email OTT attempt updates atomic.
- Validate public-link KDF parameters before persistence.
- Ensure failed collection, thumbnail, and family operations release their transactions.