### PR TITLE
[mobile][photos] Fix extensionless gallery downloads

### DIFF
--- a/mobile/apps/photos/changes/android-gallery-extensionless-download.md
+++ b/mobile/apps/photos/changes/android-gallery-extensionless-download.md
@@ -1,0 +1,1 @@
+- Fixed downloading images without file extensions to the Android gallery.

--- a/mobile/apps/photos/changes/android-gallery-extensionless-download.md
+++ b/mobile/apps/photos/changes/android-gallery-extensionless-download.md
@@ -1,1 +1,1 @@
-- Fixed downloading images without file extensions to the Android gallery.
+- Fixed downloading images without file extensions

--- a/mobile/apps/photos/lib/module/download/file.dart
+++ b/mobile/apps/photos/lib/module/download/file.dart
@@ -262,7 +262,7 @@ Future<File?> _downloadAndCache(
           return null;
         }
         final decryptedFilePath = decryptedFile.path;
-        final String fileExtension = getExtension(file.title ?? '');
+        String fileExtension = getExtension(file.title ?? '');
         File outputFile = decryptedFile;
         if ((fileExtension == "unknown" && file.fileType == FileType.image)) {
           final compressResult = await FlutterImageCompress.compressAndGetFile(
@@ -274,6 +274,7 @@ Future<File?> _downloadAndCache(
             throw Exception("Failed to convert heic to jpg");
           } else {
             outputFile = File(compressResult.path);
+            fileExtension = "jpg";
           }
           await decryptedFile.delete();
         }

--- a/mobile/apps/photos/lib/module/download/gallery.dart
+++ b/mobile/apps/photos/lib/module/download/gallery.dart
@@ -30,14 +30,17 @@ String getDownloadSkipToastFileName(EnteFile file) {
 
 String _getGallerySaveTitle(EnteFile file, String fallbackPath) {
   final displayName = file.displayName;
-  if (displayName.trim().isNotEmpty) {
-    return displayName;
+  final title = displayName.trim().isNotEmpty
+      ? displayName
+      : ((file.title != null && file.title!.trim().isNotEmpty)
+            ? file.title!
+            : file_path.basename(fallbackPath));
+  if (file.fileType == FileType.image &&
+      file_path.extension(title).isEmpty &&
+      file_path.extension(fallbackPath).toLowerCase() == ".unknown") {
+    return "$title.jpg";
   }
-  final title = file.title;
-  if (title != null && title.trim().isNotEmpty) {
-    return title;
-  }
-  return file_path.basename(fallbackPath);
+  return title;
 }
 
 Future<String?> getExistingLocalFolderNameForDownloadSkipToast(


### PR DESCRIPTION
## Summary

- cache extensionless downloaded images converted to JPEG with a `.jpg` suffix
- supply a `.jpg` gallery title for existing `.unknown` downloaded cache entries
- add a Photos changelog entry