### PR TITLE
[server] Finalize the token hash column

### DIFF
--- a/server/migrations/136_token_hash_unique_idx.down.sql
+++ b/server/migrations/136_token_hash_unique_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY tokens_token_hash_unique_idx;

--- a/server/migrations/136_token_hash_unique_idx.up.sql
+++ b/server/migrations/136_token_hash_unique_idx.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX CONCURRENTLY tokens_token_hash_unique_idx ON tokens (token_hash);

--- a/server/migrations/137_token_hash_constraints.down.sql
+++ b/server/migrations/137_token_hash_constraints.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tokens
+    DROP CONSTRAINT tokens_token_hash_present,
+    DROP CONSTRAINT tokens_token_hash_length;

--- a/server/migrations/137_token_hash_constraints.up.sql
+++ b/server/migrations/137_token_hash_constraints.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tokens
+    ADD CONSTRAINT tokens_token_hash_present CHECK (token_hash IS NOT NULL) NOT VALID,
+    ADD CONSTRAINT tokens_token_hash_length CHECK (octet_length(token_hash) = 32) NOT VALID;

--- a/server/migrations/138_validate_token_hash_constraints.down.sql
+++ b/server/migrations/138_validate_token_hash_constraints.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tokens
+    DROP CONSTRAINT tokens_token_hash_present,
+    ADD CONSTRAINT tokens_token_hash_present CHECK (token_hash IS NOT NULL) NOT VALID,
+    DROP CONSTRAINT tokens_token_hash_length,
+    ADD CONSTRAINT tokens_token_hash_length CHECK (octet_length(token_hash) = 32) NOT VALID;

--- a/server/migrations/138_validate_token_hash_constraints.up.sql
+++ b/server/migrations/138_validate_token_hash_constraints.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tokens
+    VALIDATE CONSTRAINT tokens_token_hash_present,
+    VALIDATE CONSTRAINT tokens_token_hash_length;

--- a/server/migrations/139_finalize_token_hash_columns.down.sql
+++ b/server/migrations/139_finalize_token_hash_columns.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tokens
+    ALTER COLUMN token_hash DROP NOT NULL,
+    ADD CONSTRAINT tokens_token_hash_present CHECK (token_hash IS NOT NULL);

--- a/server/migrations/139_finalize_token_hash_columns.up.sql
+++ b/server/migrations/139_finalize_token_hash_columns.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE tokens
+    ALTER COLUMN token_hash SET NOT NULL;
+
+ALTER TABLE tokens
+    DROP CONSTRAINT tokens_token_hash_present;
+
+COMMIT;


### PR DESCRIPTION
Prepare `token_hash` as the database identity for subsequent hash-based authentication.

- Build the unique index concurrently so normal token reads and writes can continue.
- Add presence and 32-byte length checks as `NOT VALID`, avoiding an existing-row scan under the strongest table lock.
- Validate existing rows under a weaker lock.
- Use the validated presence check to set `NOT NULL` without a full-table scan under `ACCESS EXCLUSIVE`, then remove the redundant presence check while retaining the length check.

This does not change authentication or token storage behavior.