### PR TITLE
[mob][photos] Add self uploader filter to galleries

### DIFF
--- a/mobile/apps/photos/changes/album-uploaded-by-you-filter.md
+++ b/mobile/apps/photos/changes/album-uploaded-by-you-filter.md
@@ -1,0 +1,1 @@
+- Added a "You" uploader filter to albums.

--- a/mobile/apps/photos/changes/album-uploaded-by-you-filter.md
+++ b/mobile/apps/photos/changes/album-uploaded-by-you-filter.md
@@ -1,1 +1,1 @@
-- Added a "You" uploader filter to albums.
+- Added a "You" uploader filter to filtered galleries.

--- a/mobile/apps/photos/lib/models/search/hierarchical/contacts_filter.dart
+++ b/mobile/apps/photos/lib/models/search/hierarchical/contacts_filter.dart
@@ -7,17 +7,19 @@ import "package:photos/services/contacts/contact_identity_resolver.dart";
 class ContactsFilter extends HierarchicalSearchFilter {
   final User user;
   final int occurrence;
+  final String? filterName;
 
   ContactsFilter({
     required this.user,
     required this.occurrence,
+    this.filterName,
     super.filterTypeName = "contactsFilter",
     super.matchedUploadedIDs,
   });
 
   @override
   String name() {
-    return resolveDisplayName(user);
+    return filterName ?? resolveDisplayName(user);
   }
 
   @override

--- a/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
+++ b/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
@@ -217,7 +217,6 @@ Future<void> curateFilters(
         ? <ContactsFilter>[]
         : curateContactsFilters(
             files,
-            initialGalleryFilter: searchFilterDataProvider.initialGalleryFilter,
             currentUser: CollectionsService.instance.resolveUserIdentity(
               currentUserID,
               null,
@@ -385,17 +384,14 @@ Future<List<LocationFilter>> _curateLocationFilters(
 
 List<ContactsFilter> curateContactsFilters(
   List<EnteFile> files, {
-  required HierarchicalSearchFilter initialGalleryFilter,
   required User currentUser,
   required String currentUserLabel,
 }) {
   final contactsFilters = <ContactsFilter>[];
   final ownerIdToOccurrence = <int, int>{};
-  final includeCurrentUser = initialGalleryFilter is AlbumFilter;
 
   for (EnteFile file in files) {
-    if ((!includeCurrentUser && file.ownerID == currentUser.id) ||
-        file.uploadedFileID == null ||
+    if (file.uploadedFileID == null ||
         file.uploadedFileID == -1 ||
         file.ownerID == null) {
       continue;

--- a/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
+++ b/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
@@ -5,6 +5,7 @@ import "package:photos/core/configuration.dart";
 import "package:photos/core/constants.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/db/ml/db.dart";
+import "package:photos/models/api/collection/user.dart";
 import "package:photos/models/file/extensions/file_props.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
@@ -211,7 +212,18 @@ Future<void> curateFilters(
     final albumFilters = await _curateAlbumFilters(files);
     final fileTypeFilters = _curateFileTypeFilters(files, l10n);
     final locationFilters = await _curateLocationFilters(files);
-    final contactsFilters = _curateContactsFilter(files);
+    final currentUserID = Configuration.instance.getUserID();
+    final contactsFilters = currentUserID == null
+        ? <ContactsFilter>[]
+        : curateContactsFilters(
+            files,
+            initialGalleryFilter: searchFilterDataProvider.initialGalleryFilter,
+            currentUser: CollectionsService.instance.resolveUserIdentity(
+              currentUserID,
+              null,
+            ),
+            currentUserLabel: l10n.you,
+          );
     final uploaderFilters = _curateUploaderFilter(files);
     final cameraFilters = _curateCameraFilters(files);
     final faceFilters = await curateFaceFilters(files);
@@ -371,12 +383,18 @@ Future<List<LocationFilter>> _curateLocationFilters(
   return locationFilters;
 }
 
-List<ContactsFilter> _curateContactsFilter(List<EnteFile> files) {
+List<ContactsFilter> curateContactsFilters(
+  List<EnteFile> files, {
+  required HierarchicalSearchFilter initialGalleryFilter,
+  required User currentUser,
+  required String currentUserLabel,
+}) {
   final contactsFilters = <ContactsFilter>[];
   final ownerIdToOccurrence = <int, int>{};
+  final includeCurrentUser = initialGalleryFilter is AlbumFilter;
 
   for (EnteFile file in files) {
-    if (file.ownerID == Configuration.instance.getUserID() ||
+    if ((!includeCurrentUser && file.ownerID == currentUser.id) ||
         file.uploadedFileID == null ||
         file.uploadedFileID == -1 ||
         file.ownerID == null) {
@@ -387,9 +405,16 @@ List<ContactsFilter> _curateContactsFilter(List<EnteFile> files) {
   }
 
   for (int id in ownerIdToOccurrence.keys) {
-    final user = CollectionsService.instance.resolveUserIdentity(id, null);
+    final isCurrentUser = id == currentUser.id;
+    final user = isCurrentUser
+        ? currentUser
+        : CollectionsService.instance.resolveUserIdentity(id, null);
     contactsFilters.add(
-      ContactsFilter(user: user, occurrence: ownerIdToOccurrence[id]!),
+      ContactsFilter(
+        user: user,
+        occurrence: ownerIdToOccurrence[id]!,
+        filterName: isCurrentUser ? currentUserLabel : null,
+      ),
     );
   }
 


### PR DESCRIPTION
## Description

Adds a localized **You** uploader filter to hierarchical galleries when the current account owns files in the current result set.

## Tests

Verified on an iOS simulator in both a mixed-uploader collaborator album and a people gallery. Applying **You** selected the current account’s files.

<img src="https://raw.githubusercontent.com/laurens-pilot/ente/6e1dff92d78349b277501208e19ad4b3d8071fe9/.github/pr-assets/album-uploader-you.png" alt="iOS simulator showing the You uploader filter in an album" width="360">
<img src="https://raw.githubusercontent.com/laurens-pilot/ente/982ad2350906638387d04e25aa95ff9301d2a1aa/.github/pr-assets/people-uploader-you.png" alt="iOS simulator showing the You uploader filter in a people gallery" width="360">
