### PR TITLE
[auth] fix the suggestfeatures link

### DIFF
--- a/mobile/apps/auth/lib/core/constants.dart
+++ b/mobile/apps/auth/lib/core/constants.dart
@@ -9,7 +9,7 @@ const String sentryDSN =
 final Uri githubFeatureRequestUri = Uri.https(
   "github.com",
   "/ente/ente/discussions/categories/enhancements",
-  {"discussions_q": "is:open label:\"- auth\" sort:top"},
+  {"discussions_q": "is:open label:\"auth\" sort:top"},
 );
 const int microSecondsInDay = 86400000000;
 const String sharedMediaIdentifier = 'ente-shared-media://';


### PR DESCRIPTION
## Description
the suggest features link inside support setting page was redirecting to github page where the label is kept` is:open label:"- auth" sort:top category:Enhancements `. the hyphen was not required. fixed it to show posts matching label "auth"

