### PR TITLE
[mobile][photos] Prefetch adjacent viewer thumbnails

### DIFF
--- a/mobile/apps/photos/lib/module/download/thumbnail.dart
+++ b/mobile/apps/photos/lib/module/download/thumbnail.dart
@@ -77,9 +77,9 @@ Future<Uint8List?> getThumbnail(EnteFile file) async {
 
 void preloadThumbnail(EnteFile file) {
   if (file.isRemoteOnlyFile) {
-    getThumbnailFromServer(file);
+    getThumbnailFromServer(file).ignore();
   } else {
-    getThumbnailFromLocal(file);
+    getThumbnailFromLocal(file).ignore();
   }
 }
 

--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -545,9 +545,11 @@ class _BodyState extends State<_Body> {
 
   void _preloadFiles(int index) {
     if (index > 0) {
+      preloadThumbnail(_files![index - 1]);
       preloadFile(_files![index - 1]);
     }
     if (index < _files!.length - 1) {
+      preloadThumbnail(_files![index + 1]);
       preloadFile(_files![index + 1]);
     }
   }


### PR DESCRIPTION
## Summary

- Prefetch thumbnails for the previous and next photos alongside their original files.
- Make adjacent previews available sooner while full-resolution images are decoded during swiping.