### PR TITLE
[mob][photos] Link existing uploads to backup albums

### DIFF
--- a/mobile/apps/photos/lib/module/upload/service/existing_upload_resolver.dart
+++ b/mobile/apps/photos/lib/module/upload/service/existing_upload_resolver.dart
@@ -112,7 +112,7 @@ class ExistingUploadResolver {
     }
 
     final fileMissingLocal = existingUploadedFiles.firstWhereOrNull(
-      (file) => file.localID == null,
+      (file) => file.collectionID == targetCollectionID && file.localID == null,
     );
     if (fileMissingLocal != null) {
       _logger.info(
@@ -134,7 +134,9 @@ class ExistingUploadResolver {
     final fileInDifferentCollection = existingUploadedFiles.firstWhereOrNull(
       (file) =>
           file.collectionID != targetCollectionID &&
-          (file.localID == fileToUpload.localID || isSandboxFile),
+          (file.localID == null ||
+              file.localID == fileToUpload.localID ||
+              isSandboxFile),
     );
     if (fileInDifferentCollection != null) {
       _logger.info(


### PR DESCRIPTION
## Summary

- only associate a missing local ID directly when the uploaded file is already in the target collection
- link hash-matched uploads from other collections into the target backup album without uploading the file again

This prevents restored device folders from producing empty backup albums when their files already exist elsewhere in Ente.