### PR TITLE
[rust] Use array chunks for fixed-width data

### DIFF
--- a/rust/crates/ensu/src/retrieval/index.rs
+++ b/rust/crates/ensu/src/retrieval/index.rs
@@ -154,8 +154,10 @@ impl RetrievalIndex {
         }
         let offsets_raw = fs::read(&offsets_path)?;
         let offsets = offsets_raw
-            .chunks_exact(8)
-            .map(|chunk| u64::from_le_bytes(chunk.try_into().expect("eight-byte chunk")))
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|chunk| u64::from_le_bytes(*chunk))
             .collect::<Vec<_>>();
         validate_offsets(&offsets, metadata_len)?;
 

--- a/rust/crates/ensu/src/transcription/audio.rs
+++ b/rust/crates/ensu/src/transcription/audio.rs
@@ -30,8 +30,10 @@ pub fn extract_speech_from_pcm16(
     }
 
     let samples = pcm_le
-        .chunks_exact(2)
-        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / 32768.0)
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|chunk| i16::from_le_bytes(*chunk) as f32 / 32768.0)
         .collect::<Vec<_>>();
 
     extract_speech(vad_model_path, input_sample_rate, &samples)

--- a/rust/crates/ml/src/cv/channels.rs
+++ b/rust/crates/ml/src/cv/channels.rs
@@ -21,7 +21,7 @@ pub(crate) fn gray_to_bgr(src: &ImageU8) -> OpResult<ImageU8> {
     require_channels(src, 1, "gray_to_bgr")?;
     let mut data = vec![0u8; src.data.len() * 3];
     super::pointwise(&mut data, 3, &src.data, 1, |data, srcd| {
-        for (out, &v) in data.chunks_exact_mut(3).zip(srcd.iter()) {
+        for (out, &v) in data.as_chunks_mut::<3>().0.iter_mut().zip(srcd.iter()) {
             out[0] = v;
             out[1] = v;
             out[2] = v;
@@ -35,7 +35,7 @@ pub(crate) fn bgr_to_gray(src: &ImageU8) -> OpResult<ImageU8> {
     let round = 1i32 << (GRAY_SHIFT - 1);
     let mut data = vec![0u8; src.data.len() / 3];
     super::pointwise(&mut data, 1, &src.data, 3, |data, srcd| {
-        for (out, px) in data.iter_mut().zip(srcd.chunks_exact(3)) {
+        for (out, px) in data.iter_mut().zip(srcd.as_chunks::<3>().0.iter()) {
             let sum = px[0] as i32 * BY15 + px[1] as i32 * GY15 + px[2] as i32 * RY15;
             *out = ((sum + round) >> GRAY_SHIFT) as u8;
         }

--- a/rust/crates/ml/src/cv/lab.rs
+++ b/rust/crates/ml/src/cv/lab.rs
@@ -181,7 +181,12 @@ pub(crate) fn bgr_to_lab(src: &ImageU8) -> OpResult<ImageU8> {
 
     let mut data = vec![0u8; src.data.len()];
     super::pointwise(&mut data, 3, &src.data, 3, |data, srcd| {
-        for (out, px) in data.chunks_exact_mut(3).zip(srcd.chunks_exact(3)) {
+        for (out, px) in data
+            .as_chunks_mut::<3>()
+            .0
+            .iter_mut()
+            .zip(srcd.as_chunks::<3>().0.iter())
+        {
             let v0 = t.srgb_gamma[px[0] as usize] as i32;
             let v1 = t.srgb_gamma[px[1] as usize] as i32;
             let v2 = t.srgb_gamma[px[2] as usize] as i32;
@@ -210,7 +215,12 @@ pub(crate) fn lab_to_bgr(src: &ImageU8) -> OpResult<ImageU8> {
 
     let mut data = vec![0u8; src.data.len()];
     super::pointwise(&mut data, 3, &src.data, 3, |data, srcd| {
-        for (out, px) in data.chunks_exact_mut(3).zip(srcd.chunks_exact(3)) {
+        for (out, px) in data
+            .as_chunks_mut::<3>()
+            .0
+            .iter_mut()
+            .zip(srcd.as_chunks::<3>().0.iter())
+        {
             let y = t.lab_to_yf[px[0] as usize * 2] as i32;
             let ify = t.lab_to_yf[px[0] as usize * 2 + 1] as i32;
 

--- a/rust/crates/ml/src/cv/resize.rs
+++ b/rust/crates/ml/src/cv/resize.rs
@@ -100,7 +100,9 @@ pub(crate) fn resize_f32(
         interp.alg(width >= src.width && height >= src.height),
     )?;
     let data = out
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|b| f32::from_ne_bytes([b[0], b[1], b[2], b[3]]))
         .collect();
     ImageF32::new(width, height, src.channels, data)

--- a/rust/crates/ml/src/cv/stats.rs
+++ b/rust/crates/ml/src/cv/stats.rs
@@ -26,7 +26,7 @@ pub(crate) fn mean_u8c3_masked(src: &ImageU8, mask: &ImageU8) -> OpResult<[f64; 
     }
     let mut sums = [0i64; 3];
     let mut count = 0i64;
-    for (px, &m) in src.data.chunks_exact(3).zip(mask.data.iter()) {
+    for (px, &m) in src.data.as_chunks::<3>().0.iter().zip(mask.data.iter()) {
         if m != 0 {
             sums[0] += px[0] as i64;
             sums[1] += px[1] as i64;

--- a/rust/crates/ml/src/scan/codec.rs
+++ b/rust/crates/ml/src/scan/codec.rs
@@ -13,7 +13,7 @@ pub(crate) fn decode_bgr(bytes: &[u8]) -> Result<ImageU8, ScanError> {
         .map_err(|_| ScanError::Codec("image height does not fit in i32".to_string()))?;
 
     let mut bgr = decoded.rgb;
-    for px in bgr.chunks_exact_mut(3) {
+    for px in bgr.as_chunks_mut::<3>().0 {
         px.swap(0, 2);
     }
     ImageU8::new(width, height, 3, bgr).map_err(ScanError::Codec)
@@ -27,7 +27,7 @@ pub(crate) fn encode_jpeg(image: &ImageU8, quality: u8) -> Result<Vec<u8>, ScanE
         )));
     }
     let mut rgb = image.data.clone();
-    for px in rgb.chunks_exact_mut(3) {
+    for px in rgb.as_chunks_mut::<3>().0 {
         px.swap(0, 2);
     }
     encode_rgb(

--- a/rust/crates/ml/src/scan/color.rs
+++ b/rust/crates/ml/src/scan/color.rs
@@ -134,7 +134,7 @@ pub(crate) fn apply_gray_world_to_document(img: &ImageU8, doc_mask: &ImageU8) ->
     let scales = [mean_gray / mean_b, mean_gray / mean_g, mean_gray / mean_r];
 
     let mut scaled = img.clone();
-    for pixel in scaled.data.chunks_exact_mut(3) {
+    for pixel in scaled.data.as_chunks_mut::<3>().0 {
         for (channel, scale) in pixel.iter_mut().zip(scales) {
             *channel = cv::saturate_u8_f32((*channel as f64 * scale) as f32);
         }

--- a/rust/crates/ml/src/scan/segmentation.rs
+++ b/rust/crates/ml/src/scan/segmentation.rs
@@ -62,7 +62,12 @@ impl Segmenter {
         let resized = cv::resize_u8(bgr, MASK_SIDE, MASK_SIDE, cv::Interp::Bilinear)?;
 
         let mut input = vec![0.0f32; resized.data.len()];
-        for (out, px) in input.chunks_exact_mut(3).zip(resized.data.chunks_exact(3)) {
+        for (out, px) in input
+            .as_chunks_mut::<3>()
+            .0
+            .iter_mut()
+            .zip(resized.data.as_chunks::<3>().0.iter())
+        {
             out[0] = (px[2] as f32 - 127.5) / 127.5;
             out[1] = (px[1] as f32 - 127.5) / 127.5;
             out[2] = (px[0] as f32 - 127.5) / 127.5;

--- a/rust/crates/ml/src/scan/yuv.rs
+++ b/rust/crates/ml/src/scan/yuv.rs
@@ -162,7 +162,9 @@ pub(crate) fn yuv420_to_bgr(
 
     let mut out = vec![0u8; width as usize * height as usize * 3];
     for (pixel, ((&y, &u), &v)) in out
-        .chunks_exact_mut(3)
+        .as_chunks_mut::<3>()
+        .0
+        .iter_mut()
         .zip(y.data.iter().zip(u.data.iter()).zip(v.data.iter()))
     {
         let (b, g, r) = yuv_to_bgr(y, u, v);
@@ -201,7 +203,12 @@ pub(crate) fn bgra_to_bgr(
     let mut out = vec![0u8; width as usize * height as usize * 3];
     for (row, dst_row) in out.chunks_exact_mut(width as usize * 3).enumerate() {
         let src_row = &bgra[row * row_stride..row * row_stride + row_bytes];
-        for (dst, src) in dst_row.chunks_exact_mut(3).zip(src_row.chunks_exact(4)) {
+        for (dst, src) in dst_row
+            .as_chunks_mut::<3>()
+            .0
+            .iter_mut()
+            .zip(src_row.as_chunks::<4>().0.iter())
+        {
             dst[0] = src[0];
             dst[1] = src[1];
             dst[2] = src[2];


### PR DESCRIPTION
## Summary

- replace constant-size `chunks_exact` and `chunks_exact_mut` calls with typed array chunks
- cover ML image processing and the additional Ensu fixed-width decoding paths reported by Rust 1.98 Clippy
- preserve the existing behavior of ignoring incomplete trailing chunks

## Testing

- `cargo fmt --all --check`
- `cargo codegen frb`
- `RUSTFLAGS="-D warnings" cargo clippy -p ente-photos-frb --features flutter --all-targets --locked`
- `RUSTFLAGS="-D warnings" cargo clippy --locked --all-targets --features museum,ente-ml/ml-assets`
- `GITHUB_TOKEN=... cargo test --locked --features museum,ente-ml/ml-assets`