### PR TITLE
[mob][photos] Resolve uploader filters with album context

### DIFF
--- a/mobile/apps/photos/changes/uploader-filter-identities.md
+++ b/mobile/apps/photos/changes/uploader-filter-identities.md
@@ -1,0 +1,1 @@
+- Fixed duplicate “Someone” entries in the Uploaded by search filter.

--- a/mobile/apps/photos/lib/services/contacts/contact_identity_resolver.dart
+++ b/mobile/apps/photos/lib/services/contacts/contact_identity_resolver.dart
@@ -3,7 +3,11 @@ import "package:photos/models/api/collection/user.dart";
 import "package:photos/services/photos_contacts_service.dart";
 import "package:photos/utils/contact_string_util.dart";
 
-typedef ResolvedUserIdentity = ({String displayName, String? knownEmail});
+typedef ResolvedUserIdentity = ({
+  String displayName,
+  bool isResolved,
+  String? knownEmail,
+});
 
 // Precedence: saved contact name → linked person name or local label → known
 // email → "Someone".
@@ -15,12 +19,13 @@ ResolvedUserIdentity resolveSuggestionIdentity(UserSuggestion suggestion) {
   final knownEmail =
       knownContactEmailOrNull(contact?.email) ??
       knownContactEmailOrNull(suggestion.email);
+  final resolvedDisplayName =
+      trimToNull(contact?.data?.name) ??
+      trimToNull(suggestion.displayName) ??
+      knownEmail;
   return (
-    displayName:
-        trimToNull(contact?.data?.name) ??
-        trimToNull(suggestion.displayName) ??
-        knownEmail ??
-        "Someone",
+    displayName: resolvedDisplayName ?? "Someone",
+    isResolved: resolvedDisplayName != null,
     knownEmail: knownEmail,
   );
 }

--- a/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
+++ b/mobile/apps/photos/lib/utils/hierarchical_search_util.dart
@@ -24,6 +24,7 @@ import "package:photos/models/search/hierarchical/top_level_generic_filter.dart"
 import "package:photos/models/search/hierarchical/uploader_filter.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/collections_service.dart";
+import "package:photos/services/contacts/contact_identity_resolver.dart";
 import "package:photos/services/machine_learning/face_ml/face_filtering/face_filtering_constants.dart";
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
 import "package:photos/services/magic_cache_service.dart";
@@ -389,28 +390,55 @@ List<ContactsFilter> curateContactsFilters(
 }) {
   final contactsFilters = <ContactsFilter>[];
   final ownerIdToOccurrence = <int, int>{};
+  final ownerIdToCollectionIDs = <int, Set<int>>{};
 
-  for (EnteFile file in files) {
+  for (final file in files) {
     if (file.uploadedFileID == null ||
         file.uploadedFileID == -1 ||
         file.ownerID == null) {
       continue;
     }
-    ownerIdToOccurrence[file.ownerID!] =
-        (ownerIdToOccurrence[file.ownerID] ?? 0) + 1;
+    final ownerID = file.ownerID!;
+    ownerIdToOccurrence[ownerID] = (ownerIdToOccurrence[ownerID] ?? 0) + 1;
+    if (file.collectionID != null) {
+      ownerIdToCollectionIDs
+          .putIfAbsent(ownerID, () => <int>{})
+          .add(file.collectionID!);
+    }
   }
 
-  for (int id in ownerIdToOccurrence.keys) {
-    final isCurrentUser = id == currentUser.id;
-    final user = isCurrentUser
-        ? currentUser
-        : CollectionsService.instance.resolveUserIdentity(id, null);
+  for (final entry in ownerIdToOccurrence.entries) {
+    final ownerID = entry.key;
+    if (ownerID == currentUser.id) {
+      contactsFilters.add(
+        ContactsFilter(
+          user: currentUser,
+          occurrence: entry.value,
+          filterName: currentUserLabel,
+        ),
+      );
+      continue;
+    }
+
+    User? resolvedUser;
+    final collectionIDs = ownerIdToCollectionIDs[ownerID] ?? const <int>{};
+    for (final collectionID in [...collectionIDs, null]) {
+      final user = CollectionsService.instance.resolveUserIdentity(
+        ownerID,
+        collectionID,
+      );
+      final identity = resolveSuggestionIdentity(UserSuggestion.fromUser(user));
+      if (identity.isResolved) {
+        resolvedUser = user;
+        break;
+      }
+    }
+    if (resolvedUser == null) {
+      continue;
+    }
+
     contactsFilters.add(
-      ContactsFilter(
-        user: user,
-        occurrence: ownerIdToOccurrence[id]!,
-        filterName: isCurrentUser ? currentUserLabel : null,
-      ),
+      ContactsFilter(user: resolvedUser, occurrence: entry.value),
     );
   }
 


### PR DESCRIPTION
## Summary

- Resolve uploader identities using the albums containing their files.
- Omit uploader filters whose owners still cannot be identified.
- Preserve named uploaders and the current-user filter.

## Context

Uploader filters previously discarded collection context during identity lookup. Uncached collaborators therefore fell back to identical “Someone” labels.