### PR TITLE
[mobile][photos] Include received albums in Ente filter

### DIFF
--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -419,6 +419,11 @@ class CollectionsService {
     Iterable<Collection> collections,
   ) async {
     final sorted = collections.toList();
+    final userID = _config.getUserID();
+    bool isPinnedForCurrentUser(Collection collection) =>
+        userID != null && !collection.isOwner(userID)
+        ? collection.hasShareePinned()
+        : collection.isPinned;
     await sortCollectionsByAlbumPreferences(sorted);
     return [
       ...sorted.where(
@@ -426,11 +431,13 @@ class CollectionsService {
       ),
       ...sorted.where(
         (collection) =>
-            collection.type != CollectionType.favorites && collection.isPinned,
+            collection.type != CollectionType.favorites &&
+            isPinnedForCurrentUser(collection),
       ),
       ...sorted.where(
         (collection) =>
-            collection.type != CollectionType.favorites && !collection.isPinned,
+            collection.type != CollectionType.favorites &&
+            !isPinnedForCurrentUser(collection),
       ),
     ];
   }
@@ -671,7 +678,7 @@ class CollectionsService {
   Future<List<Collection>> getCollectionForOnEnteSection() async {
     final bool hasFavorites = FavoritesService.instance.hasFavorites();
     return orderCollectionsForAlbums(
-      getCollectionsForUI().where(
+      getCollectionsForUI(includedShared: true).where(
         (collection) =>
             collection.type != CollectionType.uncategorized &&
             !collection.isQuickLinkCollection() &&

--- a/mobile/apps/photos/lib/services/collections_service.dart
+++ b/mobile/apps/photos/lib/services/collections_service.dart
@@ -677,6 +677,12 @@ class CollectionsService {
 
   Future<List<Collection>> getCollectionForOnEnteSection() async {
     final bool hasFavorites = FavoritesService.instance.hasFavorites();
+    final int? userID = _config.getUserID();
+    bool isEmptyOwnedFavorites(Collection collection) =>
+        collection.type == CollectionType.favorites &&
+        userID != null &&
+        collection.isOwner(userID) &&
+        !hasFavorites;
     return orderCollectionsForAlbums(
       getCollectionsForUI(includedShared: true).where(
         (collection) =>
@@ -684,7 +690,7 @@ class CollectionsService {
             !collection.isQuickLinkCollection() &&
             !collection.isHidden() &&
             !collection.isArchived() &&
-            (collection.type != CollectionType.favorites || hasFavorites),
+            !isEmptyOwnedFavorites(collection),
       ),
     );
   }

--- a/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
+++ b/mobile/apps/photos/lib/ui/tabs/albums_tab.dart
@@ -273,11 +273,15 @@ class _AlbumsTabState extends State<AlbumsTab>
     if (!RemoteSyncService.instance.isFirstRemoteSyncDone()) {
       return false;
     }
+    final userID = Configuration.instance.getUserID();
+    if (userID == null) {
+      return false;
+    }
     final collectionIDToLatestTimeCount = await CollectionsService.instance
         .getCollectionIDToNewestFileTime();
     final emptyAlbumCount = collections.where((collection) {
       final latestTimeCount = collectionIDToLatestTimeCount[collection.id];
-      return latestTimeCount == null;
+      return collection.isOwner(userID) && latestTimeCount == null;
     }).length;
     return emptyAlbumCount > 2;
   }

--- a/mobile/apps/photos/lib/ui/viewer/actions/album_selection_action_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/album_selection_action_widget.dart
@@ -71,9 +71,24 @@ class _AlbumSelectionActionWidgetState
     final hasUnpinnedAlbum = widget.selectedAlbums.albums.any(
       (album) => !album.isPinned,
     );
+    final userID = Configuration.instance.getUserID()!;
+    final isHomeSection = widget.sectionType == UISectionType.homeCollections;
+    final ownsAllSelectedAlbums = widget.selectedAlbums.albums.every(
+      (album) => album.isOwner(userID),
+    );
+    final receivesAllSelectedAlbums = widget.selectedAlbums.albums.every(
+      (album) => !album.isOwner(userID),
+    );
+    final showOwnerActions =
+        widget.sectionType == UISectionType.outgoingCollections ||
+        isHomeSection && ownsAllSelectedAlbums;
+    final showReceivedActions =
+        widget.sectionType == UISectionType.incomingCollections ||
+        isHomeSection && receivesAllSelectedAlbums;
+    final showMixedEnteActions =
+        isHomeSection && !ownsAllSelectedAlbums && !receivesAllSelectedAlbums;
 
-    if (widget.sectionType == UISectionType.homeCollections ||
-        widget.sectionType == UISectionType.outgoingCollections) {
+    if (showOwnerActions) {
       items.add(
         SelectionActionButton(
           labelText: context.strings.share,
@@ -109,6 +124,16 @@ class _AlbumSelectionActionWidgetState
           isCritical: true,
         ),
       );
+      items.add(
+        SelectionActionButton(
+          labelText: context.strings.hide,
+          hugeIcon: HugeIcons.strokeRoundedViewOffSlash,
+          onTap: _onHideOrUnHideClick,
+        ),
+      );
+    }
+
+    if (showMixedEnteActions) {
       items.add(
         SelectionActionButton(
           labelText: context.strings.hide,
@@ -160,7 +185,7 @@ class _AlbumSelectionActionWidgetState
       );
     }
 
-    if (widget.sectionType == UISectionType.incomingCollections) {
+    if (showReceivedActions) {
       if (flagService.enableShareePin) {
         final hasShareePinnedAlbum = widget.selectedAlbums.albums.any(
           (album) => album.hasShareePinned(),
@@ -434,8 +459,7 @@ class _AlbumSelectionActionWidgetState
       return;
     }
 
-    final isUnarchiving =
-        widget.sectionType == UISectionType.incomingCollections
+    final isUnarchiving = _usesShareeMetadata(collections.first)
         ? collections.first.hasShareeArchived()
         : collections.first.isArchived();
     final dialog = createProgressDialog(
@@ -446,7 +470,7 @@ class _AlbumSelectionActionWidgetState
 
     try {
       for (final collection in collections) {
-        if (widget.sectionType == UISectionType.incomingCollections) {
+        if (_usesShareeMetadata(collection)) {
           final hasShareeArchived = collection.hasShareeArchived();
           final int prevVisiblity = hasShareeArchived
               ? archiveVisibility
@@ -505,6 +529,12 @@ class _AlbumSelectionActionWidgetState
       setState(() {});
     }
     widget.selectedAlbums.clearAll();
+  }
+
+  bool _usesShareeMetadata(Collection collection) {
+    return widget.sectionType == UISectionType.incomingCollections ||
+        widget.sectionType == UISectionType.homeCollections &&
+            !collection.isOwner(Configuration.instance.getUserID()!);
   }
 
   Future<void> _leaveAlbum() async {

--- a/mobile/apps/photos/lib/ui/viewer/actions/album_selection_action_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/album_selection_action_widget.dart
@@ -572,8 +572,6 @@ class _AlbumSelectionActionWidgetState
           context: context,
           error: actionResult.exception,
         );
-      } else if (actionResult.action == ButtonAction.first) {
-        Navigator.of(context).pop();
       }
     }
   }

--- a/mobile/apps/photos/lib/utils/magic_util.dart
+++ b/mobile/apps/photos/lib/utils/magic_util.dart
@@ -92,19 +92,19 @@ Future<void> changeCollectionVisibility(
     final Map<String, dynamic> update = {magicKeyVisibility: newVisibility};
     if (isOwner) {
       await CollectionsService.instance.updateMagicMetadata(collection, update);
-      Bus.instance.fire(
-        CollectionUpdatedEvent(
-          collection.id,
-          const <EnteFile>[],
-          'collection_visibility_changed',
-        ),
-      );
     } else {
       await CollectionsService.instance.updateShareeMagicMetadata(
         collection,
         update,
       );
     }
+    Bus.instance.fire(
+      CollectionUpdatedEvent(
+        collection.id,
+        const <EnteFile>[],
+        'collection_visibility_changed',
+      ),
+    );
     // Reload so the home gallery adds or removes the collection's files.
     Bus.instance.fire(
       ForceReloadHomeGalleryEvent(


### PR DESCRIPTION
## Summary

- Include shared and received albums in the Ente albums filter.
- Preserve the existing exclusions for hidden and archived albums.