### PR TITLE
[locker] Gate document scanner behind internal flag

### DIFF
--- a/mobile/apps/locker/changes/document-scanner.md
+++ b/mobile/apps/locker/changes/document-scanner.md
@@ -1,0 +1,1 @@
+- Document scanner (behind internal flag)

--- a/mobile/apps/locker/lib/services/feature_flag_service.dart
+++ b/mobile/apps/locker/lib/services/feature_flag_service.dart
@@ -16,6 +16,7 @@ class FeatureFlagService {
   late FlagService _flagService;
 
   bool get internalUser => _flagService.internalUser;
+  bool get documentScanner => internalUser;
 
   void init(SharedPreferences preferences) {
     _preferences = preferences;

--- a/mobile/apps/locker/lib/ui/pages/save_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/save_page.dart
@@ -4,9 +4,9 @@ import 'dart:io';
 import "package:ente_components/ente_components.dart";
 import 'package:ente_strings/ente_strings.dart';
 import 'package:ente_ui/utils/toast_util.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
+import 'package:locker/services/feature_flag_service.dart';
 import 'package:locker/ui/pages/account_credentials_page.dart';
 import 'package:locker/ui/pages/personal_note_page.dart';
 import 'package:locker/ui/pages/physical_records_page.dart';
@@ -28,12 +28,10 @@ class SaveOption {
   final String description;
 }
 
-const bool docScannerEnabled = kDebugMode;
-
 List<SaveOption> saveOptions(BuildContext context) {
   final l10n = context.strings;
   return [
-    if (docScannerEnabled)
+    if (FeatureFlagService.instance.documentScanner)
       SaveOption(
         type: SaveOptionType.scanDocument,
         icon: HugeIcons.strokeRoundedFileScan,

--- a/rust/crates/ml/src/scan/mod.rs
+++ b/rust/crates/ml/src/scan/mod.rs
@@ -25,9 +25,7 @@ use ente_assets::{Asset, AssetFile, AssetStore};
 pub const SEGMENTATION_MODEL_SHA256: &str =
     "5ddcb87c70cb7674189e6fc148e84a490ca65b282276534210255a777d48a808";
 
-// Temporary dev hosting; will move to models.ente.com.
-const SEGMENTATION_MODEL_URL: &str =
-    "https://entedevassets.priem.dev/document_segmentation_opt.onnx";
+const SEGMENTATION_MODEL_URL: &str = "https://models.ente.com/document_segmentation_opt.onnx";
 const SEGMENTATION_MODEL_FILE: &str = "document_segmentation_opt.onnx";
 
 fn segmentation_model_asset() -> Result<Asset, ScanError> {


### PR DESCRIPTION
## Description

- Add a `documentScanner` Locker feature flag backed by `internalUser` and use it to gate the document scanner.
- Serve the document segmentation model from `models.ente.com`.
- Add the Locker developer changelog entry.