### PR TITLE
[server] Validate SRP updates before recovery side effects

### DIFF
--- a/server/ente/srp.go
+++ b/server/ente/srp.go
@@ -43,6 +43,13 @@ type UpdateSRPAndKeysRequest struct {
 	LogOutOtherDevices *bool              `json:"logOutOtherDevices"`
 }
 
+func (r UpdateSRPAndKeysRequest) Validate() error {
+	if r.UpdateAttributes == nil {
+		return NewBadRequestWithMessage("updatedKeyAttr is required")
+	}
+	return r.UpdateAttributes.Validate()
+}
+
 type UpdateSRPSetupResponse struct {
 	SetupID uuid.UUID `json:"setupID" binding:"required"`
 	SRPM2   string    `json:"srpM2" binding:"required"`

--- a/server/ente/user_test.go
+++ b/server/ente/user_test.go
@@ -44,6 +44,20 @@ func TestKeyRequestValidation(t *testing.T) {
 	}
 }
 
+func TestUpdateSRPAndKeysRequestValidation(t *testing.T) {
+	request := UpdateSRPAndKeysRequest{}
+	assertBadRequestMessage(t, request.Validate(), "updatedKeyAttr is required")
+
+	request.UpdateAttributes = &UpdateKeysRequest{
+		MemLimit: validArgonMemLimit,
+		OpsLimit: validArgonOpsLimit - 1,
+	}
+	assertBadRequestMessage(t, request.Validate(), "Unexpected KDF strength")
+
+	request.UpdateAttributes.OpsLimit = validArgonOpsLimit
+	require.NoError(t, request.Validate())
+}
+
 func assertBadRequestMessage(t *testing.T, err error, wantMessage string) {
 	t.Helper()
 

--- a/server/pkg/controller/emergency/recovery.go
+++ b/server/pkg/controller/emergency/recovery.go
@@ -55,6 +55,9 @@ func (c *Controller) ChangePassword(ctx *gin.Context, userID int64, request ente
 	if err != nil {
 		return nil, err
 	}
+	if err := request.UpdateSrp.Validate(); err != nil {
+		return nil, stacktrace.Propagate(err, "invalid request")
+	}
 	if disableErr := c.UserCtrl.DisableTwoFactor(contact.UserID); disableErr != nil {
 		return nil, stacktrace.Propagate(disableErr, "failed to disable 2fa")
 	}

--- a/server/pkg/controller/legacy_kit/controller.go
+++ b/server/pkg/controller/legacy_kit/controller.go
@@ -288,6 +288,9 @@ func (c *Controller) ChangePassword(ctx *gin.Context, req ente.LegacyKitRecovery
 	if session.Status != ente.LegacyKitRecoveryStatusReady {
 		return nil, stacktrace.Propagate(ente.NewBadRequestWithMessage("legacy kit recovery is not ready"), "")
 	}
+	if err := req.UpdateSrpAndKeysRequest.Validate(); err != nil {
+		return nil, stacktrace.Propagate(err, "invalid request")
+	}
 	// Known and accepted for the current recovery flow: once a legacy-kit session
 	// is READY, we clear existing second-factor requirements before applying the
 	// recovered password update, so an old TOTP/passkey enrollment does not block

--- a/server/pkg/controller/user/srp.go
+++ b/server/pkg/controller/user/srp.go
@@ -92,6 +92,9 @@ func (c *UserController) updateSrpAndKeyAttributes(context *gin.Context,
 	shouldClearTokens bool,
 	revocationScope sessionRevocationScope,
 ) (*ente.UpdateSRPSetupResponse, error) {
+	if err := req.Validate(); err != nil {
+		return nil, stacktrace.Propagate(err, "invalid request")
+	}
 	setup, err := c.UserAuthRepo.GetTempSRPSetupEntity(context, req.SetupID)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
@@ -105,7 +108,7 @@ func (c *UserController) updateSrpAndKeyAttributes(context *gin.Context,
 			return nil, err
 		}
 	}
-	err = c.UserAuthRepo.InsertOrUpdateSRPAuthAndKeyAttr(context, userID, req, setup)
+	err = c.UserAuthRepo.InsertOrUpdateSRPAuthAndKeyAttr(context, userID, *req.UpdateAttributes, setup)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to add entry in srp auth")
 	}

--- a/server/pkg/repo/srp.go
+++ b/server/pkg/repo/srp.go
@@ -116,7 +116,7 @@ func (repo *UserAuthRepository) InsertSRPAuth(ctx context.Context, userID int64,
 	return stacktrace.Propagate(err, "")
 }
 
-func (repo *UserAuthRepository) InsertOrUpdateSRPAuthAndKeyAttr(ctx context.Context, userID int64, req ente.UpdateSRPAndKeysRequest, setup *ente.SRPSetupEntity) error {
+func (repo *UserAuthRepository) InsertOrUpdateSRPAuthAndKeyAttr(ctx context.Context, userID int64, updateKeyAttr ente.UpdateKeysRequest, setup *ente.SRPSetupEntity) error {
 	isSRPSetupDone, err := repo.IsSRPSetupDone(ctx, userID)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
@@ -125,6 +125,7 @@ func (repo *UserAuthRepository) InsertOrUpdateSRPAuthAndKeyAttr(ctx context.Cont
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	if !isSRPSetupDone {
 		_, err = tx.ExecContext(ctx, `
 	INSERT INTO srp_auth(user_id, srp_user_id, salt, verifier) VALUES($1, $2 , $3, $4)`,
@@ -134,23 +135,11 @@ func (repo *UserAuthRepository) InsertOrUpdateSRPAuthAndKeyAttr(ctx context.Cont
 			setup.SRPUserID, setup.Salt, setup.Verifier, userID)
 	}
 	if err != nil {
-		rollBackErr := tx.Rollback()
-		if rollBackErr != nil {
-			return rollBackErr
-		}
 		return stacktrace.Propagate(err, "")
-	}
-	updateKeyAttr := *req.UpdateAttributes
-	if validErr := updateKeyAttr.Validate(); validErr != nil {
-		return stacktrace.Propagate(validErr, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE key_attributes SET kek_salt = $1, encrypted_key = $2, key_decryption_nonce = $3, mem_limit = $4, ops_limit = $5 WHERE user_id = $6`,
 		updateKeyAttr.KEKSalt, updateKeyAttr.EncryptedKey, updateKeyAttr.KeyDecryptionNonce, updateKeyAttr.MemLimit, updateKeyAttr.OpsLimit, userID)
 	if err != nil {
-		rollBackErr := tx.Rollback()
-		if rollBackErr != nil {
-			return rollBackErr
-		}
 		return stacktrace.Propagate(err, "")
 	}
 	return tx.Commit()


### PR DESCRIPTION
Recovery password changes removed TOTP/passkey configuration before validating `updatedKeyAttr`. A missing or invalid value could therefore mutate the account, then panic or return with an open transaction.

Validate the request before recovery side effects and at the shared SRP update boundary, pass validated key attributes into the repository, and ensure its transaction rolls back on failure.