### PR TITLE
[server] Canonicalize custom domain ownership

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1093,6 +1093,11 @@ func main() {
 
 	setKnownAPIs(server.Routes())
 	setupAndStartBackgroundJobs(objectCleanupController, replicationController3, fileDataCtrl, contactController, spaceModule)
+	time.AfterFunc(10*time.Minute, func() {
+		if err := remoteStoreRepository.BackfillCustomDomainCanonicalValues(context.Background()); err != nil {
+			log.WithError(err).Error("Failed to backfill custom domain canonical values")
+		}
+	})
 	setupAndStartCrons(
 		userAuthRepo, collectionLinkRepo, fileLinkRepo, pasteRepo, twoFactorRepo, passkeysRepo, fileController, taskLockingRepo, emailNotificationCtrl,
 		trashController, pushController, objectController, dataCleanupController, storageBonusCtrl, emergencyCtrl,

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1094,7 +1094,7 @@ func main() {
 	setKnownAPIs(server.Routes())
 	setupAndStartBackgroundJobs(objectCleanupController, replicationController3, fileDataCtrl, contactController, spaceModule)
 	time.AfterFunc(10*time.Minute, func() {
-		if err := remoteStoreRepository.BackfillCustomDomainCanonicalValues(context.Background()); err != nil {
+		if err := remoteStoreRepository.MigrateCustomDomainCanonicalValues20260824(context.Background()); err != nil {
 			log.WithError(err).Error("Failed to backfill custom domain canonical values")
 		}
 	})

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1094,7 +1094,7 @@ func main() {
 	setKnownAPIs(server.Routes())
 	setupAndStartBackgroundJobs(objectCleanupController, replicationController3, fileDataCtrl, contactController, spaceModule)
 	time.AfterFunc(10*time.Minute, func() {
-		if err := remoteStoreRepository.MigrateCustomDomainCanonicalValues20260824(context.Background()); err != nil {
+		if err := remoteStoreRepository.MigrateCustomDomainCanonicalValues(context.Background()); err != nil {
 			log.WithError(err).Error("Failed to backfill custom domain canonical values")
 		}
 	})

--- a/server/ente/remotestore.go
+++ b/server/ente/remotestore.go
@@ -192,6 +192,11 @@ func ResolveCustomDomainValue(value string) (string, error) {
 	return value, nil
 }
 
+func CanonicalDomain(domain string) (string, error) {
+	asciiDomain, err := idna.Lookup.ToASCII(domain)
+	return strings.ToLower(asciiDomain), err
+}
+
 func isValidDomainWithoutScheme(input string) error {
 	trimmed := strings.TrimSpace(input)
 	if trimmed != input {
@@ -204,7 +209,7 @@ func isValidDomainWithoutScheme(input string) error {
 		return NewBadRequestWithMessage("domain should not contain scheme (e.g., http:// or https://)")
 	}
 
-	asciiDomain, err := idna.ToASCII(trimmed)
+	asciiDomain, err := CanonicalDomain(trimmed)
 	if err != nil {
 		return NewBadRequestWithMessage(fmt.Sprintf("invalid idn domain format: %s", trimmed))
 	}

--- a/server/go.mod
+++ b/server/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.11.0 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20240701034025-d67f41855da4 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -328,8 +328,9 @@ github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.4-0.20240701034025-d67f41855da4 h1:PYKzliEgITjLJoJqbV90S0YRaG8LNAsICH6fp6MApC0=
+github.com/gorilla/websocket v1.5.4-0.20240701034025-d67f41855da4/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=

--- a/server/migrations/132_custom_domain_canonical.down.sql
+++ b/server/migrations/132_custom_domain_canonical.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS remote_store_custom_domain_canonical_unique_idx;
+
+ALTER TABLE remote_store DROP COLUMN canonical_value;

--- a/server/migrations/132_custom_domain_canonical.up.sql
+++ b/server/migrations/132_custom_domain_canonical.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE remote_store ADD COLUMN canonical_value TEXT;
+
+CREATE UNIQUE INDEX remote_store_custom_domain_canonical_unique_idx
+    ON remote_store (canonical_value)
+    WHERE key_name = 'customDomain' AND canonical_value IS NOT NULL;

--- a/server/pkg/controller/remotestore/controller.go
+++ b/server/pkg/controller/remotestore/controller.go
@@ -154,7 +154,7 @@ func (c *Controller) insertOrUpdateCustomDomain(ctx *gin.Context, userID int64, 
 	ownerID, err := c.DomainOwner(ctx, value)
 	if err == nil {
 		if ownerID != nil && *ownerID == userID {
-			if err := c.Repo.InsertOrUpdate(ctx, userID, string(ente.CustomDomain), value); err != nil {
+			if err := c.Repo.InsertOrUpdateCustomDomain(ctx, userID, value); err != nil {
 				return err
 			}
 			return c.updateFamilyCustomDomainsIfAdmin(ctx, userID, value)
@@ -179,7 +179,7 @@ func (c *Controller) insertOrUpdateCustomDomain(ctx *gin.Context, userID int64, 
 	if !errors.Is(err, &ente.ErrNotFoundError) {
 		return stacktrace.Propagate(err, "")
 	}
-	if err := c.Repo.InsertOrUpdate(ctx, userID, string(ente.CustomDomain), value); err != nil {
+	if err := c.Repo.InsertOrUpdateCustomDomain(ctx, userID, value); err != nil {
 		return err
 	}
 	return c.updateFamilyCustomDomainsIfAdmin(ctx, userID, value)
@@ -301,10 +301,10 @@ func (c *Controller) DomainOwner(ctx *gin.Context, domain string) (*int64, error
 
 	// Retry with ASCII/Unicode variants so IDN domains stored in either form still resolve.
 	var candidates []string
-	if asciiDomain, convErr := idna.ToASCII(domain); convErr == nil && asciiDomain != domain {
+	if asciiDomain, convErr := ente.CanonicalDomain(domain); convErr == nil && !strings.EqualFold(asciiDomain, domain) {
 		candidates = append(candidates, asciiDomain)
 	}
-	if unicodeDomain, convErr := idna.ToUnicode(domain); convErr == nil && unicodeDomain != domain {
+	if unicodeDomain, convErr := idna.Lookup.ToUnicode(domain); convErr == nil && !strings.EqualFold(unicodeDomain, domain) {
 		candidates = append(candidates, unicodeDomain)
 	}
 

--- a/server/pkg/controller/remotestore/controller.go
+++ b/server/pkg/controller/remotestore/controller.go
@@ -186,8 +186,16 @@ func (c *Controller) insertOrUpdateCustomDomain(ctx *gin.Context, userID int64, 
 }
 
 func isReservedCustomDomain(value, configuredCNAME string) bool {
+	canonicalValue, err := ente.CanonicalDomain(value)
+	if err != nil {
+		return false
+	}
 	for _, domain := range []string{configuredCNAME, "my.ente.com", "my.ente.io"} {
-		if domain != "" && strings.EqualFold(value, domain) {
+		if domain == "" {
+			continue
+		}
+		canonicalDomain, err := ente.CanonicalDomain(domain)
+		if err == nil && canonicalValue == canonicalDomain {
 			return true
 		}
 	}

--- a/server/pkg/controller/remotestore/controller_test.go
+++ b/server/pkg/controller/remotestore/controller_test.go
@@ -1,0 +1,9 @@
+package remotestore
+
+import "testing"
+
+func TestReservedCustomDomainCanonicalization(t *testing.T) {
+	if !isReservedCustomDomain("ｍｙ．ｅｎｔｅ．ｃｏｍ", "") {
+		t.Error("width-mapped Ente domain was not reserved")
+	}
+}

--- a/server/pkg/middleware/collection_link.go
+++ b/server/pkg/middleware/collection_link.go
@@ -13,8 +13,6 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/net/idna"
-
 	"github.com/ente/museum/pkg/repo/remotestore"
 	"github.com/gin-contrib/requestid"
 	"github.com/spf13/viper"
@@ -319,7 +317,7 @@ func (m *CollectionLinkMiddleware) validateOrigin(c *gin.Context, ownerID int64)
 		logger.WithError(err).Error("originParseFailedL")
 		return ente.NewPermissionDeniedError("unknown custom domain")
 	}
-	asciiDomain, err := idna.ToASCII(*domain)
+	asciiDomain, err := ente.CanonicalDomain(*domain)
 	if err != nil {
 		logger.WithError(err).Error("domainToASCIIFailed")
 		m.DiscordController.NotifyPotentialAbuse(alertMessage + " - domainToASCIIFailed")

--- a/server/pkg/repo/remotestore/repository.go
+++ b/server/pkg/repo/remotestore/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 
 	"github.com/ente/museum/ente"
 	"github.com/lib/pq"
@@ -36,7 +37,7 @@ func (r *Repository) BackfillCustomDomainCanonicalValues(ctx context.Context) er
 	defer tx.Rollback()
 
 	rows, err := tx.QueryContext(ctx, `SELECT user_id, key_value, canonical_value FROM remote_store
-		WHERE key_name = $1 AND left(key_value, 1) <> '_' FOR UPDATE`, ente.CustomDomain)
+		WHERE key_name = $1 FOR UPDATE`, ente.CustomDomain)
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to fetch custom domains")
 	}
@@ -65,6 +66,9 @@ func (r *Repository) BackfillCustomDomainCanonicalValues(ctx context.Context) er
 	}
 
 	for _, domain := range domains {
+		if strings.HasPrefix(domain.value, "_") {
+			continue
+		}
 		if err := ente.ValidatePublicCustomDomain(domain.value); err != nil {
 			log.WithField("user_id", domain.userID).WithError(err).Warn("Skipping invalid custom domain during backfill")
 			continue
@@ -146,14 +150,17 @@ func (r *Repository) DomainOwner(ctx context.Context, domain string) (*int64, er
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to canonicalize custom domain")
 	}
-	rows := r.DB.QueryRowContext(ctx, `SELECT user_id FROM remote_store
-	   WHERE key_name = $1 AND (canonical_value = $2 OR lower(key_value) = lower($3))`,
+	row := r.DB.QueryRowContext(ctx, `SELECT user_id FROM remote_store
+	   WHERE key_name = $1 AND canonical_value = $2`,
 		ente.CustomDomain,
 		canonicalDomain,
-		domain,
 	)
 	var userID int64
-	err = rows.Scan(&userID)
+	err = row.Scan(&userID)
+	if errors.Is(err, sql.ErrNoRows) {
+		err = r.DB.QueryRowContext(ctx, `SELECT user_id FROM remote_store
+			WHERE key_name = $1 AND lower(key_value) = lower($2)`, ente.CustomDomain, domain).Scan(&userID)
+	}
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, stacktrace.Propagate(&ente.ErrNotFoundError, "")

--- a/server/pkg/repo/remotestore/repository.go
+++ b/server/pkg/repo/remotestore/repository.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ente/museum/ente"
 	"github.com/lib/pq"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/ente/stacktrace"
 )
@@ -34,7 +35,7 @@ func (r *Repository) BackfillCustomDomainCanonicalValues(ctx context.Context) er
 	}
 	defer tx.Rollback()
 
-	rows, err := tx.QueryContext(ctx, `SELECT user_id, key_value FROM remote_store
+	rows, err := tx.QueryContext(ctx, `SELECT user_id, key_value, canonical_value FROM remote_store
 		WHERE key_name = $1 AND left(key_value, 1) <> '_' FOR UPDATE`, ente.CustomDomain)
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to fetch custom domains")
@@ -42,13 +43,16 @@ func (r *Repository) BackfillCustomDomainCanonicalValues(ctx context.Context) er
 	defer rows.Close()
 
 	type domainRow struct {
-		userID int64
-		value  string
+		userID         int64
+		value          string
+		current        sql.NullString
+		canonicalValue string
 	}
-	var domains []domainRow
+	var domains []*domainRow
+	domainsByCanonicalValue := make(map[string][]*domainRow)
 	for rows.Next() {
-		var domain domainRow
-		if err := rows.Scan(&domain.userID, &domain.value); err != nil {
+		domain := &domainRow{}
+		if err := rows.Scan(&domain.userID, &domain.value, &domain.current); err != nil {
 			return stacktrace.Propagate(err, "failed to scan custom domain")
 		}
 		domains = append(domains, domain)
@@ -62,15 +66,44 @@ func (r *Repository) BackfillCustomDomainCanonicalValues(ctx context.Context) er
 
 	for _, domain := range domains {
 		if err := ente.ValidatePublicCustomDomain(domain.value); err != nil {
-			return stacktrace.Propagate(err, "invalid stored custom domain")
+			log.WithField("user_id", domain.userID).WithError(err).Warn("Skipping invalid custom domain during backfill")
+			continue
 		}
 		canonicalDomain, err := ente.CanonicalDomain(domain.value)
 		if err != nil {
-			return stacktrace.Propagate(err, "failed to canonicalize stored custom domain")
+			log.WithField("user_id", domain.userID).WithError(err).Warn("Skipping invalid custom domain during backfill")
+			continue
+		}
+		domain.canonicalValue = canonicalDomain
+		domainsByCanonicalValue[canonicalDomain] = append(domainsByCanonicalValue[canonicalDomain], domain)
+	}
+	for _, group := range domainsByCanonicalValue {
+		if len(group) == 1 {
+			continue
+		}
+		userIDs := make([]int64, len(group))
+		for i, domain := range group {
+			userIDs[i] = domain.userID
+			domain.canonicalValue = ""
+		}
+		log.WithField("user_ids", userIDs).Warn("Skipping colliding custom domains during backfill")
+	}
+
+	for _, domain := range domains {
+		if domain.current.Valid && domain.current.String != domain.canonicalValue {
+			if _, err := tx.ExecContext(ctx, `UPDATE remote_store SET canonical_value = NULL
+				WHERE user_id = $1 AND key_name = $2`, domain.userID, ente.CustomDomain); err != nil {
+				return stacktrace.Propagate(err, "failed to clear stale custom domain")
+			}
+		}
+	}
+	for _, domain := range domains {
+		if domain.canonicalValue == "" || domain.current.Valid && domain.current.String == domain.canonicalValue {
+			continue
 		}
 		if _, err := tx.ExecContext(ctx, `UPDATE remote_store SET canonical_value = $1
 			WHERE user_id = $2 AND key_name = $3 AND canonical_value IS DISTINCT FROM $1`,
-			canonicalDomain, domain.userID, ente.CustomDomain); err != nil {
+			domain.canonicalValue, domain.userID, ente.CustomDomain); err != nil {
 			return stacktrace.Propagate(err, "failed to backfill custom domain")
 		}
 	}
@@ -109,13 +142,18 @@ func (r *Repository) RemoveKey(ctx context.Context, userID int64, key string) er
 }
 
 func (r *Repository) DomainOwner(ctx context.Context, domain string) (*int64, error) {
+	canonicalDomain, err := ente.CanonicalDomain(domain)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to canonicalize custom domain")
+	}
 	rows := r.DB.QueryRowContext(ctx, `SELECT user_id FROM remote_store
-	   WHERE key_name = $1 AND (canonical_value = $2 OR lower(key_value) = lower($2))`,
+	   WHERE key_name = $1 AND (canonical_value = $2 OR lower(key_value) = lower($3))`,
 		ente.CustomDomain,
+		canonicalDomain,
 		domain,
 	)
 	var userID int64
-	err := rows.Scan(&userID)
+	err = rows.Scan(&userID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, stacktrace.Propagate(&ente.ErrNotFoundError, "")

--- a/server/pkg/repo/remotestore/repository.go
+++ b/server/pkg/repo/remotestore/repository.go
@@ -16,24 +16,87 @@ type Repository struct {
 }
 
 func (r *Repository) InsertOrUpdate(ctx context.Context, userID int64, key string, value string) error {
-	_, err := r.DB.ExecContext(ctx, `INSERT INTO remote_store(user_id, key_name, key_value) VALUES ($1,$2,$3)
-						 ON CONFLICT (user_id, key_name) DO UPDATE SET key_value = $3;
+	return r.insertOrUpdate(ctx, userID, key, value, nil)
+}
+
+func (r *Repository) InsertOrUpdateCustomDomain(ctx context.Context, userID int64, value string) error {
+	canonicalDomain, err := ente.CanonicalDomain(value)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to canonicalize custom domain")
+	}
+	return r.insertOrUpdate(ctx, userID, string(ente.CustomDomain), value, &canonicalDomain)
+}
+
+func (r *Repository) BackfillCustomDomainCanonicalValues(ctx context.Context) error {
+	tx, err := r.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to begin custom domain backfill")
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `SELECT user_id, key_value FROM remote_store
+		WHERE key_name = $1 AND left(key_value, 1) <> '_' FOR UPDATE`, ente.CustomDomain)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to fetch custom domains")
+	}
+	defer rows.Close()
+
+	type domainRow struct {
+		userID int64
+		value  string
+	}
+	var domains []domainRow
+	for rows.Next() {
+		var domain domainRow
+		if err := rows.Scan(&domain.userID, &domain.value); err != nil {
+			return stacktrace.Propagate(err, "failed to scan custom domain")
+		}
+		domains = append(domains, domain)
+	}
+	if err := rows.Err(); err != nil {
+		return stacktrace.Propagate(err, "failed to read custom domains")
+	}
+	if err := rows.Close(); err != nil {
+		return stacktrace.Propagate(err, "failed to close custom domain rows")
+	}
+
+	for _, domain := range domains {
+		if err := ente.ValidatePublicCustomDomain(domain.value); err != nil {
+			return stacktrace.Propagate(err, "invalid stored custom domain")
+		}
+		canonicalDomain, err := ente.CanonicalDomain(domain.value)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to canonicalize stored custom domain")
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE remote_store SET canonical_value = $1
+			WHERE user_id = $2 AND key_name = $3 AND canonical_value IS DISTINCT FROM $1`,
+			canonicalDomain, domain.userID, ente.CustomDomain); err != nil {
+			return stacktrace.Propagate(err, "failed to backfill custom domain")
+		}
+	}
+	return stacktrace.Propagate(tx.Commit(), "failed to commit custom domain backfill")
+}
+
+func (r *Repository) insertOrUpdate(ctx context.Context, userID int64, key string, value string, canonicalValue *string) error {
+	_, err := r.DB.ExecContext(ctx, `INSERT INTO remote_store(user_id, key_name, key_value, canonical_value) VALUES ($1,$2,$3,$4)
+						 ON CONFLICT (user_id, key_name) DO UPDATE SET key_value = $3, canonical_value = $4;
 						 `,
 		userID,
 		key,
 		value,
+		canonicalValue,
 	)
 
 	if err != nil {
 		var pgErr *pq.Error
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			if pgErr.Constraint == "remote_store_custom_domain_unique_idx" {
+			if pgErr.Constraint == "remote_store_custom_domain_unique_idx" || pgErr.Constraint == "remote_store_custom_domain_canonical_unique_idx" {
 				return ente.NewConflictError("custom domain already exists for another user")
 			}
 		}
 		return stacktrace.Propagate(err, "failed to insert/update")
 	}
-	return stacktrace.Propagate(err, "failed to insert/update")
+	return nil
 }
 
 func (r *Repository) RemoveKey(ctx context.Context, userID int64, key string) error {
@@ -47,7 +110,7 @@ func (r *Repository) RemoveKey(ctx context.Context, userID int64, key string) er
 
 func (r *Repository) DomainOwner(ctx context.Context, domain string) (*int64, error) {
 	rows := r.DB.QueryRowContext(ctx, `SELECT user_id FROM remote_store
-	   WHERE key_name = $1 AND key_value = $2`,
+	   WHERE key_name = $1 AND (canonical_value = $2 OR lower(key_value) = lower($2))`,
 		ente.CustomDomain,
 		domain,
 	)

--- a/server/pkg/repo/remotestore/repository.go
+++ b/server/pkg/repo/remotestore/repository.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"strings"
 
 	"github.com/ente/museum/ente"
 	"github.com/lib/pq"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/ente/stacktrace"
 )
@@ -27,91 +25,6 @@ func (r *Repository) InsertOrUpdateCustomDomain(ctx context.Context, userID int6
 		return stacktrace.Propagate(err, "failed to canonicalize custom domain")
 	}
 	return r.insertOrUpdate(ctx, userID, string(ente.CustomDomain), value, &canonicalDomain)
-}
-
-func (r *Repository) BackfillCustomDomainCanonicalValues(ctx context.Context) error {
-	tx, err := r.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to begin custom domain backfill")
-	}
-	defer tx.Rollback()
-
-	rows, err := tx.QueryContext(ctx, `SELECT user_id, key_value, canonical_value FROM remote_store
-		WHERE key_name = $1 FOR UPDATE`, ente.CustomDomain)
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to fetch custom domains")
-	}
-	defer rows.Close()
-
-	type domainRow struct {
-		userID         int64
-		value          string
-		current        sql.NullString
-		canonicalValue string
-	}
-	var domains []*domainRow
-	domainsByCanonicalValue := make(map[string][]*domainRow)
-	for rows.Next() {
-		domain := &domainRow{}
-		if err := rows.Scan(&domain.userID, &domain.value, &domain.current); err != nil {
-			return stacktrace.Propagate(err, "failed to scan custom domain")
-		}
-		domains = append(domains, domain)
-	}
-	if err := rows.Err(); err != nil {
-		return stacktrace.Propagate(err, "failed to read custom domains")
-	}
-	if err := rows.Close(); err != nil {
-		return stacktrace.Propagate(err, "failed to close custom domain rows")
-	}
-
-	for _, domain := range domains {
-		if strings.HasPrefix(domain.value, "_") {
-			continue
-		}
-		if err := ente.ValidatePublicCustomDomain(domain.value); err != nil {
-			log.WithField("user_id", domain.userID).WithError(err).Warn("Skipping invalid custom domain during backfill")
-			continue
-		}
-		canonicalDomain, err := ente.CanonicalDomain(domain.value)
-		if err != nil {
-			log.WithField("user_id", domain.userID).WithError(err).Warn("Skipping invalid custom domain during backfill")
-			continue
-		}
-		domain.canonicalValue = canonicalDomain
-		domainsByCanonicalValue[canonicalDomain] = append(domainsByCanonicalValue[canonicalDomain], domain)
-	}
-	for _, group := range domainsByCanonicalValue {
-		if len(group) == 1 {
-			continue
-		}
-		userIDs := make([]int64, len(group))
-		for i, domain := range group {
-			userIDs[i] = domain.userID
-			domain.canonicalValue = ""
-		}
-		log.WithField("user_ids", userIDs).Warn("Skipping colliding custom domains during backfill")
-	}
-
-	for _, domain := range domains {
-		if domain.current.Valid && domain.current.String != domain.canonicalValue {
-			if _, err := tx.ExecContext(ctx, `UPDATE remote_store SET canonical_value = NULL
-				WHERE user_id = $1 AND key_name = $2`, domain.userID, ente.CustomDomain); err != nil {
-				return stacktrace.Propagate(err, "failed to clear stale custom domain")
-			}
-		}
-	}
-	for _, domain := range domains {
-		if domain.canonicalValue == "" || domain.current.Valid && domain.current.String == domain.canonicalValue {
-			continue
-		}
-		if _, err := tx.ExecContext(ctx, `UPDATE remote_store SET canonical_value = $1
-			WHERE user_id = $2 AND key_name = $3 AND canonical_value IS DISTINCT FROM $1`,
-			domain.canonicalValue, domain.userID, ente.CustomDomain); err != nil {
-			return stacktrace.Propagate(err, "failed to backfill custom domain")
-		}
-	}
-	return stacktrace.Propagate(tx.Commit(), "failed to commit custom domain backfill")
 }
 
 func (r *Repository) insertOrUpdate(ctx context.Context, userID int64, key string, value string, canonicalValue *string) error {

--- a/server/pkg/repo/remotestore/repository_migration.go
+++ b/server/pkg/repo/remotestore/repository_migration.go
@@ -11,7 +11,8 @@ import (
 	"github.com/ente/stacktrace"
 )
 
-func (r *Repository) MigrateCustomDomainCanonicalValues20260824(ctx context.Context) error {
+// MigrateCustomDomainCanonicalValues backfills canonical domains (2026-08-24).
+func (r *Repository) MigrateCustomDomainCanonicalValues(ctx context.Context) error {
 	tx, err := r.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to begin custom domain backfill")

--- a/server/pkg/repo/remotestore/repository_migration.go
+++ b/server/pkg/repo/remotestore/repository_migration.go
@@ -1,0 +1,97 @@
+package remotestore
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/ente/museum/ente"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/ente/stacktrace"
+)
+
+func (r *Repository) MigrateCustomDomainCanonicalValues20260824(ctx context.Context) error {
+	tx, err := r.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to begin custom domain backfill")
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `SELECT user_id, key_value, canonical_value FROM remote_store
+		WHERE key_name = $1 FOR UPDATE`, ente.CustomDomain)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to fetch custom domains")
+	}
+	defer rows.Close()
+
+	type domainRow struct {
+		userID         int64
+		value          string
+		current        sql.NullString
+		canonicalValue string
+	}
+	var domains []*domainRow
+	domainsByCanonicalValue := make(map[string][]*domainRow)
+	for rows.Next() {
+		domain := &domainRow{}
+		if err := rows.Scan(&domain.userID, &domain.value, &domain.current); err != nil {
+			return stacktrace.Propagate(err, "failed to scan custom domain")
+		}
+		domains = append(domains, domain)
+	}
+	if err := rows.Err(); err != nil {
+		return stacktrace.Propagate(err, "failed to read custom domains")
+	}
+	if err := rows.Close(); err != nil {
+		return stacktrace.Propagate(err, "failed to close custom domain rows")
+	}
+
+	for _, domain := range domains {
+		if strings.HasPrefix(domain.value, "_") {
+			continue
+		}
+		if err := ente.ValidatePublicCustomDomain(domain.value); err != nil {
+			log.WithField("user_id", domain.userID).WithError(err).Warn("Skipping invalid custom domain during backfill")
+			continue
+		}
+		canonicalDomain, err := ente.CanonicalDomain(domain.value)
+		if err != nil {
+			log.WithField("user_id", domain.userID).WithError(err).Warn("Skipping invalid custom domain during backfill")
+			continue
+		}
+		domain.canonicalValue = canonicalDomain
+		domainsByCanonicalValue[canonicalDomain] = append(domainsByCanonicalValue[canonicalDomain], domain)
+	}
+	for _, group := range domainsByCanonicalValue {
+		if len(group) == 1 {
+			continue
+		}
+		userIDs := make([]int64, len(group))
+		for i, domain := range group {
+			userIDs[i] = domain.userID
+			domain.canonicalValue = ""
+		}
+		log.WithField("user_ids", userIDs).Warn("Skipping colliding custom domains during backfill")
+	}
+
+	for _, domain := range domains {
+		if domain.current.Valid && domain.current.String != domain.canonicalValue {
+			if _, err := tx.ExecContext(ctx, `UPDATE remote_store SET canonical_value = NULL
+				WHERE user_id = $1 AND key_name = $2`, domain.userID, ente.CustomDomain); err != nil {
+				return stacktrace.Propagate(err, "failed to clear stale custom domain")
+			}
+		}
+	}
+	for _, domain := range domains {
+		if domain.canonicalValue == "" || domain.current.Valid && domain.current.String == domain.canonicalValue {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE remote_store SET canonical_value = $1
+			WHERE user_id = $2 AND key_name = $3 AND canonical_value IS DISTINCT FROM $1`,
+			domain.canonicalValue, domain.userID, ente.CustomDomain); err != nil {
+			return stacktrace.Propagate(err, "failed to backfill custom domain")
+		}
+	}
+	return stacktrace.Propagate(tx.Commit(), "failed to commit custom domain backfill")
+}

--- a/server/pkg/repo/remotestore/repository_test.go
+++ b/server/pkg/repo/remotestore/repository_test.go
@@ -57,7 +57,7 @@ func TestCustomDomainCanonicalUniqueness(t *testing.T) {
 		($2, 'customDomain', 'xn--bcher-kva.example'),
 		($3, 'customDomain', 'invalid')`, collisionID1, collisionID2, invalidID)
 	require.NoError(t, err)
-	require.NoError(t, repository.BackfillCustomDomainCanonicalValues(t.Context()))
+	require.NoError(t, repository.MigrateCustomDomainCanonicalValues20260824(t.Context()))
 
 	var value string
 	var canonicalValue *string

--- a/server/pkg/repo/remotestore/repository_test.go
+++ b/server/pkg/repo/remotestore/repository_test.go
@@ -1,0 +1,57 @@
+package remotestore
+
+import (
+	"testing"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomDomainCanonicalUniqueness(t *testing.T) {
+	testutil.WithServerRoot(t)
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() { testutil.ResetTables(t, db) })
+
+	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{UserID: 1, Email: "owner@example.com", CreationTime: 1})
+	otherID := testutil.InsertUser(t, db, testutil.UserFixture{UserID: 2, Email: "other@example.com", CreationTime: 1})
+	repository := &Repository{DB: db}
+
+	require.NoError(t, repository.InsertOrUpdateCustomDomain(t.Context(), ownerID, "BÜCHER.example"))
+	domain, err := repository.GetDomain(t.Context(), ownerID)
+	require.NoError(t, err)
+	require.Equal(t, "BÜCHER.example", *domain)
+	resolvedOwnerID, err := repository.DomainOwner(t.Context(), "xn--bcher-kva.example")
+	require.NoError(t, err)
+	require.Equal(t, ownerID, *resolvedOwnerID)
+
+	err = repository.InsertOrUpdateCustomDomain(t.Context(), otherID, "bu\u0308cher.example")
+	var apiErr *ente.ApiError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, ente.CONFLICT, apiErr.Code)
+
+	require.NoError(t, repository.InsertOrUpdateCustomDomain(t.Context(), ownerID, "xn--bcher-kva.example"))
+	domain, err = repository.GetDomain(t.Context(), ownerID)
+	require.NoError(t, err)
+	require.Equal(t, "xn--bcher-kva.example", *domain)
+
+	pointer := ente.BuildFamilyCustomDomainPointer(ownerID, "family.example")
+	require.NoError(t, repository.InsertOrUpdate(t.Context(), ownerID, string(ente.CustomDomain), pointer))
+	require.NoError(t, repository.InsertOrUpdateCustomDomain(t.Context(), otherID, "BÜCHER.example"))
+
+	_, err = db.ExecContext(t.Context(), `UPDATE remote_store SET key_value = 'LEGACY.example'
+		WHERE user_id = $1 AND key_name = 'customDomain'`, otherID)
+	require.NoError(t, err)
+	require.NoError(t, repository.BackfillCustomDomainCanonicalValues(t.Context()))
+
+	var value string
+	var canonicalValue *string
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT key_value, canonical_value FROM remote_store
+		WHERE user_id = $1 AND key_name = 'customDomain'`, otherID).Scan(&value, &canonicalValue))
+	require.Equal(t, "LEGACY.example", value)
+	require.Equal(t, "legacy.example", *canonicalValue)
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT canonical_value FROM remote_store
+		WHERE user_id = $1 AND key_name = 'customDomain'`, ownerID).Scan(&canonicalValue))
+	require.Nil(t, canonicalValue)
+}

--- a/server/pkg/repo/remotestore/repository_test.go
+++ b/server/pkg/repo/remotestore/repository_test.go
@@ -25,10 +25,7 @@ func TestCustomDomainCanonicalUniqueness(t *testing.T) {
 	domain, err := repository.GetDomain(t.Context(), ownerID)
 	require.NoError(t, err)
 	require.Equal(t, "BÜCHER.example", *domain)
-	resolvedOwnerID, err := repository.DomainOwner(t.Context(), "xn--bcher-kva.example")
-	require.NoError(t, err)
-	require.Equal(t, ownerID, *resolvedOwnerID)
-	resolvedOwnerID, err = repository.DomainOwner(t.Context(), "XN--BCHER-KVA.EXAMPLE")
+	resolvedOwnerID, err := repository.DomainOwner(t.Context(), "XN--BCHER-KVA.EXAMPLE")
 	require.NoError(t, err)
 	require.Equal(t, ownerID, *resolvedOwnerID)
 
@@ -37,17 +34,12 @@ func TestCustomDomainCanonicalUniqueness(t *testing.T) {
 	require.ErrorAs(t, err, &apiErr)
 	require.Equal(t, ente.CONFLICT, apiErr.Code)
 
-	require.NoError(t, repository.InsertOrUpdateCustomDomain(t.Context(), ownerID, "xn--bcher-kva.example"))
-	domain, err = repository.GetDomain(t.Context(), ownerID)
-	require.NoError(t, err)
-	require.Equal(t, "xn--bcher-kva.example", *domain)
-
 	pointer := ente.BuildFamilyCustomDomainPointer(ownerID, "family.example")
 	require.NoError(t, repository.InsertOrUpdate(t.Context(), ownerID, string(ente.CustomDomain), pointer))
+	require.NoError(t, repository.InsertOrUpdateCustomDomain(t.Context(), otherID, "BÜCHER.example"))
 	_, err = db.ExecContext(t.Context(), `UPDATE remote_store SET canonical_value = 'released.example'
 		WHERE user_id = $1 AND key_name = 'customDomain'`, ownerID)
 	require.NoError(t, err)
-	require.NoError(t, repository.InsertOrUpdateCustomDomain(t.Context(), otherID, "BÜCHER.example"))
 
 	_, err = db.ExecContext(t.Context(), `UPDATE remote_store SET key_value = 'LEGACY.example'
 		WHERE user_id = $1 AND key_name = 'customDomain'`, otherID)
@@ -57,7 +49,7 @@ func TestCustomDomainCanonicalUniqueness(t *testing.T) {
 		($2, 'customDomain', 'xn--bcher-kva.example'),
 		($3, 'customDomain', 'invalid')`, collisionID1, collisionID2, invalidID)
 	require.NoError(t, err)
-	require.NoError(t, repository.MigrateCustomDomainCanonicalValues20260824(t.Context()))
+	require.NoError(t, repository.MigrateCustomDomainCanonicalValues(t.Context()))
 
 	var value string
 	var canonicalValue *string

--- a/server/pkg/repo/remotestore/repository_test.go
+++ b/server/pkg/repo/remotestore/repository_test.go
@@ -16,6 +16,9 @@ func TestCustomDomainCanonicalUniqueness(t *testing.T) {
 
 	ownerID := testutil.InsertUser(t, db, testutil.UserFixture{UserID: 1, Email: "owner@example.com", CreationTime: 1})
 	otherID := testutil.InsertUser(t, db, testutil.UserFixture{UserID: 2, Email: "other@example.com", CreationTime: 1})
+	collisionID1 := testutil.InsertUser(t, db, testutil.UserFixture{UserID: 3, Email: "collision1@example.com", CreationTime: 1})
+	collisionID2 := testutil.InsertUser(t, db, testutil.UserFixture{UserID: 4, Email: "collision2@example.com", CreationTime: 1})
+	invalidID := testutil.InsertUser(t, db, testutil.UserFixture{UserID: 5, Email: "invalid@example.com", CreationTime: 1})
 	repository := &Repository{DB: db}
 
 	require.NoError(t, repository.InsertOrUpdateCustomDomain(t.Context(), ownerID, "BÜCHER.example"))
@@ -23,6 +26,9 @@ func TestCustomDomainCanonicalUniqueness(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "BÜCHER.example", *domain)
 	resolvedOwnerID, err := repository.DomainOwner(t.Context(), "xn--bcher-kva.example")
+	require.NoError(t, err)
+	require.Equal(t, ownerID, *resolvedOwnerID)
+	resolvedOwnerID, err = repository.DomainOwner(t.Context(), "XN--BCHER-KVA.EXAMPLE")
 	require.NoError(t, err)
 	require.Equal(t, ownerID, *resolvedOwnerID)
 
@@ -43,6 +49,11 @@ func TestCustomDomainCanonicalUniqueness(t *testing.T) {
 	_, err = db.ExecContext(t.Context(), `UPDATE remote_store SET key_value = 'LEGACY.example'
 		WHERE user_id = $1 AND key_name = 'customDomain'`, otherID)
 	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(), `INSERT INTO remote_store (user_id, key_name, key_value) VALUES
+		($1, 'customDomain', 'BÜCHER.example'),
+		($2, 'customDomain', 'xn--bcher-kva.example'),
+		($3, 'customDomain', 'invalid')`, collisionID1, collisionID2, invalidID)
+	require.NoError(t, err)
 	require.NoError(t, repository.BackfillCustomDomainCanonicalValues(t.Context()))
 
 	var value string
@@ -54,4 +65,8 @@ func TestCustomDomainCanonicalUniqueness(t *testing.T) {
 	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT canonical_value FROM remote_store
 		WHERE user_id = $1 AND key_name = 'customDomain'`, ownerID).Scan(&canonicalValue))
 	require.Nil(t, canonicalValue)
+	var canonicalCount int
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT count(canonical_value) FROM remote_store
+		WHERE user_id IN ($1, $2, $3)`, collisionID1, collisionID2, invalidID).Scan(&canonicalCount))
+	require.Zero(t, canonicalCount)
 }

--- a/server/pkg/repo/remotestore/repository_test.go
+++ b/server/pkg/repo/remotestore/repository_test.go
@@ -44,6 +44,9 @@ func TestCustomDomainCanonicalUniqueness(t *testing.T) {
 
 	pointer := ente.BuildFamilyCustomDomainPointer(ownerID, "family.example")
 	require.NoError(t, repository.InsertOrUpdate(t.Context(), ownerID, string(ente.CustomDomain), pointer))
+	_, err = db.ExecContext(t.Context(), `UPDATE remote_store SET canonical_value = 'released.example'
+		WHERE user_id = $1 AND key_name = 'customDomain'`, ownerID)
+	require.NoError(t, err)
 	require.NoError(t, repository.InsertOrUpdateCustomDomain(t.Context(), otherID, "BÜCHER.example"))
 
 	_, err = db.ExecContext(t.Context(), `UPDATE remote_store SET key_value = 'LEGACY.example'


### PR DESCRIPTION
Canonicalize custom domains before ownership checks so equivalent case and IDNA representations cannot be assigned to different accounts.

- Preserve the user-entered value returned to clients while storing a separate canonical hostname for uniqueness.
- Canonicalize reserved-domain checks and ownership lookups.
- Backfill existing rows while skipping invalid or colliding values and clearing stale family pointers.

Migration decision: run the dated backfill once, asynchronously, 10 minutes after each Museum process starts. This avoids blocking startup and gives rolling deployments time to drain old writers; the last upgraded process performs a later reconciliation.

Potential impact: before a process runs the backfill, legacy rows are protected only by the raw case-insensitive fallback. A pre-existing  compatibility-mapped hostname could therefore be duplicated in canonical form during that window. The backfill detects such a collision and leaves both canonical values unset for manual resolution rather than choosing an owner. Reconciliation briefly locks the existing custom-domain rows, but does not block server startup.