### PR TITLE
[mobile][photos] add double tap seek feature to video player

### DIFF
--- a/mobile/apps/photos/changes/video-double-tap-seek.md
+++ b/mobile/apps/photos/changes/video-double-tap-seek.md
@@ -1,0 +1,2 @@
+- Added double-tap video seek. (@r4khul)
+- Fixed video seek bar snapping glitch during manual drag. (@r4khul)

--- a/mobile/apps/photos/changes/video-double-tap-seek.md
+++ b/mobile/apps/photos/changes/video-double-tap-seek.md
@@ -1,2 +1,1 @@
-- Added double-tap video seek. (@r4khul)
-- Fixed video seek bar snapping glitch during manual drag. (@r4khul)
+- Added five-second double-tap seeking for videos. (@r4khul)

--- a/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
@@ -172,6 +172,10 @@ class _NativeVideoProgressControlsState
 
   void _onPlaybackPositionChanged() {
     final target = widget.controller.playbackPosition.inMilliseconds;
+    if (widget.controller.playbackStatus == PlaybackStatus.stopped &&
+        target != 0) {
+      return;
+    }
     final duration = _effectiveDurationInMilliseconds();
     widget.seekController.onPlayerPosition(
       Duration(milliseconds: target),

--- a/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/native_video_player_controls/seek_bar.dart
@@ -7,16 +7,17 @@ import "package:photos/core/event_bus.dart";
 import "package:photos/events/seekbar_triggered_event.dart";
 import "package:photos/theme/colors.dart";
 import "package:photos/ui/viewer/file/video_control/gallery_video_controls.dart";
+import "package:photos/ui/viewer/file/video_seek_controller.dart";
 
 class NativeVideoProgressControls extends StatefulWidget {
   final NativeVideoPlayerController controller;
   final int? duration;
-  final ValueNotifier<bool> isSeeking;
+  final VideoSeekController seekController;
 
   const NativeVideoProgressControls(
     this.controller,
     this.duration,
-    this.isSeeking, {
+    this.seekController, {
     super.key,
   });
 
@@ -30,10 +31,6 @@ class _NativeVideoProgressControlsState
     with SingleTickerProviderStateMixin {
   late final AnimationController _animationController;
   int _elapsedMilliseconds = 0;
-  final _debouncer = Debouncer(
-    const Duration(milliseconds: 100),
-    executionInterval: const Duration(milliseconds: 325),
-  );
   StreamSubscription<void>? _eventsSubscription;
   StreamSubscription<SeekbarTriggeredEvent>? _seekbarSubscription;
 
@@ -59,6 +56,7 @@ class _NativeVideoProgressControlsState
     });
 
     _eventsSubscription = widget.controller.events.listen(_listen);
+    widget.seekController.addListener(_onSeekStateChanged);
 
     _startMovingSeekbar();
   }
@@ -67,8 +65,8 @@ class _NativeVideoProgressControlsState
   void dispose() {
     _seekbarSubscription?.cancel();
     _eventsSubscription?.cancel();
+    widget.seekController.removeListener(_onSeekStateChanged);
     _animationController.dispose();
-    _debouncer.cancelDebounceTimer();
     super.dispose();
   }
 
@@ -77,6 +75,7 @@ class _NativeVideoProgressControlsState
     return AnimatedBuilder(
       animation: _animationController,
       builder: (_, _) {
+        final canSeek = widget.seekController.canSeek;
         final seekBar = SliderTheme(
           data: SliderTheme.of(context).copyWith(
             trackHeight: 3.0,
@@ -94,21 +93,30 @@ class _NativeVideoProgressControlsState
             min: 0.0,
             max: 1.0,
             value: _animationController.value,
-            onChangeStart: (value) {
-              widget.isSeeking.value = true;
-            },
-            onChanged: (value) {
-              _elapsedMilliseconds = _positionInMilliseconds(value) ?? 0;
-              _animationController.value = value;
-              _seekTo(value);
-            },
+            onChangeStart: canSeek
+                ? (value) => widget.seekController.beginSliderInteraction()
+                : null,
+            onChanged: canSeek
+                ? (value) {
+                    final position = _positionInMilliseconds(value);
+                    if (position != null) {
+                      widget.seekController.updateSliderTarget(
+                        Duration(milliseconds: position),
+                      );
+                    }
+                  }
+                : null,
             divisions: 4500,
-            onChangeEnd: (value) {
-              _elapsedMilliseconds = _positionInMilliseconds(value) ?? 0;
-              _animationController.value = value;
-              _seekTo(value);
-              widget.isSeeking.value = false;
-            },
+            onChangeEnd: canSeek
+                ? (value) {
+                    final position = _positionInMilliseconds(value);
+                    widget.seekController.endSliderInteraction(
+                      position == null
+                          ? widget.seekController.position
+                          : Duration(milliseconds: position),
+                    );
+                  }
+                : null,
             allowedInteraction: SliderInteraction.tapAndSlide,
           ),
         );
@@ -123,18 +131,12 @@ class _NativeVideoProgressControlsState
     );
   }
 
-  void _seekTo(double value) {
-    _debouncer.run(() async {
-      final position = _positionInMilliseconds(value);
-      if (position == null) return;
-      unawaited(widget.controller.seekTo(Duration(milliseconds: position)));
-    });
-  }
-
   void _startMovingSeekbar() {
     // Start the seek animation after delayed video playback begins.
     Future.delayed(const Duration(milliseconds: 700), () {
-      if (!mounted) {
+      if (!mounted ||
+          widget.seekController.state.phase != VideoSeekPhase.idle ||
+          widget.controller.playbackStatus != PlaybackStatus.playing) {
         return;
       }
       final nudge = _durationNudge();
@@ -168,35 +170,41 @@ class _NativeVideoProgressControlsState
     }
   }
 
-  void _onPlaybackPositionChanged() async {
-    if (widget.controller.playbackStatus == PlaybackStatus.paused ||
-        (widget.controller.playbackStatus == PlaybackStatus.stopped &&
-            widget.controller.playbackPosition.inSeconds != 0)) {
-      return;
-    }
+  void _onPlaybackPositionChanged() {
     final target = widget.controller.playbackPosition.inMilliseconds;
-
-    // The position event after zero arrives about 350 ms late.
-    if (target == 0) {
-      await Future.delayed(const Duration(milliseconds: 450));
-    }
-    if (!mounted) {
-      return;
-    }
-
-    _elapsedMilliseconds = target;
-    final duration = widget.controller.videoInfo?.durationInMilliseconds;
-    final double fractionTarget = duration == null || duration <= 0
-        ? 0
-        : target / duration;
-
-    final nudge = _durationNudge();
-    unawaited(
-      _animationController.animateTo(
-        (fractionTarget + nudge).clamp(0.0, 1.0),
-        duration: const Duration(seconds: 1),
-      ),
+    final duration = _effectiveDurationInMilliseconds();
+    widget.seekController.onPlayerPosition(
+      Duration(milliseconds: target),
+      duration: duration == null ? null : Duration(milliseconds: duration),
     );
+  }
+
+  void _onSeekStateChanged() => _syncFromController();
+
+  void _syncFromController() {
+    if (!mounted) return;
+    final duration = _effectiveDurationInMilliseconds();
+    final elapsed = widget.seekController.position.inMilliseconds;
+    if (_elapsedMilliseconds != elapsed) {
+      setState(() {
+        _elapsedMilliseconds = elapsed;
+      });
+    }
+    if (duration != null && duration > 0) {
+      final fraction = (elapsed / duration).clamp(0.0, 1.0);
+      if (widget.seekController.state.phase == VideoSeekPhase.idle &&
+          widget.controller.playbackStatus == PlaybackStatus.playing) {
+        unawaited(
+          _animationController.animateTo(
+            (fraction + _durationNudge()).clamp(0.0, 1.0),
+            duration: const Duration(seconds: 1),
+          ),
+        );
+      } else {
+        _animationController.stop();
+        _animationController.value = fraction;
+      }
+    }
   }
 
   int? _effectiveDurationInMilliseconds() {

--- a/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
@@ -168,8 +168,8 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
                       ),
                     ),
                     child: Container(
-                      width: 64,
-                      height: 64,
+                      width: 54,
+                      height: 54,
                       decoration: BoxDecoration(
                         color: Colors.black.withValues(alpha: 0.3),
                         shape: BoxShape.circle,
@@ -182,7 +182,7 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
                             icon: _badgeForward
                                 ? HugeIcons.strokeRoundedArrowRightDouble
                                 : HugeIcons.strokeRoundedArrowLeftDouble,
-                            size: 22,
+                            size: 20,
                             color: textBaseDark,
                           ),
                           Text(

--- a/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
@@ -1,0 +1,193 @@
+import "dart:async";
+
+import "package:flutter/material.dart";
+import "package:hugeicons/hugeicons.dart";
+import "package:photos/theme/colors.dart";
+import "package:photos/theme/ente_theme.dart";
+
+const kDefaultSeekDuration = Duration(seconds: 5);
+
+class DoubleTapSeekOverlay extends StatefulWidget {
+  final bool Function() enabled;
+  final Duration Function() position;
+  final Duration Function() duration;
+  final Duration Function(Duration) seekBy;
+  final VoidCallback? onSingleTap;
+  final VoidCallback? onSeekInteraction;
+  final GestureLongPressCallback? onLongPress;
+  final GestureLongPressUpCallback? onLongPressUp;
+
+  const DoubleTapSeekOverlay({
+    required this.enabled,
+    required this.position,
+    required this.duration,
+    required this.seekBy,
+    this.onSeekInteraction,
+    this.onSingleTap,
+    this.onLongPress,
+    this.onLongPressUp,
+    super.key,
+  });
+
+  @override
+  State<DoubleTapSeekOverlay> createState() => _DoubleTapSeekOverlayState();
+}
+
+class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
+    with SingleTickerProviderStateMixin {
+  Timer? _badgeHideTimer;
+  bool _showBadge = false;
+  bool _badgeForward = true;
+  int _accumulatedSeconds = 0;
+  DateTime? _lastDoubleTapTime;
+  bool? _lastDirection;
+  TapDownDetails? _doubleTapDetails;
+  int _seekGeneration = 0;
+  late final AnimationController _badgeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _badgeAnimation = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 180),
+    );
+  }
+
+  @override
+  void dispose() {
+    _badgeHideTimer?.cancel();
+    _badgeAnimation.dispose();
+    super.dispose();
+  }
+
+  void _handleDoubleTap(TapDownDetails details) {
+    if (!widget.enabled()) return;
+
+    final renderBox = context.findRenderObject() as RenderBox?;
+    final width = renderBox?.size.width ?? MediaQuery.of(context).size.width;
+    final isForward = details.localPosition.dx >= width / 2;
+
+    if (widget.duration() <= Duration.zero) return;
+
+    final now = DateTime.now();
+    final isFastSequence =
+        _lastDoubleTapTime != null &&
+        now.difference(_lastDoubleTapTime!).inMilliseconds <= 750 &&
+        _lastDirection == isForward;
+
+    final position = widget.position();
+    final target = widget.seekBy(
+      isForward ? kDefaultSeekDuration : -kDefaultSeekDuration,
+    );
+    final applied = (target - position).abs();
+    if (applied == Duration.zero) return;
+    final appliedSeconds = (applied.inMilliseconds / 1000).ceil();
+
+    if (isFastSequence) {
+      _accumulatedSeconds += appliedSeconds;
+    } else {
+      _accumulatedSeconds = appliedSeconds;
+      _lastDirection = isForward;
+    }
+    _lastDoubleTapTime = now;
+    _seekGeneration++;
+
+    widget.onSeekInteraction?.call();
+    _showSeekBadge(isForward);
+  }
+
+  void _showSeekBadge(bool forward) {
+    _badgeHideTimer?.cancel();
+    final generation = _seekGeneration;
+    setState(() {
+      _badgeForward = forward;
+      _showBadge = true;
+    });
+    _badgeAnimation.forward(from: 0);
+    _badgeHideTimer = Timer(const Duration(milliseconds: 750), () {
+      if (!mounted || generation != _seekGeneration) return;
+      setState(() {
+        _showBadge = false;
+        _lastDoubleTapTime = null;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTap: widget.onSingleTap,
+          onDoubleTapDown: (details) => _doubleTapDetails = details,
+          onDoubleTapCancel: () => _doubleTapDetails = null,
+          onDoubleTap: () {
+            if (_doubleTapDetails != null) {
+              _handleDoubleTap(_doubleTapDetails!);
+              _doubleTapDetails = null;
+            }
+          },
+          onLongPress: widget.onLongPress,
+          onLongPressUp: widget.onLongPressUp,
+          child: Container(constraints: const BoxConstraints.expand()),
+        ),
+        SafeArea(
+          top: false,
+          bottom: false,
+          child: Align(
+            alignment: _badgeForward
+                ? Alignment.centerRight
+                : Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: IgnorePointer(
+                child: AnimatedOpacity(
+                  opacity: _showBadge ? 1 : 0,
+                  duration: const Duration(milliseconds: 180),
+                  child: ScaleTransition(
+                    scale: Tween<double>(begin: 0.8, end: 1).animate(
+                      CurvedAnimation(
+                        parent: _badgeAnimation,
+                        curve: Curves.easeOutQuad,
+                      ),
+                    ),
+                    child: Container(
+                      width: 64,
+                      height: 64,
+                      decoration: BoxDecoration(
+                        color: Colors.black.withValues(alpha: 0.3),
+                        shape: BoxShape.circle,
+                        border: Border.all(color: strokeFaintDark, width: 1),
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          HugeIcon(
+                            icon: _badgeForward
+                                ? HugeIcons.strokeRoundedArrowRightDouble
+                                : HugeIcons.strokeRoundedArrowLeftDouble,
+                            size: 22,
+                            color: textBaseDark,
+                          ),
+                          Text(
+                            "${_accumulatedSeconds}s",
+                            style: getEnteTextTheme(
+                              context,
+                            ).tiny.copyWith(color: textBaseDark),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_double_tap_seek.dart
@@ -41,6 +41,7 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
   int _accumulatedSeconds = 0;
   DateTime? _lastDoubleTapTime;
   bool? _lastDirection;
+  Duration? _lastSeekTarget;
   TapDownDetails? _doubleTapDetails;
   int _seekGeneration = 0;
   late final AnimationController _badgeAnimation;
@@ -80,17 +81,28 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
     final target = widget.seekBy(
       isForward ? kDefaultSeekDuration : -kDefaultSeekDuration,
     );
-    final applied = (target - position).abs();
-    if (applied == Duration.zero) return;
-    final appliedSeconds = (applied.inMilliseconds / 1000).ceil();
+    if (isFastSequence && target == _lastSeekTarget) {
+      _lastDoubleTapTime = now;
+      _showSeekBadge(isForward);
+      return;
+    }
+    if (target == position) {
+      if (_showBadge) {
+        _lastDoubleTapTime = now;
+        _showSeekBadge(isForward);
+      }
+      return;
+    }
+    final requestedSeconds = kDefaultSeekDuration.inSeconds;
 
     if (isFastSequence) {
-      _accumulatedSeconds += appliedSeconds;
+      _accumulatedSeconds += requestedSeconds;
     } else {
-      _accumulatedSeconds = appliedSeconds;
+      _accumulatedSeconds = requestedSeconds;
       _lastDirection = isForward;
     }
     _lastDoubleTapTime = now;
+    _lastSeekTarget = target;
     _seekGeneration++;
 
     widget.onSeekInteraction?.call();
@@ -110,6 +122,7 @@ class _DoubleTapSeekOverlayState extends State<DoubleTapSeekOverlay>
       setState(() {
         _showBadge = false;
         _lastDoubleTapTime = null;
+        _lastSeekTarget = null;
       });
     });
   }

--- a/mobile/apps/photos/lib/ui/viewer/file/video_seek_controller.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_seek_controller.dart
@@ -1,0 +1,300 @@
+import "dart:async";
+
+import "package:flutter/foundation.dart";
+
+enum VideoSeekPhase { idle, dragging, settling }
+
+class VideoSeekState {
+  final Duration position;
+  final Duration? duration;
+  final VideoSeekPhase phase;
+  final int requestId;
+
+  const VideoSeekState({
+    required this.position,
+    required this.duration,
+    required this.phase,
+    required this.requestId,
+  });
+
+  bool get isInteracting => phase != VideoSeekPhase.idle;
+
+  @override
+  bool operator ==(Object other) =>
+      other is VideoSeekState &&
+      other.position == position &&
+      other.duration == duration &&
+      other.phase == phase &&
+      other.requestId == requestId;
+
+  @override
+  int get hashCode => Object.hash(position, duration, phase, requestId);
+
+  VideoSeekState copyWith({
+    Duration? position,
+    Duration? duration,
+    VideoSeekPhase? phase,
+    int? requestId,
+  }) {
+    return VideoSeekState(
+      position: position ?? this.position,
+      duration: duration ?? this.duration,
+      phase: phase ?? this.phase,
+      requestId: requestId ?? this.requestId,
+    );
+  }
+}
+
+class VideoSeekController extends ChangeNotifier {
+  static const _seekCommandTimeout = Duration(seconds: 2);
+  static const _positionTolerance = Duration(milliseconds: 750);
+  static const _reconciliationTimeout = Duration(seconds: 2);
+  static const _sliderSeekInterval = Duration(milliseconds: 300);
+
+  final Future<void> Function(Duration target) _seek;
+  final Duration Function() _readPosition;
+  final Duration? Function() _readDuration;
+  final void Function(Object error, StackTrace stackTrace)? _onSeekError;
+
+  VideoSeekState _state = const VideoSeekState(
+    position: Duration.zero,
+    duration: null,
+    phase: VideoSeekPhase.idle,
+    requestId: 0,
+  );
+  Duration _confirmedPosition = Duration.zero;
+  Duration? _expectedPosition;
+  Duration? _queuedTarget;
+  bool _commandInFlight = false;
+  bool _disposed = false;
+  int _sessionId = 0;
+  Timer? _reconciliationTimer;
+  Timer? _sliderSeekTimer;
+
+  VideoSeekController({
+    required Future<void> Function(Duration target) seek,
+    required Duration Function() readPosition,
+    required Duration? Function() readDuration,
+    void Function(Object error, StackTrace stackTrace)? onSeekError,
+  }) : _seek = seek,
+       _readPosition = readPosition,
+       _readDuration = readDuration,
+       _onSeekError = onSeekError;
+
+  VideoSeekState get state => _state;
+
+  Duration get position => _state.position;
+
+  Duration? get duration => _state.duration ?? _readDuration();
+
+  bool get canSeek {
+    final duration = this.duration;
+    return duration != null && duration > Duration.zero;
+  }
+
+  void updateDuration(Duration? duration) {
+    if (_disposed || _state.duration == duration) return;
+    _setState(_state.copyWith(duration: duration));
+  }
+
+  void beginSliderInteraction() {
+    if (_disposed || !canSeek) return;
+    _sliderSeekTimer?.cancel();
+    _sliderSeekTimer = null;
+    _setState(_state.copyWith(phase: VideoSeekPhase.dragging));
+  }
+
+  void updateSliderTarget(Duration target) {
+    if (_disposed || _state.phase != VideoSeekPhase.dragging) return;
+    _setOptimisticTarget(target, VideoSeekPhase.dragging);
+    if (_sliderSeekTimer?.isActive ?? false) return;
+    _sliderSeekTimer = Timer(_sliderSeekInterval, () {
+      _sliderSeekTimer = null;
+      _startCommandDrain();
+    });
+  }
+
+  void endSliderInteraction(Duration target) {
+    if (_disposed || _state.phase != VideoSeekPhase.dragging) return;
+    _sliderSeekTimer?.cancel();
+    _sliderSeekTimer = null;
+    _setOptimisticTarget(target, VideoSeekPhase.settling);
+    _startCommandDrain();
+  }
+
+  Duration seekBy(Duration delta) {
+    if (_disposed) return _state.position;
+    _sliderSeekTimer?.cancel();
+    _sliderSeekTimer = null;
+    final target = _clamp(_state.position + delta);
+    if (target == _state.position) return target;
+    _setOptimisticTarget(target, VideoSeekPhase.settling);
+    _startCommandDrain();
+    return _state.position;
+  }
+
+  void onPlayerPosition(Duration position, {Duration? duration}) {
+    if (_disposed) return;
+    if (duration != null) updateDuration(duration);
+
+    if (_state.phase == VideoSeekPhase.dragging) return;
+
+    final expected = _expectedPosition;
+    if (expected != null) {
+      if ((position - expected).abs() > _positionTolerance) {
+        return;
+      }
+      _clearReconciliation();
+    }
+
+    _confirmedPosition = position;
+    _setState(
+      _state.copyWith(
+        position: position,
+        phase: _commandInFlight || _queuedTarget != null
+            ? VideoSeekPhase.settling
+            : VideoSeekPhase.idle,
+      ),
+    );
+  }
+
+  void reset({Duration position = Duration.zero, Duration? duration}) {
+    if (_disposed) return;
+    _sessionId++;
+    _sliderSeekTimer?.cancel();
+    _sliderSeekTimer = null;
+    _queuedTarget = null;
+    _clearReconciliation();
+    _commandInFlight = false;
+    _confirmedPosition = position;
+    _setState(
+      VideoSeekState(
+        position: position,
+        duration: duration,
+        phase: VideoSeekPhase.idle,
+        requestId: _state.requestId + 1,
+      ),
+    );
+  }
+
+  void _setOptimisticTarget(Duration target, VideoSeekPhase phase) {
+    final clampedTarget = _clamp(target);
+    final requestId = _state.requestId + 1;
+    _reconciliationTimer?.cancel();
+    _reconciliationTimer = null;
+    _queuedTarget = clampedTarget;
+    _expectedPosition = clampedTarget;
+    _setState(
+      _state.copyWith(
+        position: clampedTarget,
+        phase: phase,
+        requestId: requestId,
+      ),
+    );
+  }
+
+  Duration _clamp(Duration target) {
+    final duration = this.duration;
+    if (duration == null || duration <= Duration.zero) {
+      return target < Duration.zero ? Duration.zero : target;
+    }
+    if (target < Duration.zero) return Duration.zero;
+    if (target > duration) return duration;
+    return target;
+  }
+
+  void _startCommandDrain() {
+    if (_commandInFlight || _disposed) return;
+    unawaited(_drainCommands());
+  }
+
+  Future<void> _drainCommands() async {
+    _commandInFlight = true;
+    final sessionId = _sessionId;
+    try {
+      while (!_disposed && sessionId == _sessionId) {
+        final target = _queuedTarget;
+        if (target == null) break;
+        final requestId = _state.requestId;
+        _queuedTarget = null;
+        try {
+          await _seek(target).timeout(_seekCommandTimeout);
+          if (!_disposed &&
+              sessionId == _sessionId &&
+              requestId == _state.requestId &&
+              _queuedTarget == null &&
+              _expectedPosition != null) {
+            _scheduleReconciliation(sessionId, requestId);
+          }
+        } catch (error, stackTrace) {
+          if (_disposed || sessionId != _sessionId) return;
+          if (_state.requestId != requestId || _queuedTarget != null) {
+            continue;
+          }
+          _clearReconciliation();
+          _queuedTarget = null;
+          _setState(
+            _state.copyWith(
+              position: _confirmedPosition,
+              phase: VideoSeekPhase.idle,
+            ),
+          );
+          _onSeekError?.call(error, stackTrace);
+          return;
+        }
+      }
+    } finally {
+      if (!_disposed && sessionId == _sessionId) {
+        _commandInFlight = false;
+        if (_queuedTarget != null) {
+          _startCommandDrain();
+        } else if (_expectedPosition == null &&
+            _state.phase != VideoSeekPhase.dragging) {
+          _setState(_state.copyWith(phase: VideoSeekPhase.idle));
+        }
+      }
+    }
+  }
+
+  void _scheduleReconciliation(int sessionId, int requestId) {
+    _reconciliationTimer?.cancel();
+    _reconciliationTimer = Timer(_reconciliationTimeout, () {
+      if (_disposed ||
+          sessionId != _sessionId ||
+          requestId != _state.requestId ||
+          _expectedPosition == null ||
+          _commandInFlight ||
+          _state.phase == VideoSeekPhase.dragging ||
+          _queuedTarget != null) {
+        return;
+      }
+      final position = _clamp(_readPosition());
+      _clearReconciliation();
+      _confirmedPosition = position;
+      _setState(
+        _state.copyWith(position: position, phase: VideoSeekPhase.idle),
+      );
+    });
+  }
+
+  void _clearReconciliation() {
+    _reconciliationTimer?.cancel();
+    _reconciliationTimer = null;
+    _expectedPosition = null;
+  }
+
+  void _setState(VideoSeekState state) {
+    if (_disposed || _state == state) return;
+    _state = state;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _sessionId++;
+    _reconciliationTimer?.cancel();
+    _sliderSeekTimer?.cancel();
+    super.dispose();
+  }
+}

--- a/mobile/apps/photos/lib/ui/viewer/file/video_seek_controller.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_seek_controller.dart
@@ -46,7 +46,6 @@ class VideoSeekState {
 }
 
 class VideoSeekController extends ChangeNotifier {
-  static const _seekCommandTimeout = Duration(seconds: 2);
   static const _positionTolerance = Duration(milliseconds: 750);
   static const _reconciliationTimeout = Duration(seconds: 2);
   static const _sliderSeekInterval = Duration(milliseconds: 300);
@@ -165,7 +164,6 @@ class VideoSeekController extends ChangeNotifier {
     _sliderSeekTimer = null;
     _queuedTarget = null;
     _clearReconciliation();
-    _commandInFlight = false;
     _confirmedPosition = position;
     _setState(
       VideoSeekState(
@@ -218,7 +216,7 @@ class VideoSeekController extends ChangeNotifier {
         final requestId = _state.requestId;
         _queuedTarget = null;
         try {
-          await _seek(target).timeout(_seekCommandTimeout);
+          await _seek(target);
           if (!_disposed &&
               sessionId == _sessionId &&
               requestId == _state.requestId &&
@@ -244,11 +242,12 @@ class VideoSeekController extends ChangeNotifier {
         }
       }
     } finally {
-      if (!_disposed && sessionId == _sessionId) {
-        _commandInFlight = false;
+      _commandInFlight = false;
+      if (!_disposed) {
         if (_queuedTarget != null) {
           _startCommandDrain();
-        } else if (_expectedPosition == null &&
+        } else if (sessionId == _sessionId &&
+            _expectedPosition == null &&
             _state.phase != VideoSeekPhase.dragging) {
           _setState(_state.copyWith(phase: VideoSeekPhase.idle));
         }

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
@@ -4,11 +4,14 @@ import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_ui/components/loading_widget.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
+import "package:logging/logging.dart";
 import "package:media_kit_video/media_kit_video.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/states/detail_page_state.dart";
 import "package:photos/theme/colors.dart";
 import "package:photos/ui/viewer/file/video_control/gallery_video_controls.dart";
+import "package:photos/ui/viewer/file/video_double_tap_seek.dart";
+import "package:photos/ui/viewer/file/video_seek_controller.dart";
 import "package:photos/ui/viewer/file/video_stream_change.dart";
 import "package:photos/ui/viewer/file/zoomable_video_viewer.dart";
 
@@ -42,19 +45,33 @@ class VideoWidget extends StatefulWidget {
 }
 
 class _VideoWidgetState extends State<VideoWidget> {
+  final _logger = Logger("VideoWidget");
   final showControlsNotifier = ValueNotifier<bool>(true);
   final _hideControlsDebouncer = Debouncer(const Duration(milliseconds: 2000));
-  final _isSeekingNotifier = ValueNotifier<bool>(false);
+  late final VideoSeekController _seekController;
+  bool _isSeekInteractionActive = false;
   late final StreamSubscription<bool> _isPlayingStreamSubscription;
+  late final StreamSubscription<bool> _completedStreamSubscription;
 
   @override
   void initState() {
     super.initState();
     widget.playbackSpeed.addListener(_onPlaybackSpeedChanged);
     widget.controller.player.setRate(widget.playbackSpeed.value);
+    _seekController = VideoSeekController(
+      seek: widget.controller.player.seek,
+      readPosition: () => widget.controller.player.state.position,
+      readDuration: () => widget.controller.player.state.duration,
+      onSeekError: (error, stackTrace) {
+        _logger.warning("Could not seek video", error, stackTrace);
+      },
+    );
+    _seekController.addListener(_onSeekInteractionChanged);
     _isPlayingStreamSubscription = widget.controller.player.stream.playing
         .listen((isPlaying) {
-          if (isPlaying && !_isSeekingNotifier.value) {
+          if (!isPlaying) {
+            _hideControlsDebouncer.cancelDebounceTimer();
+          } else if (!_seekController.state.isInteracting) {
             _hideControlsDebouncer.run(() async {
               showControlsNotifier.value = false;
               widget.playbackCallback?.call(
@@ -64,8 +81,15 @@ class _VideoWidgetState extends State<VideoWidget> {
             });
           }
         });
-
-    _isSeekingNotifier.addListener(isSeekingListener);
+    _completedStreamSubscription = widget.controller.player.stream.completed
+        .listen((isCompleted) {
+          if (isCompleted) {
+            _seekController.reset(
+              position: widget.controller.player.state.position,
+              duration: widget.controller.player.state.duration,
+            );
+          }
+        });
   }
 
   @override
@@ -73,9 +97,10 @@ class _VideoWidgetState extends State<VideoWidget> {
     widget.playbackSpeed.removeListener(_onPlaybackSpeedChanged);
     showControlsNotifier.dispose();
     _isPlayingStreamSubscription.cancel();
+    _completedStreamSubscription.cancel();
     _hideControlsDebouncer.cancelDebounceTimer();
-    _isSeekingNotifier.removeListener(isSeekingListener);
-    _isSeekingNotifier.dispose();
+    _seekController.removeListener(_onSeekInteractionChanged);
+    _seekController.dispose();
     super.dispose();
   }
 
@@ -83,8 +108,11 @@ class _VideoWidgetState extends State<VideoWidget> {
     widget.controller.player.setRate(widget.playbackSpeed.value);
   }
 
-  void isSeekingListener() {
-    if (_isSeekingNotifier.value) {
+  void _onSeekInteractionChanged() {
+    final isInteracting = _seekController.state.isInteracting;
+    if (_isSeekInteractionActive == isInteracting) return;
+    _isSeekInteractionActive = isInteracting;
+    if (isInteracting) {
       _hideControlsDebouncer.cancelDebounceTimer();
     } else {
       if (widget.controller.player.state.playing) {
@@ -116,6 +144,48 @@ class _VideoWidgetState extends State<VideoWidget> {
                 child: videoWidget,
               )
             : videoWidget,
+        DoubleTapSeekOverlay(
+          enabled: () => !widget.isFromMemories,
+          position: () => _seekController.position,
+          duration: () => widget.controller.player.state.duration,
+          seekBy: _seekController.seekBy,
+          onSeekInteraction: () {
+            showControlsNotifier.value = true;
+          },
+          onSingleTap: widget.isFromMemories
+              ? null
+              : () {
+                  showControlsNotifier.value = !showControlsNotifier.value;
+                  if (widget.playbackCallback != null) {
+                    widget.playbackCallback!(
+                      !showControlsNotifier.value,
+                      FullScreenRequestReason.userInteraction,
+                    );
+                  }
+                },
+          onLongPress: widget.isFromMemories
+              ? () {
+                  widget.playbackCallback?.call(
+                    false,
+                    FullScreenRequestReason.userInteraction,
+                  );
+                  if (widget.controller.player.state.playing) {
+                    widget.controller.player.pause();
+                  }
+                }
+              : null,
+          onLongPressUp: widget.isFromMemories
+              ? () {
+                  widget.playbackCallback?.call(
+                    true,
+                    FullScreenRequestReason.userInteraction,
+                  );
+                  if (!widget.controller.player.state.playing) {
+                    widget.controller.player.play();
+                  }
+                }
+              : null,
+        ),
         ValueListenableBuilder(
           valueListenable: showControlsNotifier,
           builder: (context, value, _) {
@@ -130,46 +200,6 @@ class _VideoWidgetState extends State<VideoWidget> {
                     VideoBottomScrim(
                       hasCaption: widget.file.caption?.isNotEmpty ?? false,
                     ),
-                  GestureDetector(
-                    behavior: HitTestBehavior.translucent,
-                    onTap: widget.isFromMemories
-                        ? null
-                        : () {
-                            showControlsNotifier.value =
-                                !showControlsNotifier.value;
-                            if (widget.playbackCallback != null) {
-                              widget.playbackCallback!(
-                                !showControlsNotifier.value,
-                                FullScreenRequestReason.userInteraction,
-                              );
-                            }
-                          },
-                    onLongPress: () {
-                      if (widget.isFromMemories) {
-                        widget.playbackCallback?.call(
-                          false,
-                          FullScreenRequestReason.userInteraction,
-                        );
-                        if (widget.controller.player.state.playing) {
-                          widget.controller.player.pause();
-                        }
-                      }
-                    },
-                    onLongPressUp: () {
-                      if (widget.isFromMemories) {
-                        widget.playbackCallback?.call(
-                          true,
-                          FullScreenRequestReason.userInteraction,
-                        );
-                        if (!widget.controller.player.state.playing) {
-                          widget.controller.player.play();
-                        }
-                      }
-                    },
-                    child: Container(
-                      constraints: const BoxConstraints.expand(),
-                    ),
-                  ),
                   widget.isFromMemories
                       ? const SizedBox.shrink()
                       : IgnorePointer(
@@ -190,7 +220,7 @@ class _VideoWidgetState extends State<VideoWidget> {
                               right: false,
                               child: _MediaKitVideoProgressControls(
                                 controller: widget.controller,
-                                isSeekingNotifier: _isSeekingNotifier,
+                                seekController: _seekController,
                               ),
                             ),
                           ),
@@ -211,7 +241,15 @@ class _VideoWidgetState extends State<VideoWidget> {
                               showControls: value,
                               file: widget.file,
                               isPreviewPlayer: widget.isPreviewPlayer,
-                              onStreamChange: widget.onStreamChange,
+                              onStreamChange: () {
+                                _seekController.reset(
+                                  position:
+                                      widget.controller.player.state.position,
+                                  duration:
+                                      widget.controller.player.state.duration,
+                                );
+                                widget.onStreamChange();
+                              },
                             ),
                           ),
                         ),
@@ -310,11 +348,11 @@ class _PlayPauseButtonState extends State<PlayPauseButtonMediaKit> {
 
 class _MediaKitVideoProgressControls extends StatefulWidget {
   final VideoController controller;
-  final ValueNotifier<bool> isSeekingNotifier;
+  final VideoSeekController seekController;
 
   const _MediaKitVideoProgressControls({
     required this.controller,
-    required this.isSeekingNotifier,
+    required this.seekController,
   });
 
   @override
@@ -324,48 +362,34 @@ class _MediaKitVideoProgressControls extends StatefulWidget {
 
 class _MediaKitVideoProgressControlsState
     extends State<_MediaKitVideoProgressControls> {
-  double _sliderValue = 0.0;
-  Duration _elapsedTime = Duration.zero;
   late final StreamSubscription<Duration> _positionStreamSubscription;
-  final _debouncer = Debouncer(
-    const Duration(milliseconds: 300),
-    executionInterval: const Duration(milliseconds: 300),
-  );
   @override
   void initState() {
     super.initState();
+    widget.seekController.addListener(_onSeekStateChanged);
     _positionStreamSubscription = widget.controller.player.stream.position
         .listen((event) {
-          if (widget.isSeekingNotifier.value) return;
-          if (mounted) {
-            setState(() {
-              _elapsedTime = event;
-              _sliderValue =
-                  (event.inMilliseconds /
-                          widget
-                              .controller
-                              .player
-                              .state
-                              .duration
-                              .inMilliseconds)
-                      .clamp(0, 1);
-              if (_sliderValue.isNaN) {
-                _sliderValue = 0.0;
-              }
-            });
-          }
+          widget.seekController.onPlayerPosition(
+            event,
+            duration: widget.controller.player.state.duration,
+          );
         });
   }
 
   @override
   void dispose() {
+    widget.seekController.removeListener(_onSeekStateChanged);
     _positionStreamSubscription.cancel();
-    _debouncer.cancelDebounceTimer();
     super.dispose();
+  }
+
+  void _onSeekStateChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
+    final canSeek = widget.seekController.canSeek;
     final seekBar = SliderTheme(
       data: SliderTheme.of(context).copyWith(
         trackHeight: 3.0,
@@ -383,51 +407,40 @@ class _MediaKitVideoProgressControlsState
         min: 0.0,
         max: 1.0,
         value: _sliderValue,
-        onChangeStart: (value) {
-          if (mounted) {
-            setState(() {
-              widget.isSeekingNotifier.value = true;
-            });
-          }
-        },
-        onChanged: (value) {
-          if (mounted) {
-            setState(() {
-              _sliderValue = value;
-              _elapsedTime = _positionAt(value);
-            });
-          }
-
-          _debouncer.run(() async {
-            await widget.controller.player.seek(_positionAt(value));
-          });
-        },
+        onChangeStart: canSeek
+            ? (value) => widget.seekController.beginSliderInteraction()
+            : null,
+        onChanged: canSeek
+            ? (value) =>
+                  widget.seekController.updateSliderTarget(_positionAt(value))
+            : null,
         divisions: 4500,
-        onChangeEnd: (value) async {
-          await widget.controller.player.seek(_positionAt(value));
-          if (mounted) {
-            setState(() {
-              widget.isSeekingNotifier.value = false;
-            });
-          }
-        },
+        onChangeEnd: canSeek
+            ? (value) =>
+                  widget.seekController.endSliderInteraction(_positionAt(value))
+            : null,
         allowedInteraction: SliderInteraction.tapAndSlide,
       ),
     );
     return VideoProgressRow(
       seekBar: seekBar,
-      elapsedTime: secondsToDuration(_elapsedTime.inSeconds),
+      elapsedTime: secondsToDuration(widget.seekController.position.inSeconds),
       totalTime: secondsToDuration(
-        widget.controller.player.state.duration.inSeconds,
+        (widget.seekController.duration ?? Duration.zero).inSeconds,
       ),
     );
   }
 
   Duration _positionAt(double value) {
-    return Duration(
-      milliseconds:
-          (value * widget.controller.player.state.duration.inMilliseconds)
-              .round(),
-    );
+    final duration = widget.seekController.duration ?? Duration.zero;
+    return Duration(milliseconds: (value * duration.inMilliseconds).round());
+  }
+
+  double get _sliderValue {
+    final duration = widget.seekController.duration;
+    if (duration == null || duration <= Duration.zero) return 0;
+    return (widget.seekController.position.inMilliseconds /
+            duration.inMilliseconds)
+        .clamp(0.0, 1.0);
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -34,6 +34,8 @@ import "package:photos/ui/viewer/file/native_video_player_controls/play_pause_bu
 import "package:photos/ui/viewer/file/native_video_player_controls/seek_bar.dart";
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
 import "package:photos/ui/viewer/file/video_control/gallery_video_controls.dart";
+import "package:photos/ui/viewer/file/video_double_tap_seek.dart";
+import "package:photos/ui/viewer/file/video_seek_controller.dart";
 import "package:photos/ui/viewer/file/video_stream_change.dart";
 import "package:photos/ui/viewer/file/zoomable_video_viewer.dart";
 import "package:photos/utils/dialog_util.dart";
@@ -92,6 +94,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   bool _isCompletelyVisible = false;
   final _showControls = ValueNotifier(true);
   final _isSeeking = ValueNotifier(false);
+  late final VideoSeekController _seekController;
   final _debouncer = Debouncer(const Duration(milliseconds: 2000));
   StreamSubscription<PlaybackEvent>? _subscription;
   StreamSubscription<StreamSwitchedEvent>? _streamSwitchedSubscription;
@@ -106,6 +109,25 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
     );
     super.initState();
     widget.playbackSpeed.addListener(_onPlaybackSpeedChanged);
+    _seekController = VideoSeekController(
+      seek: (target) async {
+        final controller = _controller;
+        if (controller != null) await controller.seekTo(target);
+      },
+      readPosition: () => _controller?.playbackPosition ?? Duration.zero,
+      readDuration: () {
+        final milliseconds = _controller?.videoInfo?.durationInMilliseconds;
+        if (milliseconds != null && milliseconds > 0) {
+          return Duration(milliseconds: milliseconds);
+        }
+        final seconds = durationToSeconds(duration);
+        return seconds == null ? null : Duration(seconds: seconds);
+      },
+      onSeekError: (error, stackTrace) {
+        _logger.warning("Could not seek video", error, stackTrace);
+      },
+    );
+    _seekController.addListener(_syncSeekInteraction);
     WidgetsBinding.instance.addObserver(this);
 
     if (widget.selectedPreview) {
@@ -177,6 +199,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   }
 
   Future<void> setVideoSource() async {
+    _seekController.reset();
     if (_filePath == null) {
       _logger.info('Stop video player, file path is null');
       await _controller?.stop();
@@ -288,6 +311,8 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
     _showControls.dispose();
     _isSeeking.removeListener(_seekListener);
     _isSeeking.dispose();
+    _seekController.removeListener(_syncSeekInteraction);
+    _seekController.dispose();
     _debouncer.cancelDebounceTimer();
     _transformationController.dispose();
     wakeLockService.updateWakeLock(
@@ -378,9 +403,17 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                     widget.file.caption?.isNotEmpty ?? false,
                               ),
                             ),
-                          GestureDetector(
-                            behavior: HitTestBehavior.translucent,
-                            onTap: widget.isFromMemories
+                          DoubleTapSeekOverlay(
+                            enabled: () =>
+                                !widget.isFromMemories && isPlaybackReady,
+                            position: () => _seekController.position,
+                            duration: () =>
+                                _seekController.duration ?? Duration.zero,
+                            seekBy: _seekController.seekBy,
+                            onSeekInteraction: () {
+                              _showControls.value = true;
+                            },
+                            onSingleTap: widget.isFromMemories
                                 ? null
                                 : () {
                                     _showControls.value = !_showControls.value;
@@ -391,27 +424,25 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                       );
                                     }
                                   },
-                            onLongPress: () {
-                              if (widget.isFromMemories) {
-                                widget.playbackCallback?.call(
-                                  false,
-                                  FullScreenRequestReason.userInteraction,
-                                );
-                                _controller?.pause();
-                              }
-                            },
-                            onLongPressUp: () {
-                              if (widget.isFromMemories && widget.isActive) {
-                                widget.playbackCallback?.call(
-                                  true,
-                                  FullScreenRequestReason.userInteraction,
-                                );
-                                _controller?.play();
-                              }
-                            },
-                            child: Container(
-                              constraints: const BoxConstraints.expand(),
-                            ),
+                            onLongPress: widget.isFromMemories
+                                ? () {
+                                    widget.playbackCallback?.call(
+                                      false,
+                                      FullScreenRequestReason.userInteraction,
+                                    );
+                                    _controller?.pause();
+                                  }
+                                : null,
+                            onLongPressUp: widget.isFromMemories
+                                ? () {
+                                    if (!widget.isActive) return;
+                                    widget.playbackCallback?.call(
+                                      true,
+                                      FullScreenRequestReason.userInteraction,
+                                    );
+                                    _controller?.play();
+                                  }
+                                : null,
                           ),
                           if (!widget.isFromMemories && isPlaybackReady)
                             Positioned.fill(
@@ -451,7 +482,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                             controller: _controller!,
                                             duration: duration,
                                             showControls: _showControls,
-                                            isSeeking: _isSeeking,
+                                            seekController: _seekController,
                                           )
                                         : const SizedBox.shrink(),
                                   ),
@@ -542,6 +573,10 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
 
   void _seekListener() {
     if (widget.isFromMemories) return;
+    if (_isSeeking.value) {
+      _debouncer.cancelDebounceTimer();
+      return;
+    }
     if (!_isSeeking.value &&
         _controller?.playbackStatus == PlaybackStatus.playing) {
       _debouncer.run(() async {
@@ -559,6 +594,13 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
           }
         }
       });
+    }
+  }
+
+  void _syncSeekInteraction() {
+    final isSeeking = _seekController.state.isInteracting;
+    if (_isSeeking.value != isSeeking) {
+      _isSeeking.value = isSeeking;
     }
   }
 
@@ -591,6 +633,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
         });
       }
     } else {
+      _debouncer.cancelDebounceTimer();
       if (widget.playbackCallback != null && mounted) {
         widget.playbackCallback!(
           false,
@@ -621,6 +664,8 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
   }
 
   void _onPlaybackEnded() async {
+    _seekController.reset(duration: _seekController.duration);
+    _debouncer.cancelDebounceTimer();
     await _controller?.stop();
     if (widget.isActive && localSettings.shouldLoopVideo()) {
       Bus.instance.fire(SeekbarTriggeredEvent(position: 0));
@@ -891,13 +936,13 @@ class _VideoProgressControls extends StatelessWidget {
   final NativeVideoPlayerController controller;
   final String? duration;
   final ValueNotifier<bool> showControls;
-  final ValueNotifier<bool> isSeeking;
+  final VideoSeekController seekController;
 
   const _VideoProgressControls({
     required this.controller,
     required this.duration,
     required this.showControls,
-    required this.isSeeking,
+    required this.seekController,
   });
 
   @override
@@ -914,7 +959,7 @@ class _VideoProgressControls extends StatelessWidget {
             child: NativeVideoProgressControls(
               controller,
               durationToSeconds(duration),
-              isSeeking,
+              seekController,
             ),
           ),
         );

--- a/mobile/apps/photos/test/ui/viewer/file/video_double_tap_seek_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/file/video_double_tap_seek_test.dart
@@ -1,0 +1,188 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/ui/viewer/file/video_double_tap_seek.dart";
+
+void main() {
+  testWidgets("opposite-direction double taps reset the accumulated badge", (
+    tester,
+  ) async {
+    final seeks = <Duration>[];
+    var position = const Duration(seconds: 30);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 300,
+          child: DoubleTapSeekOverlay(
+            enabled: () => true,
+            position: () => position,
+            duration: () => const Duration(seconds: 60),
+            seekBy: (delta) {
+              position += delta;
+              if (position < Duration.zero) position = Duration.zero;
+              if (position > const Duration(seconds: 60)) {
+                position = const Duration(seconds: 60);
+              }
+              seeks.add(position);
+              return position;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await _doubleTap(tester, forward: true);
+    await _doubleTap(tester, forward: false);
+
+    expect(seeks, [const Duration(seconds: 35), const Duration(seconds: 30)]);
+    expect(find.text("5s"), findsOneWidget);
+  });
+
+  testWidgets("rapid same-direction double taps accumulate the badge", (
+    tester,
+  ) async {
+    final seeks = <Duration>[];
+    var position = Duration.zero;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 300,
+          child: DoubleTapSeekOverlay(
+            enabled: () => true,
+            position: () => position,
+            duration: () => const Duration(seconds: 40),
+            seekBy: (delta) {
+              position += delta;
+              if (position > const Duration(seconds: 40)) {
+                position = const Duration(seconds: 40);
+              }
+              seeks.add(position);
+              return position;
+            },
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 8; i++) {
+      await _doubleTap(tester, forward: true);
+    }
+
+    expect(seeks, [
+      for (var seconds = 5; seconds <= 40; seconds += 5)
+        Duration(seconds: seconds),
+    ]);
+    expect(find.text("40s"), findsOneWidget);
+  });
+
+  testWidgets(
+    "keeps the requested badge when position updates are stale at a boundary",
+    (tester) async {
+      final seeks = <Duration>[];
+      const position = Duration(seconds: 2);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 400,
+            height: 300,
+            child: DoubleTapSeekOverlay(
+              enabled: () => true,
+              position: () => position,
+              duration: () => const Duration(seconds: 60),
+              seekBy: (delta) {
+                final unclampedTarget = position + delta;
+                final target = unclampedTarget < Duration.zero
+                    ? Duration.zero
+                    : unclampedTarget > const Duration(seconds: 60)
+                    ? const Duration(seconds: 60)
+                    : unclampedTarget;
+                seeks.add(target);
+                return target;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await _doubleTap(tester, forward: false);
+      await _doubleTap(tester, forward: false);
+
+      expect(seeks, [Duration.zero, Duration.zero]);
+      expect(find.text("5s"), findsOneWidget);
+    },
+  );
+
+  testWidgets("reports the requested seek at a boundary", (tester) async {
+    var position = const Duration(seconds: 57);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 300,
+          child: DoubleTapSeekOverlay(
+            enabled: () => true,
+            position: () => position,
+            duration: () => const Duration(seconds: 60),
+            seekBy: (delta) {
+              position += delta;
+              if (position > const Duration(seconds: 60)) {
+                position = const Duration(seconds: 60);
+              }
+              return position;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await _doubleTap(tester, forward: true);
+
+    expect(find.text("5s"), findsOneWidget);
+  });
+
+  testWidgets("does not seek while the overlay is disabled", (tester) async {
+    var seekCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 300,
+          child: DoubleTapSeekOverlay(
+            enabled: () => false,
+            position: () => const Duration(seconds: 30),
+            duration: () => const Duration(seconds: 60),
+            seekBy: (_) {
+              seekCount++;
+              return const Duration(seconds: 30);
+            },
+          ),
+        ),
+      ),
+    );
+
+    await _doubleTap(tester, forward: true);
+
+    expect(seekCount, 0);
+  });
+}
+
+Future<void> _doubleTap(WidgetTester tester, {required bool forward}) async {
+  final rect = tester.getRect(find.byType(DoubleTapSeekOverlay));
+  final position = Offset(
+    rect.left + rect.width * (forward ? 0.75 : 0.25),
+    rect.center.dy,
+  );
+  final firstTap = await tester.startGesture(position);
+  await firstTap.up();
+  await tester.pump(const Duration(milliseconds: 50));
+
+  final secondTap = await tester.startGesture(position);
+  await secondTap.up();
+  await tester.pump(const Duration(milliseconds: 400));
+}

--- a/mobile/apps/photos/test/ui/viewer/file/video_seek_controller_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/file/video_seek_controller_test.dart
@@ -1,0 +1,225 @@
+import "dart:async";
+
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/ui/viewer/file/video_seek_controller.dart";
+
+void main() {
+  test(
+    "retains the latest user intent while an earlier seek is in flight",
+    () async {
+      final firstSeek = Completer<void>();
+      final seeks = <Duration>[];
+      final controller = VideoSeekController(
+        seek: (target) {
+          seeks.add(target);
+          return seeks.length == 1 ? firstSeek.future : Future.value();
+        },
+        readPosition: () => const Duration(seconds: 40),
+        readDuration: () => const Duration(seconds: 60),
+      );
+      controller.onPlayerPosition(const Duration(seconds: 30));
+
+      controller.seekBy(const Duration(seconds: 5));
+      await _flushMicrotasks();
+      controller.seekBy(const Duration(seconds: 5));
+
+      expect(controller.position, const Duration(seconds: 40));
+      expect(seeks, [const Duration(seconds: 35)]);
+
+      firstSeek.complete();
+      await _flushMicrotasks();
+
+      expect(seeks, [const Duration(seconds: 35), const Duration(seconds: 40)]);
+      controller.onPlayerPosition(const Duration(seconds: 40));
+      expect(controller.state.phase, VideoSeekPhase.idle);
+      controller.dispose();
+    },
+  );
+
+  test(
+    "rejects a stale player event until the requested target is observed",
+    () async {
+      final controller = VideoSeekController(
+        seek: (_) async {},
+        readPosition: () => const Duration(seconds: 35),
+        readDuration: () => const Duration(seconds: 60),
+      );
+      controller.onPlayerPosition(const Duration(seconds: 30));
+
+      controller.seekBy(const Duration(seconds: 5));
+      await _flushMicrotasks();
+      controller.onPlayerPosition(const Duration(seconds: 10));
+
+      expect(controller.position, const Duration(seconds: 35));
+
+      controller.onPlayerPosition(const Duration(seconds: 35));
+      expect(controller.position, const Duration(seconds: 35));
+      expect(controller.state.phase, VideoSeekPhase.idle);
+      controller.dispose();
+    },
+  );
+
+  test("a source reset keeps an in-flight seek serialized", () async {
+    final firstSeek = Completer<void>();
+    final seeks = <Duration>[];
+    final controller = VideoSeekController(
+      seek: (target) {
+        seeks.add(target);
+        return seeks.length == 1 ? firstSeek.future : Future.value();
+      },
+      readPosition: () => const Duration(seconds: 12),
+      readDuration: () => const Duration(seconds: 60),
+    );
+
+    controller.seekBy(const Duration(seconds: 5));
+    await _flushMicrotasks();
+    controller.reset(
+      position: const Duration(seconds: 12),
+      duration: const Duration(seconds: 60),
+    );
+    controller.seekBy(const Duration(seconds: 5));
+    await _flushMicrotasks();
+
+    expect(seeks, [const Duration(seconds: 5)]);
+
+    firstSeek.complete();
+    await _flushMicrotasks();
+
+    expect(seeks, [const Duration(seconds: 5), const Duration(seconds: 17)]);
+    controller.onPlayerPosition(const Duration(seconds: 17));
+    expect(controller.state.phase, VideoSeekPhase.idle);
+    controller.dispose();
+  });
+
+  testWidgets("reconciles a seek when no matching event arrives", (
+    tester,
+  ) async {
+    var playerPosition = const Duration(seconds: 30);
+    final controller = VideoSeekController(
+      seek: (target) async {
+        playerPosition = target - const Duration(seconds: 1);
+      },
+      readPosition: () => playerPosition,
+      readDuration: () => const Duration(seconds: 60),
+    );
+    controller.onPlayerPosition(playerPosition);
+
+    controller.seekBy(const Duration(seconds: 5));
+    await tester.pump();
+    expect(controller.state.phase, VideoSeekPhase.settling);
+
+    await tester.pump(const Duration(seconds: 2));
+    expect(controller.position, const Duration(seconds: 34));
+    expect(controller.state.phase, VideoSeekPhase.idle);
+    controller.dispose();
+  });
+
+  test("does not notify listeners for an unchanged player position", () {
+    final controller = VideoSeekController(
+      seek: (_) async {},
+      readPosition: () => const Duration(seconds: 30),
+      readDuration: () => const Duration(seconds: 60),
+    );
+    var notifications = 0;
+    controller.addListener(() => notifications++);
+
+    controller.onPlayerPosition(const Duration(seconds: 30));
+    notifications = 0;
+    controller.onPlayerPosition(const Duration(seconds: 30));
+
+    expect(notifications, 0);
+    controller.dispose();
+  });
+
+  test("does not enter dragging until a duration is available", () {
+    final controller = VideoSeekController(
+      seek: (_) async {},
+      readPosition: () => Duration.zero,
+      readDuration: () => null,
+    );
+
+    controller.beginSliderInteraction();
+    controller.endSliderInteraction(Duration.zero);
+
+    expect(controller.state.phase, VideoSeekPhase.idle);
+    controller.dispose();
+  });
+
+  testWidgets("a slider release seeks to its final target", (tester) async {
+    final seeks = <Duration>[];
+    final controller = VideoSeekController(
+      seek: (target) async {
+        seeks.add(target);
+      },
+      readPosition: () => const Duration(seconds: 10),
+      readDuration: () => const Duration(seconds: 60),
+    );
+
+    controller.beginSliderInteraction();
+    controller.updateSliderTarget(const Duration(seconds: 20));
+    controller.endSliderInteraction(const Duration(seconds: 40));
+    await tester.pump();
+
+    expect(seeks, [const Duration(seconds: 40)]);
+    controller.dispose();
+  });
+
+  test("relative seeks clamp to bounds and skip no-op commands", () async {
+    final seeks = <Duration>[];
+    final controller = VideoSeekController(
+      seek: (target) async {
+        seeks.add(target);
+      },
+      readPosition: () => const Duration(seconds: 3),
+      readDuration: () => const Duration(seconds: 60),
+    );
+    controller.onPlayerPosition(const Duration(seconds: 3));
+
+    controller.seekBy(const Duration(seconds: -5));
+    await _flushMicrotasks();
+    controller.onPlayerPosition(Duration.zero);
+    controller.seekBy(const Duration(seconds: -5));
+    controller.seekBy(const Duration(seconds: 70));
+    await _flushMicrotasks();
+
+    expect(seeks, [Duration.zero, const Duration(seconds: 60)]);
+    controller.dispose();
+  });
+
+  testWidgets("does not reconcile while a slider interaction is active", (
+    tester,
+  ) async {
+    final controller = VideoSeekController(
+      seek: (_) async {},
+      readPosition: () => const Duration(seconds: 10),
+      readDuration: () => const Duration(seconds: 60),
+    );
+
+    controller.beginSliderInteraction();
+    controller.updateSliderTarget(const Duration(seconds: 30));
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump(const Duration(seconds: 2));
+
+    expect(controller.position, const Duration(seconds: 30));
+    expect(controller.state.phase, VideoSeekPhase.dragging);
+    controller.dispose();
+  });
+
+  test("recovers from a failed seek command", () async {
+    final controller = VideoSeekController(
+      seek: (_) => Future.error(StateError("seek failed")),
+      readPosition: () => const Duration(seconds: 10),
+      readDuration: () => const Duration(seconds: 60),
+    );
+    controller.onPlayerPosition(const Duration(seconds: 10));
+
+    controller.seekBy(const Duration(seconds: 5));
+    await _flushMicrotasks();
+
+    expect(controller.position, const Duration(seconds: 10));
+    expect(controller.state.phase, VideoSeekPhase.idle);
+    controller.dispose();
+  });
+}
+
+Future<void> _flushMicrotasks() => Future<void>.delayed(Duration.zero);


### PR DESCRIPTION
 ## Description 
  
  Adds double-tap video seeking.

  - Double-tap the left or right side of a video to seek backward or forward by 5 seconds.
  - Shows an animated seek badge and reveals controls after seeking.
  - Works when paused and while zoomed.
  - Disabled for Memories.

  ### Seek handling improvements

  Introduces a shared seek controller for native and MediaKit players.

  - Keeps the latest target during rapid seeks.
  - Filters stale player-position events after a seek.
  - Keeps the progress bar in sync when seeking while paused.
  - Prevents slider jumps during manual dragging or tapping.
  - Resets seek state safely when the video source changes.
  - Clamps seeks at the start and end of a video.

### Visuals

**Portrait:**

https://github.com/user-attachments/assets/73d76bdd-026c-462e-be04-1cc5facbe28b

**Landscape:**

https://github.com/user-attachments/assets/238c92b1-a40c-4130-b33d-a1b26f474f7c

**Double tap seek shows seekbar for context about timeline to the user:**

https://github.com/user-attachments/assets/73476790-adde-42aa-9ffb-b285f8279784

**While zooming:**

https://github.com/user-attachments/assets/1575df41-1594-44f0-a8e2-2756e4837afc

## Tests

  Adds focused coverage for:

  - Rapid taps and direction changes
  - Boundary seeks and seek-badge labels
  - Disabled gestures
  - In-flight seeks, stale events, timeouts, resets, and slider interactions
  
  
## Verification
Physical device : Realme C67 5g & Realme Pad 2