### PR TITLE
[server] Add Photos and Locker file count state

### DIFF
--- a/server/migrations/133_file_counts.down.sql
+++ b/server/migrations/133_file_counts.down.sql
@@ -1,0 +1,9 @@
+SET lock_timeout = '5s';
+
+ALTER TABLE usage
+    DROP CONSTRAINT usage_file_counts_both_ready_or_both_unknown,
+    DROP COLUMN file_count_source_version,
+    DROP COLUMN locker_file_count,
+    DROP COLUMN photos_file_count;
+
+RESET lock_timeout;

--- a/server/migrations/133_file_counts.down.sql
+++ b/server/migrations/133_file_counts.down.sql
@@ -1,9 +1,5 @@
-SET lock_timeout = '5s';
-
 ALTER TABLE usage
     DROP CONSTRAINT usage_file_counts_both_ready_or_both_unknown,
     DROP COLUMN file_count_source_version,
     DROP COLUMN locker_file_count,
     DROP COLUMN photos_file_count;
-
-RESET lock_timeout;

--- a/server/migrations/133_file_counts.up.sql
+++ b/server/migrations/133_file_counts.up.sql
@@ -1,5 +1,3 @@
-SET lock_timeout = '5s';
-
 ALTER TABLE usage
     ADD COLUMN photos_file_count BIGINT,
     ADD COLUMN locker_file_count BIGINT,
@@ -7,5 +5,3 @@ ALTER TABLE usage
     ADD CONSTRAINT usage_file_counts_both_ready_or_both_unknown
         CHECK ((photos_file_count IS NULL) = (locker_file_count IS NULL))
         NOT VALID;
-
-RESET lock_timeout;

--- a/server/migrations/133_file_counts.up.sql
+++ b/server/migrations/133_file_counts.up.sql
@@ -1,0 +1,11 @@
+SET lock_timeout = '5s';
+
+ALTER TABLE usage
+    ADD COLUMN photos_file_count BIGINT,
+    ADD COLUMN locker_file_count BIGINT,
+    ADD COLUMN file_count_source_version BIGINT NOT NULL DEFAULT 0,
+    ADD CONSTRAINT usage_file_counts_both_ready_or_both_unknown
+        CHECK ((photos_file_count IS NULL) = (locker_file_count IS NULL))
+        NOT VALID;
+
+RESET lock_timeout;


### PR DESCRIPTION
Adds nullable Photos and Locker file counts and a source version to `usage`. Existing rows remain uninitialized and application behavior is unchanged.

The paired-state constraint prevents half-initialized counters without scanning existing rows.