### PR TITLE
[mobile][photos] Enable background ML

### DIFF
--- a/mobile/packages/feature_flag/lib/src/flag_service.dart
+++ b/mobile/packages/feature_flag/lib/src/flag_service.dart
@@ -104,7 +104,7 @@ class FlagService {
 
   bool get enableMemoryShareLink => true;
 
-  bool get enableMLInBackground => false;
+  bool get enableMLInBackground => true;
 
   bool get useRustForHeicDecoder => internalUser;
 


### PR DESCRIPTION
## Description

Enable background ML processing in Photos mobile by restoring the `enableMLInBackground` feature flag.