### PR TITLE
[mobile] Use shared offline location lookup

### DIFF
--- a/mobile/apps/photos/README.md
+++ b/mobile/apps/photos/README.md
@@ -63,7 +63,7 @@ After updating Flutter dependencies, run `pod install` from `ios/` on macOS and 
 
 ## 🏙️ Attributions
 
-City coordinates from [Simple Maps](https://simplemaps.com/data/world-cities)
+City data from [GeoNames](https://www.geonames.org/), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## 🌍 Translate
 

--- a/mobile/apps/photos/changes/location-search.md
+++ b/mobile/apps/photos/changes/location-search.md
@@ -1,0 +1,1 @@
+- Added country-name search and improved city matching for locations and memories.

--- a/mobile/apps/photos/lib/service_locator.dart
+++ b/mobile/apps/photos/lib/service_locator.dart
@@ -206,7 +206,7 @@ TrashSyncService get trashSyncService {
 
 LocationService? _locationService;
 LocationService get locationService {
-  _locationService ??= LocationService(ServiceLocator.instance.prefs);
+  _locationService ??= LocationService();
   return _locationService!;
 }
 

--- a/mobile/apps/photos/lib/services/location_service.dart
+++ b/mobile/apps/photos/lib/services/location_service.dart
@@ -1,11 +1,10 @@
 import "dart:convert";
-import "dart:io";
 import "dart:math";
 
 import "package:computer/computer.dart";
-import "package:ente_pure_utils/ente_pure_utils.dart";
-import "package:flutter/foundation.dart";
+import "package:ente_photos_platform/ente_photos_platform.dart";
 import "package:logging/logging.dart";
+import "package:path_provider/path_provider.dart";
 import "package:photos/core/constants.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/events/location_tag_updated_event.dart";
@@ -16,71 +15,42 @@ import "package:photos/models/local_entity_data.dart";
 import "package:photos/models/location/location.dart";
 import 'package:photos/models/location_tag/location_tag.dart';
 import "package:photos/service_locator.dart";
-import "package:photos/services/remote_assets_service.dart";
-import "package:shared_preferences/shared_preferences.dart";
+import "package:photos/src/rust/api/location_api.dart" as rust;
 
 const double earthRadius = 6371; // Earth's radius in kilometers
 
 class CitySearchIndex {
-  static const empty = CitySearchIndex(
-    cities: <City>[],
-    nodes: <List<int>>[],
-    root: -1,
-    maxLatDelta: 0,
-    maxLngDelta: 0,
-  );
+  final Map<EnteFile, City> assignments;
 
-  final List<City> cities;
-  final List<List<int>> nodes;
-  final int root;
-  final double maxLatDelta;
-  final double maxLngDelta;
+  const CitySearchIndex(this.assignments);
 
-  const CitySearchIndex({
-    required this.cities,
-    required this.nodes,
-    required this.root,
-    required this.maxLatDelta,
-    required this.maxLngDelta,
-  });
-
-  bool get isEmpty => cities.isEmpty;
-
-  Map<String, dynamic> searchArgs(List<EnteFile> files, {String query = ''}) {
-    return <String, dynamic>{
-      "query": query,
-      "cities": cities,
-      "files": files,
-      if (nodes.isNotEmpty && root >= 0) ...{
-        "kdTreeNodes": nodes,
-        "kdTreeRoot": root,
-        "kdTreeMaxLatDelta": maxLatDelta,
-        "kdTreeMaxLngDelta": maxLngDelta,
-      },
-    };
+  Map<City, List<EnteFile>> match(List<EnteFile> files) {
+    final results = <City, List<EnteFile>>{};
+    for (final file in files) {
+      final city = assignments[file];
+      if (city != null) results.putIfAbsent(city, () => []).add(file);
+    }
+    return results;
   }
 }
 
 class LocationService {
-  final SharedPreferences prefs;
   final Logger _logger = Logger((LocationService).toString());
   final Computer _computer = Computer.shared();
 
   // Refresh discovery if it ran before the city index loaded.
   bool reloadLocationDiscoverySection = false;
 
-  static const _kCitiesKdTreeRemotePath =
-      "https://assets.ente.com/world_cities.kdtree.bin";
-
-  CitySearchIndex _citySearchIndex = CitySearchIndex.empty;
+  rust.LocationIndex? _index;
+  Future<rust.LocationIndex?>? _loading;
+  final _countryNames = <String, CountryNames>{};
 
   // TODO: lau: consider actually using this in location section
   List<BaseLocation> baseLocations = [];
 
-  LocationService(this.prefs) {
-    debugPrint('LocationService constructor');
+  LocationService() {
     Future.delayed(const Duration(seconds: 3), () {
-      _loadCities();
+      _loadIndex();
     });
   }
 
@@ -108,39 +78,115 @@ class LocationService {
     List<EnteFile> allFiles,
     String query,
   ) async {
-    if (allFiles.isNotEmpty && _citySearchIndex.isEmpty && query.isEmpty) {
-      reloadLocationDiscoverySection = true;
-    }
-    final EnteWatch w = EnteWatch("cities_search")..start();
-    w.log('start for files ${allFiles.length} and query $query');
-    final normalizedQuery = query.toLowerCase();
-    if (normalizedQuery.isNotEmpty &&
-        !_citySearchIndex.cities.any(
-          (city) => city.city.toLowerCase().contains(normalizedQuery),
-        )) {
-      w.log(
-        'end for query: $query  on ${allFiles.length} files, found 0 cities',
-      );
+    final index = await _loadIndex();
+    if (index == null) {
+      if (allFiles.isNotEmpty && query.isEmpty) {
+        reloadLocationDiscoverySection = true;
+      }
       return {};
     }
-    final args = _citySearchIndex.searchArgs(allFiles, query: query);
-    final result = await _computer.compute(getCityResults, param: args);
-    w.log(
-      'end for query: $query  on ${allFiles.length} files, found '
-      '${result.length} cities',
+    final files = allFiles.where((file) => file.hasLocation).toList();
+    final groups = await index.groupCities(
+      coordinates: _coordinates(files),
+      query: query,
     );
-    return result;
+    return {
+      for (final group in groups)
+        _city(group.city): [
+          for (final position in group.coordinateIndices) files[position],
+        ],
+    };
+  }
+
+  Future<Map<String, List<EnteFile>>> getFilesInCountry(
+    List<EnteFile> allFiles,
+    String query,
+    String locale,
+  ) async {
+    if (query.isEmpty) return {};
+    final index = await _loadIndex();
+    if (index == null) return {};
+    final names = _countryNames[locale] ??= await CountryNamesClient.get(
+      locale,
+    );
+    final normalizedQuery = query.toLowerCase();
+    final matchingCodes = names.names.entries
+        .where((entry) => entry.value.toLowerCase().contains(normalizedQuery))
+        .map((entry) => entry.key)
+        .toSet();
+    if (matchingCodes.isEmpty) return {};
+    final files = allFiles.where((file) => file.hasLocation).toList();
+    final groups = await index.groupCountries(
+      coordinates: _coordinates(files),
+      region: names.region,
+    );
+    return {
+      for (final group in groups)
+        if (matchingCodes.contains(group.code))
+          names.names[group.code]!: [
+            for (final position in group.coordinateIndices) files[position],
+          ],
+    };
   }
 
   Future<List<City>> getCities() async {
-    return (await getCitySearchIndex()).cities;
+    final index = await _loadIndex();
+    if (index == null) return [];
+    return (await index.cities()).map(_city).toList();
   }
 
-  Future<CitySearchIndex> getCitySearchIndex() async {
-    if (_citySearchIndex.isEmpty) {
-      await _loadCities();
+  Future<CitySearchIndex> getCitySearchIndex(
+    Iterable<EnteFile> allFiles,
+  ) async {
+    final files = allFiles.toList();
+    final groups = await getFilesInCity(files, '');
+    return CitySearchIndex({
+      for (final group in groups.entries)
+        for (final file in group.value) file: group.key,
+    });
+  }
+
+  List<rust.LocationCoordinate> _coordinates(List<EnteFile> files) => [
+    for (final file in files)
+      rust.LocationCoordinate(
+        latitude: file.location!.latitude!,
+        longitude: file.location!.longitude!,
+      ),
+  ];
+
+  City _city(rust.LocationCity city) => City(
+    city: city.name,
+    country: city.country,
+    lat: city.latitude,
+    lng: city.longitude,
+  );
+
+  Future<rust.LocationIndex?> _loadIndex() {
+    if (_index != null) return Future.value(_index);
+    return _loading ??= _openIndex();
+  }
+
+  Future<rust.LocationIndex?> _openIndex() async {
+    final startTime = DateTime.now();
+    try {
+      final root = (await getApplicationSupportDirectory()).path;
+      _index = await rust.openLocationIndex(assetRoot: root);
+      _logger.info(
+        "Loaded location index in ${DateTime.now().difference(startTime).inMilliseconds}ms, reloadingDiscovery: $reloadLocationDiscoverySection",
+      );
+      if (reloadLocationDiscoverySection) {
+        reloadLocationDiscoverySection = false;
+        Bus.instance.fire(
+          LocationTagUpdatedEvent(LocTagEventType.dataSetLoaded),
+        );
+      }
+      return _index;
+    } catch (e, s) {
+      _logger.severe("Failed to load location index", e, s);
+      return null;
+    } finally {
+      _loading = null;
     }
-    return _citySearchIndex;
   }
 
   Future<Iterable<LocalEntity<LocationTag>>> getLocationTags() {
@@ -279,41 +325,6 @@ class LocationService {
       rethrow;
     }
   }
-
-  void _applyKdTreeLoadResult(Map<String, dynamic> result) {
-    _citySearchIndex = CitySearchIndex(
-      cities: result["cities"] as List<City>,
-      nodes: (result["nodes"] as List).cast<List<int>>(),
-      root: result["root"] as int,
-      maxLatDelta: (result["maxLatDelta"] as num).toDouble(),
-      maxLngDelta: (result["maxLngDelta"] as num).toDouble(),
-    );
-  }
-
-  Future<void> _loadCities() async {
-    final startTime = DateTime.now();
-    try {
-      final file = await RemoteAssetsService.instance.getAsset(
-        _kCitiesKdTreeRemotePath,
-      );
-      final kdTreeResult = await _computer.compute(
-        parseCitiesFromKdTreeBin,
-        param: {"filePath": file.path},
-      );
-      _applyKdTreeLoadResult(kdTreeResult);
-      _logger.info(
-        "Loaded KD-tree cities from CDN in ${(DateTime.now().millisecondsSinceEpoch - startTime.millisecondsSinceEpoch)}ms, reloadingDiscovery: $reloadLocationDiscoverySection",
-      );
-      if (reloadLocationDiscoverySection) {
-        reloadLocationDiscoverySection = false;
-        Bus.instance.fire(
-          LocationTagUpdatedEvent(LocTagEventType.dataSetLoaded),
-        );
-      }
-    } catch (e, s) {
-      _logger.severe("Failed to load KD-tree cities", e, s);
-    }
-  }
 }
 
 Map<LocationTag, int> _getLocationTagsToOccurenceForIsolate(Map args) {
@@ -347,277 +358,6 @@ Map<LocationTag, int> _getLocationTagsToOccurenceForIsolate(Map args) {
   }
 
   return locationTagToOccurence;
-}
-
-Future<Map<String, dynamic>> parseCitiesFromKdTreeBin(Map args) async {
-  final String filePath = args["filePath"] as String;
-  final payload = ByteData.sublistView(await File(filePath).readAsBytes());
-  final buffer = payload.buffer;
-  final baseOffset = payload.offsetInBytes;
-  const endian = Endian.little;
-
-  final magic = String.fromCharCodes([
-    payload.getUint8(0),
-    payload.getUint8(1),
-    payload.getUint8(2),
-    payload.getUint8(3),
-  ]);
-  if (magic != "KDT1") {
-    throw FormatException("Unsupported KD-tree magic: $magic");
-  }
-  final headerSize = payload.getUint16(4, endian);
-  final version = payload.getUint16(6, endian);
-  if (headerSize < 64 || version != 1) {
-    throw FormatException(
-      "Unsupported KD-tree header: size=$headerSize version=$version",
-    );
-  }
-  final flags = payload.getUint32(8, endian);
-  if ((flags & 0x1) == 0) {
-    throw const FormatException("Unsupported KD-tree coordinate format");
-  }
-
-  final nodeCount = payload.getUint32(12, endian);
-  final pointCount = payload.getUint32(16, endian);
-  final cityCount = payload.getUint32(20, endian);
-  final countryCount = payload.getUint32(24, endian);
-  final rootIndex = payload.getInt32(28, endian);
-  final nodesOffset = payload.getUint32(32, endian);
-  final pointsOffset = payload.getUint32(36, endian);
-  final citiesOffsetsOffset = payload.getUint32(40, endian);
-  final citiesBlobOffset = payload.getUint32(44, endian);
-  final countriesOffsetsOffset = payload.getUint32(48, endian);
-  final countriesBlobOffset = payload.getUint32(52, endian);
-
-  final parsedNodes = <List<int>>[];
-  final nodesBaseOffset = nodesOffset;
-  for (var i = 0; i < nodeCount; i += 1) {
-    final nodeOffset = nodesBaseOffset + i * 16;
-    parsedNodes.add([
-      payload.getInt32(nodeOffset, endian),
-      payload.getInt32(nodeOffset + 4, endian),
-      payload.getInt32(nodeOffset + 8, endian),
-      payload.getInt32(nodeOffset + 12, endian),
-    ]);
-  }
-
-  final cityOffsets = List<int>.generate(
-    cityCount + 1,
-    (index) => payload.getUint32(citiesOffsetsOffset + index * 4, endian),
-    growable: false,
-  );
-  final cityBlobLength = cityOffsets[cityCount];
-  final cityBlob = Uint8List.view(
-    buffer,
-    baseOffset + citiesBlobOffset,
-    cityBlobLength,
-  );
-  final cityNames = List<String>.generate(cityCount, (index) {
-    final start = cityOffsets[index];
-    final end = cityOffsets[index + 1];
-    return utf8.decode(cityBlob.sublist(start, end));
-  }, growable: false);
-
-  final countryOffsets = List<int>.generate(
-    countryCount + 1,
-    (index) => payload.getUint32(countriesOffsetsOffset + index * 4, endian),
-    growable: false,
-  );
-  final countryBlobLength = countryOffsets[countryCount];
-  final countryBlob = Uint8List.view(
-    buffer,
-    baseOffset + countriesBlobOffset,
-    countryBlobLength,
-  );
-  final countryNames = List<String>.generate(countryCount, (index) {
-    final start = countryOffsets[index];
-    final end = countryOffsets[index + 1];
-    return utf8.decode(countryBlob.sublist(start, end));
-  }, growable: false);
-
-  final cities = <City>[];
-  double maxA = 0;
-  double maxB = 0;
-  final pointsBaseOffset = pointsOffset;
-  for (var i = 0; i < pointCount; i += 1) {
-    final pointOffset = pointsBaseOffset + i * 16;
-    final lat = payload.getFloat32(pointOffset, endian);
-    final lng = payload.getFloat32(pointOffset + 4, endian);
-    final cityIndex = payload.getUint32(pointOffset + 8, endian);
-    final countryIndex = payload.getUint32(pointOffset + 12, endian);
-    final a = (defaultCityRadius * scaleFactor(lat)) / kilometersPerDegree;
-    const b = defaultCityRadius / kilometersPerDegree;
-    cities.add(
-      City(
-        city: cityNames[cityIndex],
-        country: countryNames[countryIndex],
-        lat: lat,
-        lng: lng,
-        a: a,
-        aSquare: a * a,
-        b: b,
-        bSquare: b * b,
-      ),
-    );
-    if (a > maxA) {
-      maxA = a;
-    }
-    if (b > maxB) {
-      maxB = b;
-    }
-  }
-
-  return {
-    "cities": cities,
-    "nodes": parsedNodes,
-    "root": rootIndex,
-    "maxLatDelta": maxA,
-    "maxLngDelta": maxB,
-  };
-}
-
-List<int> _kdTreeRangeSearch({
-  required List<List<int>> nodes,
-  required List<City> cities,
-  required int rootIndex,
-  required double minLat,
-  required double maxLat,
-  required double minLng,
-  required double maxLng,
-}) {
-  if (rootIndex < 0 || nodes.isEmpty) {
-    return const [];
-  }
-  final results = <int>[];
-  final stack = <int>[rootIndex];
-  while (stack.isNotEmpty) {
-    final nodeIndex = stack.removeLast();
-    if (nodeIndex < 0 || nodeIndex >= nodes.length) {
-      continue;
-    }
-    final node = nodes[nodeIndex];
-    final pointIndex = node[0];
-    if (pointIndex < 0 || pointIndex >= cities.length) {
-      continue;
-    }
-    final city = cities[pointIndex];
-    final lat = city.lat;
-    final lng = city.lng;
-    if (lat >= minLat && lat <= maxLat && lng >= minLng && lng <= maxLng) {
-      results.add(pointIndex);
-    }
-    final axis = node[3];
-    final leftIndex = node[1];
-    final rightIndex = node[2];
-    if (axis == 0) {
-      if (minLat <= lat && leftIndex >= 0 && leftIndex < nodes.length) {
-        stack.add(leftIndex);
-      }
-      if (maxLat >= lat && rightIndex >= 0 && rightIndex < nodes.length) {
-        stack.add(rightIndex);
-      }
-    } else if (axis == 1) {
-      if (minLng <= lng && leftIndex >= 0 && leftIndex < nodes.length) {
-        stack.add(leftIndex);
-      }
-      if (maxLng >= lng && rightIndex >= 0 && rightIndex < nodes.length) {
-        stack.add(rightIndex);
-      }
-    } else {
-      if (leftIndex >= 0 && leftIndex < nodes.length) {
-        stack.add(leftIndex);
-      }
-      if (rightIndex >= 0 && rightIndex < nodes.length) {
-        stack.add(rightIndex);
-      }
-    }
-  }
-  return results;
-}
-
-Map<City, List<EnteFile>> getCityResults(Map args) {
-  final query = (args["query"] as String).toLowerCase();
-  final List<City> cities = args["cities"] as List<City>;
-  final List<EnteFile> files = args["files"] as List<EnteFile>;
-  final kdTreeNodesRaw = args["kdTreeNodes"];
-  final List<List<int>> kdTreeNodes = kdTreeNodesRaw is List
-      ? kdTreeNodesRaw.cast<List<int>>()
-      : const [];
-  final int kdTreeRoot = (args["kdTreeRoot"] as int?) ?? -1;
-  final double kdTreeMaxLatDelta =
-      (args["kdTreeMaxLatDelta"] as num?)?.toDouble() ?? 0;
-  final double kdTreeMaxLngDelta =
-      (args["kdTreeMaxLngDelta"] as num?)?.toDouble() ?? 0;
-  final bool useKdTree =
-      kdTreeNodes.isNotEmpty &&
-      kdTreeRoot >= 0 &&
-      kdTreeMaxLatDelta > 0 &&
-      kdTreeMaxLngDelta > 0;
-
-  if (!useKdTree) {
-    final matchingCities = cities
-        .where((city) => city.city.toLowerCase().contains(query))
-        .toList();
-
-    final Map<City, List<EnteFile>> results = {};
-    for (final file in files) {
-      if (!file.hasLocation) continue;
-      final fileLocation = file.location!;
-      for (final city in matchingCities) {
-        final x = city.lat - fileLocation.latitude!;
-        final y = city.lng - fileLocation.longitude!;
-
-        if (x.abs() > city.a || y.abs() > city.b) continue;
-
-        if ((x * x) / city.aSquare + (y * y) / city.bSquare <= 1) {
-          results.putIfAbsent(city, () => []).add(file);
-          break;
-        }
-      }
-    }
-    return results;
-  }
-
-  final bool hasQuery = query.isNotEmpty;
-  final Map<City, List<EnteFile>> results = {};
-  for (final file in files) {
-    if (!file.hasLocation) continue;
-    final fileLocation = file.location!;
-    final fileLat = fileLocation.latitude!;
-    final fileLng = fileLocation.longitude!;
-    final candidateIndices = _kdTreeRangeSearch(
-      nodes: kdTreeNodes,
-      cities: cities,
-      rootIndex: kdTreeRoot,
-      minLat: fileLat - kdTreeMaxLatDelta,
-      maxLat: fileLat + kdTreeMaxLatDelta,
-      minLng: fileLng - kdTreeMaxLngDelta,
-      maxLng: fileLng + kdTreeMaxLngDelta,
-    );
-    int bestIndex = -1;
-    for (final cityIndex in candidateIndices) {
-      final city = cities[cityIndex];
-      if (hasQuery && !city.city.toLowerCase().contains(query)) {
-        continue;
-      }
-      final x = city.lat - fileLat;
-      final y = city.lng - fileLng;
-      if (x.abs() > city.a || y.abs() > city.b) {
-        continue;
-      }
-      if ((x * x) / city.aSquare + (y * y) / city.bSquare <= 1) {
-        if (bestIndex == -1 || cityIndex < bestIndex) {
-          bestIndex = cityIndex;
-        }
-      }
-    }
-    if (bestIndex != -1) {
-      final city = cities[bestIndex];
-      results.putIfAbsent(city, () => []).add(file);
-    }
-  }
-
-  return results;
 }
 
 bool isFileInsideLocationTag(
@@ -666,45 +406,12 @@ class City {
   final double lat;
   final double lng;
 
-  // Ellipse semi-axes in degrees and their precomputed squares.
-  final double a;
-  final double aSquare;
-  final double b;
-  final double bSquare;
-
-  City({
+  const City({
     required this.city,
     required this.country,
     required this.lat,
     required this.lng,
-    required this.a,
-    required this.aSquare,
-    required this.b,
-    required this.bSquare,
   });
-
-  factory City.fromMap(Map<String, dynamic> map) {
-    final lat = map['lat']?.toDouble() ?? 0.0;
-    final a = (defaultCityRadius * scaleFactor(lat)) / kilometersPerDegree;
-    const b = defaultCityRadius / kilometersPerDegree;
-    return City(
-      city: map['city'] ?? '',
-      country: map['country'] ?? '',
-      lat: lat,
-      lng: map['lng']?.toDouble() ?? 0.0,
-      a: a,
-      aSquare: a * a,
-      b: b,
-      bSquare: b * b,
-    );
-  }
-
-  factory City.fromJson(String source) => City.fromMap(json.decode(source));
-
-  @override
-  String toString() {
-    return 'City(city: $city, country: $country, lat: $lat, lng: $lng)';
-  }
 }
 
 class GPSData {

--- a/mobile/apps/photos/lib/services/search_service.dart
+++ b/mobile/apps/photos/lib/services/search_service.dart
@@ -1035,6 +1035,7 @@ class SearchService {
     final Map<LocalEntity<LocationTag>, List<EnteFile>> result = {};
     final normalizedQuery = query.toLowerCase();
     if (!context.mounted) return const [];
+    final locale = Localizations.localeOf(context).toLanguageTag();
     final noLocationName = context.strings.noLocation;
     if (!context.mounted) return const [];
     final noLocationTagName = context.strings.noLocationTag;
@@ -1163,6 +1164,37 @@ class SearchService {
     final allCitiesSearch = query == '__city';
     if (allCitiesSearch) {
       query = '';
+    }
+    if (!allCitiesSearch) {
+      Map<String, List<EnteFile>> countries;
+      try {
+        countries = await locationService.getFilesInCountry(
+          filesWithLocation,
+          query,
+          locale,
+        );
+      } catch (e, s) {
+        _logger.warning("Failed to search countries", e, s);
+        countries = {};
+      }
+      final sortedCountries = countries.keys.toList()
+        ..sort((a, b) => countries[b]!.length.compareTo(countries[a]!.length));
+      for (final country in sortedCountries) {
+        if (!locationTagNames.add(country)) continue;
+        searchResults.add(
+          GenericSearchResult(
+            ResultType.location,
+            country,
+            countries[country]!,
+            hierarchicalSearchFilter: TopLevelGenericFilter(
+              filterName: country,
+              occurrence: kMostRelevantFilter,
+              filterResultType: ResultType.location,
+              matchedUploadedIDs: filesToUploadedFileIDs(countries[country]!),
+            ),
+          ),
+        );
+      }
     }
     final results = await locationService.getFilesInCity(
       filesWithLocation,

--- a/mobile/apps/photos/lib/services/smart_memories_service.dart
+++ b/mobile/apps/photos/lib/services/smart_memories_service.dart
@@ -356,9 +356,11 @@ class SmartMemoriesService {
         : Configuration.instance.getEmail();
     _logger.info('currentUserEmail: $currentUserEmail $timeLogger');
 
-    final citySearchIndex = await locationService.getCitySearchIndex();
+    final citySearchIndex = await locationService.getCitySearchIndex(
+      allFileIdsToFile.values,
+    );
     _logger.info(
-      'cities has ${citySearchIndex.cities.length} entries $timeLogger',
+      'matched ${citySearchIndex.assignments.length} files to cities $timeLogger',
     );
 
     final Map<int, List<FaceWithoutEmbedding>> fileIdToFaces = mlEnabled
@@ -1484,7 +1486,7 @@ class SmartMemoriesService {
     CitySearchIndex citySearchIndex,
   ) {
     final files = Memory.filesFromMemories(memories);
-    final results = getCityResults(citySearchIndex.searchArgs(files));
+    final results = citySearchIndex.match(files);
     final List<City> sortedByResultCount = results.keys.toList()
       ..sort((a, b) => results[b]!.length.compareTo(results[a]!.length));
     if (sortedByResultCount.isEmpty) return null;

--- a/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/PhotosPlatformPlugin.kt
+++ b/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/PhotosPlatformPlugin.kt
@@ -1,20 +1,24 @@
 package io.ente.photos.platform
 
+import io.ente.photos.platform.flutter.CountryNamesChannelAdapter
 import io.ente.photos.platform.flutter.PhotosPlatformChannelRouter
 import io.ente.photos.platform.flutter.ProcessLockChannelAdapter
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 
 class PhotosPlatformPlugin : FlutterPlugin {
     private val channelRouter = PhotosPlatformChannelRouter()
+    private val countryNamesAdapter = CountryNamesChannelAdapter()
     private val processLockAdapter = ProcessLockChannelAdapter()
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channelRouter.attach(binding)
+        countryNamesAdapter.attach(binding)
         processLockAdapter.attach(binding)
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channelRouter.detach()
+        countryNamesAdapter.detach()
         processLockAdapter.detach()
     }
 }

--- a/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/country/CountryNamesService.kt
+++ b/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/country/CountryNamesService.kt
@@ -1,0 +1,20 @@
+package io.ente.photos.platform.country
+
+import java.util.Locale
+
+data class CountryNames(
+    val region: String?,
+    val names: Map<String, String>,
+)
+
+class CountryNamesService {
+    fun names(localeTag: String): CountryNames {
+        val displayLocale = Locale.forLanguageTag(localeTag)
+        return CountryNames(
+            Locale.getDefault().country.ifEmpty { null },
+            Locale.getISOCountries().associateWith { code ->
+                Locale.Builder().setRegion(code).build().getDisplayCountry(displayLocale)
+            },
+        )
+    }
+}

--- a/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/flutter/CountryNamesChannelAdapter.kt
+++ b/mobile/apps/photos/plugins/ente_photos_platform/android/src/main/kotlin/io/ente/photos/platform/flutter/CountryNamesChannelAdapter.kt
@@ -1,0 +1,34 @@
+package io.ente.photos.platform.flutter
+
+import io.ente.photos.platform.country.CountryNamesService
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+internal class CountryNamesChannelAdapter : MethodChannel.MethodCallHandler {
+    private val service = CountryNamesService()
+    private lateinit var channel: MethodChannel
+
+    fun attach(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel = MethodChannel(binding.binaryMessenger, CHANNEL)
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) =
+        when (call.method) {
+            "get" -> {
+                val locale = call.arguments as? String
+                    ?: return result.error("invalid_locale", "Expected a locale identifier", null)
+                val names = service.names(locale)
+                result.success(mapOf("region" to names.region, "names" to names.names))
+            }
+
+            else -> result.notImplemented()
+        }
+
+    fun detach() = channel.setMethodCallHandler(null)
+
+    private companion object {
+        const val CHANNEL = "io.ente.photos.platform/country_names"
+    }
+}

--- a/mobile/apps/photos/plugins/ente_photos_platform/ios/Flutter/CountryNamesChannelAdapter.swift
+++ b/mobile/apps/photos/plugins/ente_photos_platform/ios/Flutter/CountryNamesChannelAdapter.swift
@@ -1,0 +1,30 @@
+@preconcurrency import Flutter
+
+@MainActor
+final class CountryNamesChannelAdapter {
+    private let channel: FlutterMethodChannel
+    private let service = CountryNamesService()
+
+    init(registrar: FlutterPluginRegistrar) {
+        channel = FlutterMethodChannel(
+            name: "io.ente.photos.platform/country_names",
+            binaryMessenger: registrar.messenger()
+        )
+        channel.setMethodCallHandler { [service] call, result in
+            guard call.method == "get" else {
+                result(FlutterMethodNotImplemented)
+                return
+            }
+            guard let locale = call.arguments as? String else {
+                result(FlutterError(code: "invalid_locale", message: "Expected a locale identifier", details: nil))
+                return
+            }
+            let names = service.names(localeIdentifier: locale)
+            result(["region": names.region, "names": names.names])
+        }
+    }
+
+    func detach() {
+        channel.setMethodCallHandler(nil)
+    }
+}

--- a/mobile/apps/photos/plugins/ente_photos_platform/ios/Flutter/PhotosPlatformPlugin.swift
+++ b/mobile/apps/photos/plugins/ente_photos_platform/ios/Flutter/PhotosPlatformPlugin.swift
@@ -3,10 +3,12 @@ import Foundation
 
 @MainActor
 public final class PhotosPlatformPlugin: NSObject, @preconcurrency FlutterPlugin {
+    private let countryNamesAdapter: CountryNamesChannelAdapter
     private let deviceHealthAdapter: DeviceHealthChannelAdapter
     private let processLockAdapter: ProcessLockChannelAdapter
 
     private init(registrar: FlutterPluginRegistrar) {
+        countryNamesAdapter = CountryNamesChannelAdapter(registrar: registrar)
         deviceHealthAdapter = DeviceHealthChannelAdapter(registrar: registrar)
         processLockAdapter = ProcessLockChannelAdapter(registrar: registrar)
         super.init()
@@ -17,6 +19,7 @@ public final class PhotosPlatformPlugin: NSObject, @preconcurrency FlutterPlugin
     }
 
     public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        countryNamesAdapter.detach()
         deviceHealthAdapter.detach()
         processLockAdapter.detach()
     }

--- a/mobile/apps/photos/plugins/ente_photos_platform/ios/Sources/PhotosPlatformCore/CountryNamesService.swift
+++ b/mobile/apps/photos/plugins/ente_photos_platform/ios/Sources/PhotosPlatformCore/CountryNamesService.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct CountryNames: Sendable {
+    public let region: String?
+    public let names: [String: String]
+}
+
+public struct CountryNamesService {
+    public init() {}
+
+    public func names(localeIdentifier: String) -> CountryNames {
+        let locale = Locale(identifier: localeIdentifier)
+        return CountryNames(
+            region: Locale.current.regionCode,
+            names: Dictionary(
+                uniqueKeysWithValues: Locale.isoRegionCodes.compactMap { code in
+                    locale.localizedString(forRegionCode: code).map { (code, $0) }
+                })
+        )
+    }
+}

--- a/mobile/apps/photos/plugins/ente_photos_platform/lib/ente_photos_platform.dart
+++ b/mobile/apps/photos/plugins/ente_photos_platform/lib/ente_photos_platform.dart
@@ -1,3 +1,4 @@
+export 'src/country_names.dart';
 export 'src/device_health.dart';
 export 'src/device_trash.dart';
 export 'src/process_lock.dart';

--- a/mobile/apps/photos/plugins/ente_photos_platform/lib/src/country_names.dart
+++ b/mobile/apps/photos/plugins/ente_photos_platform/lib/src/country_names.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/services.dart';
+
+class CountryNames {
+  const CountryNames({required this.region, required this.names});
+
+  final String? region;
+  final Map<String, String> names;
+}
+
+class CountryNamesClient {
+  static const _channel = MethodChannel(
+    'io.ente.photos.platform/country_names',
+  );
+
+  static Future<CountryNames> get(String locale) async {
+    final result = await _channel.invokeMapMethod<String, dynamic>(
+      'get',
+      locale,
+    );
+    return CountryNames(
+      region: result!['region'] as String?,
+      names: (result['names'] as Map).cast<String, String>(),
+    );
+  }
+}

--- a/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
+++ b/mobile/apps/photos/test/services/memories/smart_memories_source_selection_test.dart
@@ -58,22 +58,15 @@ void main() {
         final allFileIdsToFile = {
           for (final file in fullSourceFiles) file.uploadedFileID!: file,
         };
-        final citySearchIndex = CitySearchIndex(
-          cities: [
-            City.fromMap({
-              "city": "Paris",
-              "country": "France",
-              "lat": tripLocation.latitude,
-              "lng": tripLocation.longitude,
-            }),
-          ],
-          nodes: const [
-            [0, -1, -1, 0],
-          ],
-          root: 0,
-          maxLatDelta: 1,
-          maxLngDelta: 1,
+        const city = City(
+          city: "Paris",
+          country: "France",
+          lat: 48.8566,
+          lng: 2.3522,
         );
+        final citySearchIndex = CitySearchIndex({
+          for (final file in fullSourceFiles) file: city,
+        });
 
         final (fullTrips, _) = await TripMemoriesCalculatorV2.compute(
           fullSourceFiles,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2749,8 +2749,11 @@ dependencies = [
 name = "ente-photos"
 version = "0.0.0"
 dependencies = [
+ "ente-assets",
+ "ente-location",
  "quick-xml",
  "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/rust/bindings/frb/photos/src/api/location_api.rs
+++ b/rust/bindings/frb/photos/src/api/location_api.rs
@@ -13,3 +13,101 @@ impl From<core::Error> for LocationError {
         }
     }
 }
+
+impl From<ente_photos::location::Error> for LocationError {
+    fn from(error: ente_photos::location::Error) -> Self {
+        Self::Other {
+            message: ente_core::error::chain(&error),
+        }
+    }
+}
+
+#[frb(opaque)]
+pub struct LocationIndex(ente_photos::location::LocationIndex);
+
+#[derive(Clone, Debug)]
+pub struct LocationCoordinate {
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct LocationCity {
+    pub name: String,
+    pub country: String,
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+#[derive(Debug)]
+pub struct LocationCityGroup {
+    pub city: LocationCity,
+    pub coordinate_indices: Vec<u32>,
+}
+
+#[derive(Debug)]
+pub struct LocationCountryGroup {
+    pub code: String,
+    pub coordinate_indices: Vec<u32>,
+}
+
+pub async fn open_location_index(asset_root: String) -> Result<LocationIndex, LocationError> {
+    Ok(LocationIndex(
+        ente_photos::location::LocationIndex::open(asset_root).await?,
+    ))
+}
+
+impl LocationIndex {
+    pub fn cities(&self) -> Vec<LocationCity> {
+        self.0.cities().into_iter().map(Into::into).collect()
+    }
+
+    pub fn group_cities(
+        &self,
+        coordinates: Vec<LocationCoordinate>,
+        query: String,
+    ) -> Vec<LocationCityGroup> {
+        self.0
+            .group_cities(&core_coordinates(coordinates), &query)
+            .into_iter()
+            .map(|group| LocationCityGroup {
+                city: group.city.into(),
+                coordinate_indices: group.coordinate_indices,
+            })
+            .collect()
+    }
+
+    pub fn group_countries(
+        &self,
+        coordinates: Vec<LocationCoordinate>,
+        region: Option<String>,
+    ) -> Result<Vec<LocationCountryGroup>, LocationError> {
+        Ok(self
+            .0
+            .group_countries(&core_coordinates(coordinates), region.as_deref())?
+            .into_iter()
+            .map(|group| LocationCountryGroup {
+                code: group.country.to_string(),
+                coordinate_indices: group.coordinate_indices,
+            })
+            .collect())
+    }
+}
+
+impl From<core::City> for LocationCity {
+    fn from(city: core::City) -> Self {
+        Self {
+            name: city.name,
+            country: city.country_name,
+            latitude: city.latitude,
+            longitude: city.longitude,
+        }
+    }
+}
+
+fn core_coordinates(coordinates: Vec<LocationCoordinate>) -> Vec<core::Coordinate> {
+    coordinates
+        .into_iter()
+        .map(|coordinate| core::Coordinate::new(coordinate.latitude, coordinate.longitude))
+        .collect()
+}

--- a/rust/crates/location/src/lib.rs
+++ b/rust/crates/location/src/lib.rs
@@ -131,8 +131,15 @@ impl CountryIndex {
         let mut unclassified_coordinate_indices = Vec::new();
 
         for (coordinate_index, &coordinate) in coordinates.iter().enumerate() {
-            let classification = self.lookup(coordinate)?;
             let coordinate_index = coordinate_index as u32;
+            let classification = match self.lookup(coordinate) {
+                Ok(classification) => classification,
+                Err(Error::InvalidCoordinate) => {
+                    unclassified_coordinate_indices.push(coordinate_index);
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
             if classification.disputes.is_empty() {
                 if classification.countries.is_empty() {
                     unclassified_coordinate_indices.push(coordinate_index);

--- a/rust/crates/photos/Cargo.toml
+++ b/rust/crates/photos/Cargo.toml
@@ -3,7 +3,10 @@ name = "ente-photos"
 edition = "2024"
 
 [dependencies]
+ente-assets.workspace = true
+ente-location.workspace = true
 quick-xml = "0.41"
+thiserror.workspace = true
 
 [dev-dependencies]
 tempfile = "3.12"

--- a/rust/crates/photos/src/lib.rs
+++ b/rust/crates/photos/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod location;
 pub mod motion_photo;
 
 pub use motion_photo::{

--- a/rust/crates/photos/src/location.rs
+++ b/rust/crates/photos/src/location.rs
@@ -1,0 +1,91 @@
+use std::path::Path;
+
+use ente_assets::download::CancellationToken;
+use ente_assets::{Asset, AssetFile, AssetStore};
+use ente_location::{CityIndex, CityMatch, Coordinate, CountryIndex, CountryView};
+
+const ASSET_URL: &str = "https://assets.ente.com";
+const CITY_FILE: &str = "cities.bin";
+const COUNTRY_FILE: &str = "countries.bin";
+const DISPUTE_FILE: &str = "disputes.bin";
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Asset(#[from] ente_assets::download::Error),
+    #[error(transparent)]
+    Location(#[from] ente_location::Error),
+    #[error(transparent)]
+    CountryCode(#[from] ente_location::InvalidCountryCode),
+}
+
+pub struct LocationIndex {
+    cities: CityIndex,
+    countries: CountryIndex,
+}
+
+impl LocationIndex {
+    pub async fn open(asset_root: impl AsRef<Path>) -> Result<Self, Error> {
+        let asset = asset()?;
+        let store = AssetStore::new(asset_root.as_ref());
+        let directory = store.asset_dir(&asset);
+        store
+            .download(&[asset], |_| {}, CancellationToken::new())
+            .await?;
+        Ok(Self {
+            cities: CityIndex::from_path(directory.join(CITY_FILE))?,
+            countries: CountryIndex::from_paths(
+                directory.join(COUNTRY_FILE),
+                directory.join(DISPUTE_FILE),
+            )?,
+        })
+    }
+
+    pub fn cities(&self) -> Vec<ente_location::City> {
+        self.cities.search("", usize::MAX)
+    }
+
+    pub fn group_cities(&self, coordinates: &[Coordinate], query: &str) -> Vec<CityMatch> {
+        self.cities.match_coordinates(coordinates, query)
+    }
+
+    pub fn group_countries(
+        &self,
+        coordinates: &[Coordinate],
+        region: Option<&str>,
+    ) -> Result<Vec<ente_location::CountryGroup>, Error> {
+        let view = match region {
+            Some(region) => CountryView::Region(region.parse()?),
+            None => CountryView::SourceDefault,
+        };
+        Ok(self.countries.group(coordinates, view)?.countries)
+    }
+}
+
+fn asset() -> Result<Asset, ente_assets::download::Error> {
+    Asset::files(
+        vec!["location".into(), "v1".into()],
+        vec![
+            file(
+                CITY_FILE,
+                "929a488aeac782d1cfc9e90b3eeb9536423977aab9f21cb1f86b9324ac53efbc",
+            ),
+            file(
+                COUNTRY_FILE,
+                "3ead1ef2bb03b4ffa95813df4316cf149d37c82d16a322352bd6e3b19218c796",
+            ),
+            file(
+                DISPUTE_FILE,
+                "c44d0af6ad40a3b195bc10cb87512c16998a20e837af190ff1a46b00170dfd7b",
+            ),
+        ],
+    )
+}
+
+fn file(name: &str, sha256: &str) -> AssetFile {
+    AssetFile {
+        name: name.into(),
+        url: format!("{ASSET_URL}/{name}"),
+        sha256: sha256.into(),
+    }
+}


### PR DESCRIPTION
Replace Photos’ Dart city KD-tree with the shared Rust location index, downloaded through `ente-assets`. Add localized partial country search and use Rust city assignments for Search, Memories, and Wrapped.

Android profile testing reduced 100k-photo city grouping from 1.02 s to 0.63 s and partial lookup from 0.93 s to 0.22 s, while index memory dropped from approximately 22 MiB to 2 MiB.