### PR TITLE
[server] Add token hash compatibility column

### DIFF
--- a/server/migrations/134_add_token_hash.down.sql
+++ b/server/migrations/134_add_token_hash.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP TRIGGER sync_token_hash ON tokens;
+DROP FUNCTION sync_token_hash();
+ALTER TABLE tokens DROP COLUMN token_hash;
+
+COMMIT;

--- a/server/migrations/134_add_token_hash.up.sql
+++ b/server/migrations/134_add_token_hash.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+ALTER TABLE tokens ADD COLUMN token_hash BYTEA;
+
+CREATE FUNCTION sync_token_hash() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.token IS NOT NULL THEN
+        NEW.token_hash := sha256(convert_to(NEW.token, 'UTF8'));
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER sync_token_hash
+    BEFORE INSERT OR UPDATE OF token ON tokens
+    FOR EACH ROW EXECUTE FUNCTION sync_token_hash();
+
+COMMIT;

--- a/server/pkg/repo/userauth_test.go
+++ b/server/pkg/repo/userauth_test.go
@@ -1,12 +1,58 @@
 package repo
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"testing"
 
 	"github.com/ente/museum/ente"
 	"github.com/ente/museum/internal/testutil"
 	"github.com/ente/museum/pkg/utils/time"
 )
+
+func TestTokenHashCompatibilityTrigger(t *testing.T) {
+	testutil.WithServerRoot(t)
+
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() { testutil.ResetTables(t, db) })
+
+	userID := testutil.InsertUser(t, db, testutil.UserFixture{
+		Email:        "token-hash@example.com",
+		CreationTime: 1,
+	})
+	rawToken := "existing-bearer-token"
+	var storedToken string
+	var storedHash []byte
+	err := db.QueryRow(
+		`INSERT INTO tokens(user_id, token, token_hash, creation_time, last_used_at, app)
+		 VALUES($1, $2, $3, $4, $5, $6)
+		 RETURNING token, token_hash`,
+		userID, rawToken, bytes.Repeat([]byte{0xff}, sha256.Size), 1, 1, ente.Photos,
+	).Scan(&storedToken, &storedHash)
+	if err != nil {
+		t.Fatalf("failed to insert token: %v", err)
+	}
+
+	expectedHash := sha256.Sum256([]byte(rawToken))
+	if storedToken != rawToken {
+		t.Fatalf("raw token changed: got %q want %q", storedToken, rawToken)
+	}
+	if !bytes.Equal(storedHash, expectedHash[:]) {
+		t.Fatalf("unexpected token hash: got %x want %x", storedHash, expectedHash)
+	}
+
+	rawToken = "updated-bearer-token"
+	if err := db.QueryRow(
+		`UPDATE tokens SET token = $1 WHERE user_id = $2 RETURNING token_hash`, rawToken, userID,
+	).Scan(&storedHash); err != nil {
+		t.Fatalf("failed to update token: %v", err)
+	}
+	expectedHash = sha256.Sum256([]byte(rawToken))
+	if !bytes.Equal(storedHash, expectedHash[:]) {
+		t.Fatalf("unexpected updated token hash: got %x want %x", storedHash, expectedHash)
+	}
+}
 
 func TestUserAuthRepositoryRemoveOTTReturnsWhetherRowWasConsumed(t *testing.T) {
 	testutil.WithServerRoot(t)


### PR DESCRIPTION
Add a nullable `token_hash` column and a database trigger that derives it from raw tokens on insert or token update. Existing authentication and token storage behavior remain unchanged.

A follow-up migration will backfill existing rows and add the index and constraints before Museum begins reading tokens by hash.