### PR TITLE
[mob][photos] Simplify the skipped files screen

### DIFF
--- a/mobile/apps/photos/changes/remove-skipped-files-subtitle.md
+++ b/mobile/apps/photos/changes/remove-skipped-files-subtitle.md
@@ -1,0 +1,1 @@
+- Simplified the skipped files experience in device folders.

--- a/mobile/apps/photos/lib/ui/viewer/gallery/device/backup_header_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/device/backup_header_widget.dart
@@ -105,8 +105,6 @@ class _BackupHeaderWidgetState extends State<BackupHeaderWidget> {
         return _paddedHeader(
           MenuItemWidgetNew(
             title: l10n.skippedFiles,
-            subText: l10n.chooseReasonToViewFiles,
-            titleToSubTextSpacing: 2,
             leadingIconWidget: _menuIcon(
               context,
               HugeIcons.strokeRoundedReload,

--- a/mobile/apps/photos/lib/ui/viewer/gallery/device/device_folder_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/device/device_folder_page.dart
@@ -150,11 +150,7 @@ class _DeviceFolderPageState extends State<DeviceFolderPage> {
   Future<void> _openSkippedFiles() async {
     await routeToPage(
       context,
-      SkippedDeviceFolderPage(
-        widget.deviceCollection,
-        shouldBackup: _shouldBackup,
-        onBackupChanged: _updateBackupStatus,
-      ),
+      SkippedDeviceFolderPage(widget.deviceCollection),
     );
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/gallery/device/skipped_device_folder_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/device/skipped_device_folder_page.dart
@@ -267,29 +267,33 @@ class SkippedFilesHeaderWidget extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child: Row(
-                  children: [
-                    for (final bucket in visibleBuckets)
-                      Padding(
-                        padding: const EdgeInsets.only(right: 8),
-                        child: TagChipComponent(
-                          key: ValueKey("ignored_upload_filter_${bucket.name}"),
-                          label: ignoredUploadReasonBucketLabel(
-                            context,
-                            bucket,
+              if (visibleBuckets.length > 1) ...[
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      for (final bucket in visibleBuckets)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 8),
+                          child: TagChipComponent(
+                            key: ValueKey(
+                              "ignored_upload_filter_${bucket.name}",
+                            ),
+                            label: ignoredUploadReasonBucketLabel(
+                              context,
+                              bucket,
+                            ),
+                            state: effectiveSelectedBucket == bucket
+                                ? TagChipComponentState.selected
+                                : TagChipComponentState.unselected,
+                            onTap: () => onBucketChanged(bucket),
                           ),
-                          state: effectiveSelectedBucket == bucket
-                              ? TagChipComponentState.selected
-                              : TagChipComponentState.unselected,
-                          onTap: () => onBucketChanged(bucket),
                         ),
-                      ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              const SizedBox(height: 20),
+                const SizedBox(height: 20),
+              ],
               _ResetIgnoredFilesSection(
                 onResetIgnoredFiles: onResetIgnoredFiles,
               ),

--- a/mobile/apps/photos/lib/ui/viewer/gallery/device/skipped_device_folder_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/device/skipped_device_folder_page.dart
@@ -26,15 +26,8 @@ import "package:photos/ui/viewer/gallery/state/selection_state.dart";
 
 class SkippedDeviceFolderPage extends StatefulWidget {
   final DeviceCollection deviceCollection;
-  final bool shouldBackup;
-  final Future<bool> Function(bool shouldBackup) onBackupChanged;
 
-  const SkippedDeviceFolderPage(
-    this.deviceCollection, {
-    required this.shouldBackup,
-    required this.onBackupChanged,
-    super.key,
-  });
+  const SkippedDeviceFolderPage(this.deviceCollection, {super.key});
 
   @override
   State<SkippedDeviceFolderPage> createState() =>
@@ -48,13 +41,11 @@ class _SkippedDeviceFolderPageState extends State<SkippedDeviceFolderPage> {
   late final StreamSubscription<LocalPhotosUpdatedEvent> _localPhotosSub;
   late Future<List<EnteFile>> _filesInDeviceCollection;
   late Future<Set<IgnoredUploadReasonBucket>> _ignoredUploadBuckets;
-  late bool _shouldBackup;
   IgnoredUploadReasonBucket? _selectedBucket;
 
   @override
   void initState() {
     super.initState();
-    _shouldBackup = widget.shouldBackup;
     _refreshIgnoredState();
     _localPhotosSub = Bus.instance.on<LocalPhotosUpdatedEvent>().listen((_) {
       if (!mounted) {
@@ -98,11 +89,7 @@ class _SkippedDeviceFolderPageState extends State<SkippedDeviceFolderPage> {
       GalleryType.localFolder,
       l10n.skippedFiles,
       _selectedFiles,
-      deviceCollection: widget.deviceCollection,
-      isDeviceFolderBackedUp: _shouldBackup,
-      onDisableDeviceFolderBackup: () async {
-        await _updateBackupStatus(false);
-      },
+      showOverflowMenu: false,
     );
     final gallery = Gallery(
       key: ValueKey("skipped_device_folder:${widget.deviceCollection.id}"),
@@ -170,19 +157,6 @@ class _SkippedDeviceFolderPageState extends State<SkippedDeviceFolderPage> {
     setState(_refreshIgnoredState);
     await _syncSelectedBucket(popIfEmpty: true);
     unawaited(RemoteSyncService.instance.sync(silently: true));
-  }
-
-  Future<void> _updateBackupStatus(bool shouldBackup) async {
-    final updated = await widget.onBackupChanged(shouldBackup);
-    if (!mounted || !updated) {
-      return;
-    }
-    setState(() {
-      _shouldBackup = shouldBackup;
-    });
-    if (!shouldBackup) {
-      await Navigator.of(context).maybePop();
-    }
   }
 
   Future<void> _syncSelectedBucket({required bool popIfEmpty}) async {

--- a/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/gallery_app_bar_widget.dart
@@ -77,6 +77,7 @@ class GalleryAppBarWidget extends StatefulWidget {
     Collection? collection,
     List<EnteFile>? files,
     PreferredSizeWidget? bottom,
+    bool showOverflowMenu = true,
   }) {
     return GalleryAppBarConfig(
       sliverBuilder: (_) => GalleryAppBarWidget._(
@@ -90,6 +91,7 @@ class GalleryAppBarWidget extends StatefulWidget {
         collection: collection,
         files: files,
         bottom: bottom,
+        showOverflowMenu: showOverflowMenu,
       ),
       geometryBuilder: (context) => _resolveSliverGeometry(
         context,
@@ -139,6 +141,7 @@ class GalleryAppBarWidget extends StatefulWidget {
   final Collection? collection;
   final List<EnteFile>? files;
   final PreferredSizeWidget? bottom;
+  final bool showOverflowMenu;
 
   const GalleryAppBarWidget._(
     this.type,
@@ -151,6 +154,7 @@ class GalleryAppBarWidget extends StatefulWidget {
     this.collection,
     this.files,
     this.bottom,
+    required this.showOverflowMenu,
   });
 
   @override
@@ -570,7 +574,8 @@ class _GalleryAppBarWidgetState extends State<GalleryAppBarWidget> {
     final bool isArchived = widget.collection?.isArchived() ?? false;
     final bool isHidden = widget.collection?.isHidden() ?? false;
 
-    if (!_hasOverflowMenuActions(userId, isArchived, isHidden)) {
+    if (!widget.showOverflowMenu ||
+        !_hasOverflowMenuActions(userId, isArchived, isHidden)) {
       return actions;
     }
 

--- a/mobile/packages/strings/lib/l10n/arb/strings_bg.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_bg.arb
@@ -597,7 +597,6 @@
   "chooseBackupLocation": "Choose a backup location",
   "chooseFromAnExistingContact": "Choose from an existing contact",
   "chooseIcon": "Изберете икона",
-  "chooseReasonToViewFiles": "Choose a reason to view these files",
   "chooseYourPlan": "Choose your plan",
   "city": "In the city",
   "citySunsets": "City sunset glow",

--- a/mobile/packages/strings/lib/l10n/arb/strings_de.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_de.arb
@@ -594,7 +594,6 @@
   "chooseBackupLocation": "Sicherungsort festlegen",
   "chooseFromAnExistingContact": "Aus einem vorhandenen Kontakt auswählen",
   "chooseIcon": "Symbol wählen",
-  "chooseReasonToViewFiles": "Wähle einen Grund für die Anzeige dieser Dateien",
   "chooseYourPlan": "Wähle dein Abonnement",
   "city": "In der Stadt",
   "citySunsets": "Leuchtender Sonnenuntergang in der Stadt",

--- a/mobile/packages/strings/lib/l10n/arb/strings_en.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_en.arb
@@ -602,7 +602,6 @@
   "chooseBackupLocation": "Choose a backup location",
   "chooseFromAnExistingContact": "Choose from an existing contact",
   "chooseIcon": "Choose icon",
-  "chooseReasonToViewFiles": "Choose a reason to view these files",
   "chooseYourPlan": "Choose your plan",
   "city": "In the city",
   "citySunsets": "City sunset glow",

--- a/mobile/packages/strings/lib/l10n/arb/strings_fr.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_fr.arb
@@ -518,7 +518,6 @@
   "chooseBackupLocation": "Choisir l'emplacement de la sauvegarde",
   "chooseFromAnExistingContact": "Choisir parmi un contact existant",
   "chooseIcon": "Choisir un icône",
-  "chooseReasonToViewFiles": "Choisissez une raison pour voir ces fichiers",
   "chooseYourPlan": "Choisissez votre abonnement",
   "city": "Dans la ville",
   "citySunsets": "Coucher du soleil en ville",

--- a/mobile/packages/strings/lib/l10n/arb/strings_it.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_it.arb
@@ -579,7 +579,6 @@
   "chooseBackupLocation": "Scegli una posizione di backup",
   "chooseFromAnExistingContact": "Scegli da un contatto esistente",
   "chooseIcon": "Scegli icona",
-  "chooseReasonToViewFiles": "Scegliere un motivo per visualizzare questi file",
   "chooseYourPlan": "Scegli il tuo piano",
   "city": "In città",
   "citySunsets": "Tramonti in città",

--- a/mobile/packages/strings/lib/l10n/arb/strings_pt_BR.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_pt_BR.arb
@@ -597,7 +597,6 @@
   "chooseBackupLocation": "Selecione o local do backup",
   "chooseFromAnExistingContact": "Escolher de um contato existente",
   "chooseIcon": "Escolher ícone",
-  "chooseReasonToViewFiles": "Escolha um motivo para ver estes arquivos",
   "chooseYourPlan": "Escolha seu plano",
   "city": "Na cidade",
   "citySunsets": "Brilho do pôr do sol na cidade",

--- a/mobile/packages/strings/lib/l10n/arb/strings_ru.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_ru.arb
@@ -585,7 +585,6 @@
   "chooseBackupLocation": "Выберите место для резервной копии",
   "chooseFromAnExistingContact": "Выбрать из существующих контактов",
   "chooseIcon": "Выберите значок",
-  "chooseReasonToViewFiles": "Выберите причину для просмотра этих файлов",
   "chooseYourPlan": "Выбери свой тариф",
   "city": "В городе",
   "citySunsets": "Городской закат",

--- a/mobile/packages/strings/lib/l10n/arb/strings_vi.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_vi.arb
@@ -597,7 +597,6 @@
   "chooseBackupLocation": "Chọn nơi sao lưu",
   "chooseFromAnExistingContact": "Chọn từ danh bạ hiện có",
   "chooseIcon": "Chọn biểu tượng",
-  "chooseReasonToViewFiles": "Hãy chọn một lý do để xem các tệp này",
   "chooseYourPlan": "Chọn gói của bạn",
   "city": "Trong thành phố",
   "citySunsets": "Hoàng hôn thành phố",

--- a/mobile/packages/strings/lib/l10n/arb/strings_zh_TW.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_zh_TW.arb
@@ -484,7 +484,6 @@
   "chooseBackupLocation": "選擇備份存放位置",
   "chooseFromAnExistingContact": "從現有聯絡人中選擇",
   "chooseIcon": "選擇圖示",
-  "chooseReasonToViewFiles": "選擇原因以查看這些檔案",
   "chooseYourPlan": "選擇您的方案",
   "city": "在此城市",
   "citySunsets": "城市日落餘暉",


### PR DESCRIPTION
### Description

- Remove the “Choose a reason to view these files” subtitle and device-folder overflow menu.
- Hide reason filters when only one is available.