### PR TITLE
use --reporter=failures-only to only display failed tests in mobile lint workflow

### DIFF
--- a/.github/workflows/mobile-lint.yml
+++ b/.github/workflows/mobile-lint.yml
@@ -100,13 +100,16 @@ jobs:
               working-directory: mobile
               run: |
                   test_package() (
-                      member=${1#"$PWD/"}
+                      member=${2#"$PWD/"}
                       echo "Testing $member"
                       cd "$member"
-                      flutter test --no-pub
-                  )
+                      flutter test --no-pub --reporter=failures-only
+                  ) > "$reports/$1" 2>&1
                   export -f test_package
 
+                  reports=$(mktemp -d)
+                  export reports
+                  status=0
                   dart pub workspace list --json |
                       jq -r '.packages[] | select(.name != "ente_workspace") | .path' |
                       while IFS= read -r member; do
@@ -114,4 +117,7 @@ jobs:
                               printf '%s\n' "$member"
                           fi
                       done |
-                      xargs -P4 -n1 bash -e -c 'test_package "$1"' _
+                      nl -n rz |
+                      xargs -P4 -n2 bash -e -c 'test_package "$1" "$2"' _ || status=$?
+                  cat "$reports"/*
+                  exit "$status"


### PR DESCRIPTION
this allows to know which tests are failing, especially when the cause only exists on the merge result, rather than the PR head.