### PR TITLE
[server] Safely hand off object cleanup transactions

### DIFF
--- a/server/pkg/controller/object_cleanup.go
+++ b/server/pkg/controller/object_cleanup.go
@@ -81,11 +81,10 @@ func (c *ObjectCleanupController) removeUnreportedObjects() int {
 
 	tx, tempObjects, err := c.Repo.GetAndLockExpiredObjects()
 	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			logger.Error(err)
-		}
+		logger.Error(err)
 		return count
 	}
+	defer tx.Rollback()
 
 	for _, tempObject := range tempObjects {
 		err = c.removeUnreportedObject(tx, tempObject)

--- a/server/pkg/repo/object_cleanup.go
+++ b/server/pkg/repo/object_cleanup.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/ente/stacktrace"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/ente/museum/ente"
 	"github.com/ente/museum/pkg/utils/time"
@@ -83,19 +82,12 @@ func (repo *ObjectCleanupRepository) GetAndLockExpiredObjects() (*sql.Tx, []ente
 		return nil, nil, stacktrace.Propagate(err, "")
 	}
 
-	rollback := func() {
-		rerr := tx.Rollback()
-		if rerr != nil {
-			log.Errorf("Ignoring error when rolling back transaction: %s", rerr)
+	transferred := false
+	defer func() {
+		if !transferred {
+			_ = tx.Rollback()
 		}
-	}
-
-	commit := func() {
-		cerr := tx.Commit()
-		if cerr != nil {
-			log.Errorf("Ignoring error when committing transaction: %s", cerr)
-		}
-	}
+	}()
 
 	rows, err := tx.Query(`
 	SELECT object_key, is_multipart, upload_id, bucket_id FROM temp_objects
@@ -104,13 +96,7 @@ func (repo *ObjectCleanupRepository) GetAndLockExpiredObjects() (*sql.Tx, []ente
 	FOR UPDATE SKIP LOCKED
 	`, time.Microseconds())
 
-	if err != nil && errors.Is(err, sql.ErrNoRows) {
-		commit()
-		return nil, nil, err
-	}
-
 	if err != nil {
-		rollback()
 		return nil, nil, stacktrace.Propagate(err, "")
 	}
 
@@ -122,7 +108,6 @@ func (repo *ObjectCleanupRepository) GetAndLockExpiredObjects() (*sql.Tx, []ente
 		var bucketID sql.NullString
 		err := rows.Scan(&tempObject.ObjectKey, &tempObject.IsMultipart, &uploadID, &bucketID)
 		if err != nil {
-			rollback()
 			return nil, nil, stacktrace.Propagate(err, "")
 		}
 		if tempObject.IsMultipart {
@@ -133,6 +118,10 @@ func (repo *ObjectCleanupRepository) GetAndLockExpiredObjects() (*sql.Tx, []ente
 		}
 		tempObjects = append(tempObjects, tempObject)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, stacktrace.Propagate(err, "")
+	}
+	transferred = true
 	return tx, tempObjects, nil
 }
 

--- a/server/space/controller/cleanup.go
+++ b/server/space/controller/cleanup.go
@@ -53,13 +53,13 @@ func (c *CleanupController) removeUnreportedObjects(ctx context.Context) int {
 		logger.Error(err)
 		return 0
 	}
+	defer tx.Rollback()
 
 	var deleteAfterCommit []spacerepo.SpaceTempObjectRecord
 	count := 0
 	for _, tempObject := range tempObjects {
 		action, err := c.prepareUnreportedObject(ctx, tx, tempObject)
 		if err != nil {
-			_ = tx.Rollback()
 			logger.Error(err)
 			return count
 		}

--- a/server/space/repo/temp_objects.go
+++ b/server/space/repo/temp_objects.go
@@ -133,6 +133,12 @@ func (r *AssetsRepository) GetAndLockExpiredTempObjects(ctx context.Context, now
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(err, "")
 	}
+	transferred := false
+	defer func() {
+		if !transferred {
+			_ = tx.Rollback()
+		}
+	}()
 	rows, err := tx.QueryContext(ctx, `
 		SELECT object_key, space_id, purpose, bucket_id, expected_size, expires_at, cleanup_after, created_at
 		FROM space_temp_objects
@@ -142,7 +148,6 @@ func (r *AssetsRepository) GetAndLockExpiredTempObjects(ctx context.Context, now
 		FOR UPDATE SKIP LOCKED
 	`, nowMicros, limit)
 	if err != nil {
-		_ = tx.Rollback()
 		return nil, nil, stacktrace.Propagate(err, "")
 	}
 	defer rows.Close()
@@ -151,15 +156,14 @@ func (r *AssetsRepository) GetAndLockExpiredTempObjects(ctx context.Context, now
 	for rows.Next() {
 		rec, err := scanSpaceTempObject(rows)
 		if err != nil {
-			_ = tx.Rollback()
 			return nil, nil, err
 		}
 		tempObjects = append(tempObjects, *rec)
 	}
 	if err := rows.Err(); err != nil {
-		_ = tx.Rollback()
 		return nil, nil, stacktrace.Propagate(err, "")
 	}
+	transferred = true
 	return tx, tempObjects, nil
 }
 


### PR DESCRIPTION
Object cleanup repositories return an open transaction because rows are locked with `FOR UPDATE SKIP LOCKED`.

Keep rollback ownership in the repository until a successful handoff, then defer rollback in the controller. This ensures query, iteration, and panic paths release the transaction and its pooled connection.