### PR TITLE
[locker] Speed up auto-capture and add a dedicated scanner button

### DIFF
--- a/mobile/apps/locker/lib/services/scanner/auto_capture_controller.dart
+++ b/mobile/apps/locker/lib/services/scanner/auto_capture_controller.dart
@@ -8,7 +8,7 @@ class AutoCaptureController {
 
   static const armGrace = Duration(milliseconds: 250);
 
-  static const clearHold = Duration(milliseconds: 700);
+  static const clearHold = Duration(milliseconds: 400);
 
   static const maxFrameGap = Duration(milliseconds: 200);
 

--- a/mobile/apps/locker/lib/services/scanner/auto_capture_controller.dart
+++ b/mobile/apps/locker/lib/services/scanner/auto_capture_controller.dart
@@ -8,7 +8,7 @@ class AutoCaptureController {
 
   static const armGrace = Duration(milliseconds: 250);
 
-  static const clearHold = Duration(milliseconds: 400);
+  static const clearHold = Duration(milliseconds: 700);
 
   static const maxFrameGap = Duration(milliseconds: 200);
 

--- a/mobile/apps/locker/lib/services/scanner/auto_capture_controller.dart
+++ b/mobile/apps/locker/lib/services/scanner/auto_capture_controller.dart
@@ -4,7 +4,7 @@ import 'package:locker/services/scanner/scanner_models.dart';
 enum AutoCaptureState { searching, arming, cooldown }
 
 class AutoCaptureController {
-  static const armHold = Duration(milliseconds: 2500);
+  static const armHold = Duration(milliseconds: 1500);
 
   static const armGrace = Duration(milliseconds: 250);
 

--- a/mobile/apps/locker/lib/ui/components/save_to_locker_empty_state_widget.dart
+++ b/mobile/apps/locker/lib/ui/components/save_to_locker_empty_state_widget.dart
@@ -29,7 +29,7 @@ class SaveToLockerEmptyStateWidget extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         const SaveToLockerBanner(),
-        for (final option in saveOptions(context)) ...[
+        for (final option in saveOptions(context, includeScanner: true)) ...[
           const SizedBox(height: _optionSpacing),
           _SaveOptionTile(
             title: option.title,

--- a/mobile/apps/locker/lib/ui/components/save_to_locker_empty_state_widget.dart
+++ b/mobile/apps/locker/lib/ui/components/save_to_locker_empty_state_widget.dart
@@ -29,7 +29,7 @@ class SaveToLockerEmptyStateWidget extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         const SaveToLockerBanner(),
-        for (final option in saveOptions(context, includeScanner: true)) ...[
+        for (final option in saveOptions(context)) ...[
           const SizedBox(height: _optionSpacing),
           _SaveOptionTile(
             title: option.title,

--- a/mobile/apps/locker/lib/ui/pages/home_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/home_page.dart
@@ -20,6 +20,7 @@ import 'package:locker/models/selected_files.dart';
 import 'package:locker/services/collections/collections_service.dart';
 import 'package:locker/services/collections/models/collection.dart';
 import 'package:locker/services/configuration.dart';
+import 'package:locker/services/feature_flag_service.dart';
 import 'package:locker/services/files/sync/models/file.dart';
 import 'package:locker/services/local_settings.dart';
 import "package:locker/states/user_details_state.dart";
@@ -654,16 +655,28 @@ class _HomePageState extends UploaderPageState<HomePage>
                           if (_selectedFiles.files.isNotEmpty) {
                             return const SizedBox.shrink();
                           }
-                          return FloatingActionButton(
-                            tooltip: 'Add item',
-                            onPressed: _openSavePage,
-                            shape: const CircleBorder(),
-                            backgroundColor: colors.primary,
-                            elevation: 0,
-                            child: HugeIcon(
-                              icon: HugeIcons.strokeRoundedPlusSign,
-                              color: colors.specialWhite,
-                            ),
+                          return Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            children: [
+                              if (FeatureFlagService
+                                  .instance
+                                  .documentScanner) ...[
+                                _buildScannerFab(colors),
+                                const SizedBox(height: 14),
+                              ],
+                              FloatingActionButton(
+                                tooltip: 'Add item',
+                                onPressed: _openSavePage,
+                                shape: const CircleBorder(),
+                                backgroundColor: colors.primary,
+                                elevation: 0,
+                                child: HugeIcon(
+                                  icon: HugeIcons.strokeRoundedPlusSign,
+                                  color: colors.specialWhite,
+                                ),
+                              ),
+                            ],
                           );
                         },
                       ),
@@ -836,6 +849,36 @@ class _HomePageState extends UploaderPageState<HomePage>
   void _openSavePage() {
     showSaveBottomSheet(
       context,
+      onUploadDocument: addFile,
+      onUploadFiles: uploadFiles,
+    );
+  }
+
+  Widget _buildScannerFab(ColorTokens colors) {
+    return SizedBox(
+      width: 56,
+      child: Center(
+        child: Semantics(
+          button: true,
+          label: context.strings.scanDocumentTitle,
+          child: FABComponent(
+            variant: FABComponentVariant.secondary,
+            icon: HugeIcon(
+              icon: HugeIcons.strokeRoundedCamera01,
+              color: colors.primary,
+              size: 24,
+            ),
+            onTap: _openScanner,
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openScanner() {
+    handleSaveOption(
+      context,
+      SaveOptionType.scanDocument,
       onUploadDocument: addFile,
       onUploadFiles: uploadFiles,
     );

--- a/mobile/apps/locker/lib/ui/pages/home_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/home_page.dart
@@ -667,7 +667,8 @@ class _HomePageState extends UploaderPageState<HomePage>
                               ],
                               FloatingActionButton(
                                 tooltip: 'Add item',
-                                onPressed: _openSavePage,
+                                onPressed: () =>
+                                    _openSavePage(includeScanner: false),
                                 shape: const CircleBorder(),
                                 backgroundColor: colors.primary,
                                 elevation: 0,
@@ -779,7 +780,7 @@ class _HomePageState extends UploaderPageState<HomePage>
           child: HomeEmptyStateWidget(
             isLoading: _isSyncing,
             onSetupLegacy: () => openLegacyFromHome(context),
-            onSaveToLocker: _openSavePage,
+            onSaveToLocker: () => _openSavePage(includeScanner: true),
           ),
         ),
       ),
@@ -846,11 +847,12 @@ class _HomePageState extends UploaderPageState<HomePage>
     );
   }
 
-  void _openSavePage() {
+  void _openSavePage({required bool includeScanner}) {
     showSaveBottomSheet(
       context,
       onUploadDocument: addFile,
       onUploadFiles: uploadFiles,
+      includeScanner: includeScanner,
     );
   }
 

--- a/mobile/apps/locker/lib/ui/pages/save_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/save_page.dart
@@ -28,10 +28,13 @@ class SaveOption {
   final String description;
 }
 
-List<SaveOption> saveOptions(BuildContext context) {
+List<SaveOption> saveOptions(
+  BuildContext context, {
+  bool includeScanner = false,
+}) {
   final l10n = context.strings;
   return [
-    if (FeatureFlagService.instance.documentScanner)
+    if (includeScanner && FeatureFlagService.instance.documentScanner)
       SaveOption(
         type: SaveOptionType.scanDocument,
         icon: HugeIcons.strokeRoundedFileScan,

--- a/mobile/apps/locker/lib/ui/pages/save_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/save_page.dart
@@ -28,13 +28,10 @@ class SaveOption {
   final String description;
 }
 
-List<SaveOption> saveOptions(
-  BuildContext context, {
-  bool includeScanner = false,
-}) {
+List<SaveOption> saveOptions(BuildContext context) {
   final l10n = context.strings;
   return [
-    if (includeScanner && FeatureFlagService.instance.documentScanner)
+    if (FeatureFlagService.instance.documentScanner)
       SaveOption(
         type: SaveOptionType.scanDocument,
         icon: HugeIcons.strokeRoundedFileScan,

--- a/mobile/apps/locker/lib/ui/pages/save_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/save_page.dart
@@ -28,10 +28,13 @@ class SaveOption {
   final String description;
 }
 
-List<SaveOption> saveOptions(BuildContext context) {
+List<SaveOption> saveOptions(
+  BuildContext context, {
+  bool includeScanner = true,
+}) {
   final l10n = context.strings;
   return [
-    if (FeatureFlagService.instance.documentScanner)
+    if (includeScanner && FeatureFlagService.instance.documentScanner)
       SaveOption(
         type: SaveOptionType.scanDocument,
         icon: HugeIcons.strokeRoundedFileScan,
@@ -135,6 +138,7 @@ Future<void> showSaveBottomSheet(
   BuildContext context, {
   required Future<bool> Function() onUploadDocument,
   required Future<bool> Function(List<File> files) onUploadFiles,
+  bool includeScanner = true,
 }) {
   return showBottomSheetComponent<void>(
     context: context,
@@ -142,6 +146,7 @@ Future<void> showSaveBottomSheet(
       rootContext: context,
       onUploadDocument: onUploadDocument,
       onUploadFiles: onUploadFiles,
+      includeScanner: includeScanner,
     ),
   );
 }
@@ -152,17 +157,19 @@ class SaveBottomSheet extends StatelessWidget {
     required this.rootContext,
     required this.onUploadDocument,
     required this.onUploadFiles,
+    this.includeScanner = true,
   });
 
   final BuildContext rootContext;
   final Future<bool> Function() onUploadDocument;
   final Future<bool> Function(List<File> files) onUploadFiles;
+  final bool includeScanner;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.componentColors;
     final maxHeight = MediaQuery.of(context).size.height * 0.75;
-    final options = saveOptions(context);
+    final options = saveOptions(context, includeScanner: includeScanner);
 
     return BottomSheetComponent(
       title: context.strings.saveToLocker,
@@ -230,6 +237,7 @@ class SaveBottomSheet extends StatelessWidget {
           navigator.context,
           onUploadDocument: onUploadDocument,
           onUploadFiles: onUploadFiles,
+          includeScanner: includeScanner,
         );
       });
     }


### PR DESCRIPTION
## Description

Two tweaks to the Locker document scanner:

- **Faster auto-capture**: the arm hold (stable quad → shutter) goes from 2.5s to 1.5s. The grace window and post-capture cooldown are unchanged.
- **Dedicated scanner button**: the scanner now has its own button above the "Add item" FAB on the home page, using the `FABComponent` secondary variant with a camera icon. It opens the capture page directly and is gated on the `documentScanner` flag. The scanner entry is removed from the "Save to Locker" sheet when it is opened from the add FAB, but kept when the sheet is opened from the empty state, where the FAB (and thus the dedicated button) is hidden.

## Tests

Verified on the iOS simulator in both light and dark themes: button placement and styling, and direct navigation to the capture page.
