### PR TITLE
Fix smart album auto-add after face recognition

### DIFF
--- a/mobile/apps/photos/changes/smart-album-auto-add.md
+++ b/mobile/apps/photos/changes/smart-album-auto-add.md
@@ -1,0 +1,1 @@
+- Fixed smart albums not automatically adding newly recognized people.

--- a/mobile/apps/photos/lib/services/machine_learning/face_ml/person/person_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/face_ml/person/person_service.dart
@@ -339,6 +339,7 @@ class PersonService {
     final persons = await getPersonsMap();
     w?.log("Got persons");
     int orphanMappingsRemoved = 0;
+    final entityUpdates = <Future<LocalEntityData>>[];
     for (var personID in dbPersonClusterInfo.keys) {
       final person = persons[personID];
       if (person == null) {
@@ -388,23 +389,31 @@ class PersonService {
         continue;
       }
 
+      var updatedPersonData = personData;
       if (shouldUpdateAssigned) {
-        personData.assigned = dbPersonCluster.entries
-            .map((e) => ClusterInfo(id: e.key, faces: e.value))
-            .toList();
+        updatedPersonData = updatedPersonData.copyWith(
+          assigned: dbPersonCluster.entries
+              .map((e) => ClusterInfo(id: e.key, faces: e.value))
+              .toList(),
+        );
       }
 
       if (shouldUpdateManualAssignments) {
-        personData.manuallyAssigned = updatedManualAssignments ?? <int>[];
+        updatedPersonData = updatedPersonData.copyWith(
+          manuallyAssigned: updatedManualAssignments ?? <int>[],
+        );
       }
 
-      _addOrUpdateEntity(
-        EntityType.cgroup,
-        personData.toJson(),
-        id: personID,
-      ).ignore();
-      personData.logStats();
+      entityUpdates.add(
+        _addOrUpdateEntity(
+          EntityType.cgroup,
+          updatedPersonData.toJson(),
+          id: personID,
+        ),
+      );
+      updatedPersonData.logStats();
     }
+    await Future.wait(entityUpdates);
     if (orphanMappingsRemoved > 0) {
       logger.warning(
         "Removed $orphanMappingsRemoved orphaned local person mappings during reconcile",

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -473,6 +473,11 @@ class MLService {
         _logRunStopped(control, "before post-run cache scheduling");
         return MlRunDisposition.stopped;
       }
+      await PersonService.instance.sync();
+      if (control.stopRequested) {
+        _logRunStopped(control, "after post-run person sync");
+        return MlRunDisposition.stopped;
+      }
       if (_mlControllerStatus == true) {
         // Persist refreshed caches after ML so foreground can pick them up
         // on the next resume, even when the work ran headlessly in background.


### PR DESCRIPTION
## Summary

- Wait for person entity updates before completing reconciliation.
- Preserve retry correctness by avoiding in-place cache mutations.
- Run person reconciliation after final ML clustering, before smart album sync.
- Honor latched stop requests before scheduling post-run caches.

## Context

Smart albums could miss newly recognized photos because auto-add could run before updated person assignments were persisted. Removing and re-adding a person reset the watermark and temporarily caught the album up.