### PR TITLE
[mobile][photos] Dispose resolved image handles

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/ocr/inline_text_detection.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/ocr/inline_text_detection.dart
@@ -353,17 +353,14 @@ class _InlineTextDetectionState extends State<InlineTextDetection> {
       final displayPath = await DisplayImageHelper.ensureDisplayablePath(
         localPath,
       );
-      final imageInfo = await getImageInfo(FileImage(File(displayPath)));
+      final imageSize = await getImageSize(FileImage(File(displayPath)));
       if (!mounted ||
           requestId != _imageSizeRequestId ||
           _localFilePath != localPath) {
         return;
       }
       setState(() {
-        _resolvedImageSize = Size(
-          imageInfo.image.width.toDouble(),
-          imageInfo.image.height.toDouble(),
-        );
+        _resolvedImageSize = imageSize;
       });
     } catch (error, stackTrace) {
       _logger.warning(

--- a/mobile/apps/photos/lib/utils/image_util.dart
+++ b/mobile/apps/photos/lib/utils/image_util.dart
@@ -38,15 +38,25 @@ const Set<String> _rawImageExtensions = {
 bool isRawImageExtension(String extension) =>
     _rawImageExtensions.contains(extension.toLowerCase());
 
-Future<ImageInfo> getImageInfo(ImageProvider imageProvider) {
-  final completer = Completer<ImageInfo>();
+Future<Size> getImageSize(ImageProvider imageProvider) {
+  final completer = Completer<Size>();
   final imageStream = imageProvider.resolve(const ImageConfiguration());
   late final ImageStreamListener listener;
   listener = ImageStreamListener(
     (imageInfo, _) {
-      if (completer.isCompleted) return;
       imageStream.removeListener(listener);
-      completer.complete(imageInfo);
+      try {
+        if (!completer.isCompleted) {
+          completer.complete(
+            Size(
+              imageInfo.image.width.toDouble(),
+              imageInfo.image.height.toDouble(),
+            ),
+          );
+        }
+      } finally {
+        imageInfo.dispose();
+      }
     },
     onError: (error, stackTrace) {
       if (completer.isCompleted) return;


### PR DESCRIPTION
## Summary

- replace the leak-prone `getImageInfo` API with a dimensions-only helper that disposes its listener-owned `ImageInfo`
- update the OCR dimension consumer to retain only the resolved `Size`

## Reproduction before this change

1. Open a regular still image in the full-screen viewer. The image must not be in Trash or a guest view, and its `EnteFile` must have a missing width or height (`hasDimensions == false`).
2. Long-press the image to activate OCR/text selection.
3. Ente resolves the full display image to determine its dimensions. Before this change, the listener-owned `ImageInfo` returned by that operation was never disposed.
4. Repeat with distinct large, dimensionless images to accumulate retained decoded image memory.

Merely viewing the image does not trigger this path on current `main`, and the image does not need to contain detectable text. The leak occurs while preparing the OCR overlay.

## Memory impact

An `ImageInfo` owns a handle to the decoded `ui.Image`. If that handle is not disposed, it can keep the decoded backing image alive after the image stream and cache no longer need it. Flutter estimates this memory as `width × height × 4` bytes:

- a 12 MP image (`4000 × 3000`) is about 48 MB / 45.8 MiB
- a 48 MP image (`8000 × 6000`) is about 192 MB / 183 MiB

This means one unresolved handle can retain tens or hundreds of MiB until the process exits. The exact resident and GPU memory varies by decoder and platform; the handle does not itself allocate a second copy of the pixel buffer.

## Validation

- `flutter analyze lib/utils/image_util.dart lib/ui/viewer/file/ocr/inline_text_detection.dart`
