### PR TITLE
[mob][photos] Harden log_viewer.db against engine kills

### DIFF
--- a/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
+++ b/mobile/apps/photos/lib/core/error-reporting/super_logging.dart
@@ -164,9 +164,14 @@ class SuperLogging {
     EnteWatch.setLogLevel(_terminalLoggerLevel);
     Logger.root.onRecord.listen(onLogRecord);
 
-    if (_preferences.getBool("enable_db_logging") ?? kDebugMode) {
+    // Bg engines killed mid-write can wedge log_viewer.db; keep DB logging
+    // foreground-only and never let startup block on it.
+    if (_getExecutionContext() == 'foreground' &&
+        (_preferences.getBool("enable_db_logging") ?? kDebugMode)) {
       try {
-        await LogViewer.initialize(prefix: appConfig.prefix);
+        await LogViewer.initialize(
+          prefix: appConfig.prefix,
+        ).timeout(const Duration(seconds: 2));
         $.info("Log viewer initialized successfully");
       } catch (e) {
         $.warning("Failed to initialize log viewer: $e");

--- a/mobile/packages/log_viewer/lib/src/core/log_database.dart
+++ b/mobile/packages/log_viewer/lib/src/core/log_database.dart
@@ -24,11 +24,15 @@ class LogDatabase {
     final documentsDirectory = await getApplicationDocumentsDirectory();
     final path = join(documentsDirectory.path, _databaseName);
 
-    return await openDatabase(
+    return await databaseFactory.openDatabase(
       path,
-      version: _databaseVersion,
-      onCreate: _onCreate,
-      onOpen: _onOpen,
+      options: OpenDatabaseOptions(
+        version: _databaseVersion,
+        onCreate: _onCreate,
+        onOpen: _onOpen,
+        // Transactions orphaned by killed engines must not block later opens.
+        rollbackActiveTransactionOnOpen: true,
+      ),
     );
   }
 

--- a/mobile/packages/log_viewer/lib/src/core/log_store.dart
+++ b/mobile/packages/log_viewer/lib/src/core/log_store.dart
@@ -58,25 +58,36 @@ class LogStore {
     }
   }
 
-  Future<void>? _flushFuture;
+  Future<void>? _activeFlush;
+  Future<void>? _queuedFlush;
 
+  // At most one drain runs and one is queued; arrivals share the queued one.
+  // Its snapshot is taken after the active drain, so every caller sees the
+  // records buffered before its call, yet waits at most two batch inserts.
   Future<void> _flush() {
-    return _flushFuture ??= _drainBuffer().whenComplete(() {
-      _flushFuture = null;
+    final active = _activeFlush;
+    if (active == null) {
+      return _activeFlush = _drainOnce().whenComplete(() {
+        _activeFlush = null;
+      });
+    }
+    return _queuedFlush ??= active.then((_) {
+      _queuedFlush = null;
+      return _flush();
     });
   }
 
-  Future<void> _drainBuffer() async {
-    while (_buffer.isNotEmpty) {
-      final toInsert = List<LogEntry>.from(_buffer);
-      _buffer.clear();
+  Future<void> _drainOnce() async {
+    if (_buffer.isEmpty) return;
 
-      try {
-        await _database.insertLogs(toInsert);
-      } catch (e) {
-        // ignore: avoid_print
-        print('Failed to insert logs to database: $e');
-      }
+    final toInsert = List<LogEntry>.from(_buffer);
+    _buffer.clear();
+
+    try {
+      await _database.insertLogs(toInsert);
+    } catch (e) {
+      // ignore: avoid_print
+      print('Failed to insert logs to database: $e');
     }
   }
 
@@ -191,10 +202,10 @@ class LogStore {
   }
 
   Future<void> dispose() async {
+    _initialized = false;
     _flushTimer?.cancel();
     await _flush();
     await _database.close();
     await _logStreamController.close();
-    _initialized = false;
   }
 }

--- a/mobile/packages/log_viewer/lib/src/core/log_store.dart
+++ b/mobile/packages/log_viewer/lib/src/core/log_store.dart
@@ -61,9 +61,6 @@ class LogStore {
   Future<void>? _activeFlush;
   Future<void>? _queuedFlush;
 
-  // At most one drain runs and one is queued; arrivals share the queued one.
-  // Its snapshot is taken after the active drain, so every caller sees the
-  // records buffered before its call, yet waits at most two batch inserts.
   Future<void> _flush() {
     final active = _activeFlush;
     if (active == null) {

--- a/mobile/packages/log_viewer/lib/src/core/log_store.dart
+++ b/mobile/packages/log_viewer/lib/src/core/log_store.dart
@@ -16,7 +16,6 @@ class LogStore {
   final List<LogEntry> _buffer = [];
   Timer? _flushTimer;
   static const int _bufferSize = 10;
-  static const int _maxBufferSize = 200;
 
   bool _initialized = false;
   bool get initialized => _initialized;
@@ -56,23 +55,29 @@ class LogStore {
 
     if (_buffer.length >= _bufferSize) {
       _flush();
-    } else if (_buffer.length >= _maxBufferSize) {
-      _flush();
     }
   }
 
-  Future<void> _flush() async {
-    if (_buffer.isEmpty) return;
+  Future<void>? _flushFuture;
 
-    final toInsert = List<LogEntry>.from(_buffer);
-    _buffer.clear();
+  Future<void> _flush() {
+    return _flushFuture ??= _drainBuffer().whenComplete(() {
+      _flushFuture = null;
+    });
+  }
 
-    unawaited(
-      _database.insertLogs(toInsert).catchError((e) {
+  Future<void> _drainBuffer() async {
+    while (_buffer.isNotEmpty) {
+      final toInsert = List<LogEntry>.from(_buffer);
+      _buffer.clear();
+
+      try {
+        await _database.insertLogs(toInsert);
+      } catch (e) {
         // ignore: avoid_print
         print('Failed to insert logs to database: $e');
-      }),
-    );
+      }
+    }
   }
 
   Future<List<LogEntry>> getLogs({


### PR DESCRIPTION
## Problem

Part of the Android blank-screen release blocker: a background WorkManager engine killed mid log-flush leaves an orphaned exclusive transaction on log_viewer.db's single native connection. Every engine created afterwards in the same process blocks in `LogViewer.initialize` before `runApp`, drawing the app blank until the user kills it (verified live in the Aug 21 bugreport: transaction held 68 min, `mReportedDrawn=false`). sqflite only rolls back recovered transactions by default in debug builds, which is why this never reproduced in debug APKs.

## Fix (layered)

- Open log_viewer.db with `rollbackActiveTransactionOnOpen: true`, so a new engine rolls the orphan back instead of queuing behind it forever
- Bound `LogViewer.initialize` with a fail-open 2s timeout, so app startup can never hang on this database
- Keep DB-backed viewer logging foreground-only; background engines no longer touch the database (file logs are unaffected)
- Coalesce log flushes into a single awaited in-flight drain: viewer reads now see everything buffered, and a slow insert can no longer grow an unbounded flush queue

## Validation

On a Pixel 8, orphaned a real sqflite transaction on log_viewer.db and relaunched a fresh engine into the same process: with the fix the orphan rolls back and the app draws normally; with the rollback flag disabled the engine hangs exactly like the incident and the 2s timeout fails open. Background runs no longer open the database at all, while their file logging is unchanged.

Note: this removes the blank-screen symptom, but the underlying trigger (bg ML runs vs the OS battery clamp) is addressed separately.