### PR TITLE
[android][ensu] Disable Android backups

### DIFF
--- a/android/apps/ensu/app/src/main/AndroidManifest.xml
+++ b/android/apps/ensu/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:largeHeap="true"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:theme="@style/Theme.Ensu"
         android:usesCleartextTraffic="true">
         <activity

--- a/android/apps/ensu/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/apps/ensu/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </cloud-backup>
+
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Description

Prevent Android from backing up or transferring Ensu app data.

- Disable legacy and cloud backup in the application manifest.
- Exclude all app storage domains from Android 12+ cloud backup and device-to-device transfer.

This prevents restored encrypted preferences from being paired with a missing Android Keystore key, which could crash Ensu at startup after a reinstall or device migration.