### PR TITLE
[server] Roll back database transactions on all exits

### DIFF
--- a/server/pkg/controller/file_outdated.go
+++ b/server/pkg/controller/file_outdated.go
@@ -186,9 +186,9 @@ func (c *FileController) prepareOutdatedObjectForDeletion(qItem repo.QueueItem) 
 		ctxLogger.WithError(err).Error("Failed to begin transaction for delayed outdated object enqueue")
 		return
 	}
+	defer tx.Rollback()
 	err = c.QueueRepo.AddItems(context.Background(), tx, repo.DeleteOutdatedObjectQueue, []string{qItem.Item})
 	if err != nil {
-		tx.Rollback()
 		ctxLogger.WithError(err).Error("Failed to enqueue outdated object for delayed deletion")
 		return
 	}

--- a/server/pkg/repo/collection.go
+++ b/server/pkg/repo/collection.go
@@ -510,12 +510,10 @@ func (repo *CollectionRepository) Share(
 				END`,
 		collectionID, fromUserID, toUserID, encryptedKey, updationTime, role, updationTime)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(context, `UPDATE collections SET updation_time = $1 WHERE collection_id = $2`, updationTime, collectionID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	err = tx.Commit()
@@ -591,26 +589,23 @@ func (repo *CollectionRepository) UpdateShareeMetadata(
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	sqlResult, err := tx.ExecContext(context, `UPDATE collection_shares SET magic_metadata = $1, updation_time = $2  WHERE collection_id = $3 AND from_user_id = $4 AND to_user_id = $5 AND is_deleted = $6`,
 		metadata, updationTime, collectionID, ownerUserID, shareeUserID, false)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	affected, err := sqlResult.RowsAffected()
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	if affected != 1 {
-		tx.Rollback()
 		err = fmt.Errorf("invalid number of rows affected %d", affected)
 		return stacktrace.Propagate(err, "")
 	}
 
 	_, err = tx.ExecContext(context, `UPDATE collections SET updation_time = $1 WHERE collection_id = $2`, updationTime, collectionID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	err = tx.Commit()
@@ -823,17 +818,16 @@ func (repo *CollectionRepository) RemoveFilesV3(context context.Context, collect
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	_, err = tx.ExecContext(context, `UPDATE collection_files 
 		SET is_deleted = $1, updation_time = $2 WHERE collection_id = $3 AND file_id = ANY($4)`,
 		true, updationTime, collectionID, pq.Array(fileIDs))
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(context, `UPDATE collections SET updation_time = $1
 		WHERE collection_id = $2`, updationTime, collectionID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	err = tx.Commit()
@@ -849,17 +843,16 @@ func (repo *CollectionRepository) SuggestAction(ctx context.Context, collectionI
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	_, err = tx.ExecContext(ctx, `UPDATE collection_files
             SET action_user = $1, action = $2, updation_time = $3
             WHERE collection_id = $4 AND file_id = ANY($5)`,
 		actorUserID, action, updationTime, collectionID, pq.Array(fileIDs))
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1 WHERE collection_id = $2`, updationTime, collectionID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	return tx.Commit()
@@ -1115,23 +1108,21 @@ func (repo *CollectionRepository) ScheduleDelete(collectionID int64) error {
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	_, err = tx.ExecContext(ctx, `UPDATE collection_shares 
 		SET is_deleted = $1, updation_time = $2 
 		WHERE collection_id = $3`, true, updationTime, collectionID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE collections 
 		SET is_deleted = $1, updation_time = $2 
 		WHERE collection_id = $3`, true, updationTime, collectionID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	err = repo.QueueRepo.AddItems(ctx, tx, TrashCollectionQueueV3, []string{strconv.FormatInt(collectionID, 10)})
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	err = tx.Commit()

--- a/server/pkg/repo/family.go
+++ b/server/pkg/repo/family.go
@@ -25,26 +25,23 @@ func (repo *FamilyRepository) CreateFamily(ctx context.Context, adminID int64) e
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	_, err = tx.ExecContext(ctx, `INSERT INTO families(id, admin_id, member_id, status) 
 			VALUES($1, $2, $3, $4) ON CONFLICT (admin_id,member_id) 
 			    DO UPDATE SET status = $4 WHERE families.status NOT IN ($4)`, uuid.New(), adminID, adminID, ente.SELF)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 
 	result, err := tx.ExecContext(ctx, `UPDATE users SET family_admin_id = $1 WHERE user_id = $2 and family_admin_id is  null`, adminID, adminID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	if affected != 1 {
-		tx.Rollback()
 		return stacktrace.Propagate(errors.New("exactly one row should be updated"), "")
 	}
 	return stacktrace.Propagate(tx.Commit(), "failed to commit txn creating family")
@@ -58,18 +55,15 @@ func (repo *FamilyRepository) CloseFamily(ctx context.Context, adminID int64) er
 	defer tx.Rollback()
 	_, err = tx.ExecContext(ctx, `DELETE FROM families WHERE admin_id = $1`, adminID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	affectedRows, err := tx.ExecContext(ctx, `UPDATE users SET family_admin_id = null WHERE family_admin_id = $1`, adminID)
 
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	affected, err := affectedRows.RowsAffected()
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	if affected != 1 {
@@ -131,23 +125,20 @@ func (repo *FamilyRepository) AcceptInvite(ctx context.Context, adminID int64, m
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	_, err = tx.ExecContext(ctx, `UPDATE families SET status = $1 WHERE token = $2`, ente.ACCEPTED, token)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	result, err := tx.ExecContext(ctx, `UPDATE users SET family_admin_id = $1 WHERE user_id = $2 and family_admin_id is  null`, adminID, memberID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	if affected != 1 {
-		tx.Rollback()
 		return stacktrace.Propagate(errors.New("exactly one row should be updated"), "")
 	}
 	return stacktrace.Propagate(tx.Commit(), "failed to commit txn for accepting family invite")
@@ -158,19 +149,17 @@ func (repo *FamilyRepository) RemoveMember(ctx context.Context, adminID int64, m
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	result, err := tx.ExecContext(ctx, `UPDATE families set status = $1 WHERE admin_id = $2 AND member_id = $3 AND status= $4`, removeReason, adminID, memberID, ente.ACCEPTED)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	affected, _ := result.RowsAffected()
 	if affected != 1 {
-		tx.Rollback()
 		return stacktrace.Propagate(errors.New("exactly one row should be updated"), "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE users set family_admin_id = null WHERE user_id = $1 and family_admin_id = $2`, memberID, adminID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	return stacktrace.Propagate(tx.Commit(), "failed to commit")
@@ -190,9 +179,9 @@ func (repo *FamilyRepository) RevokeInvite(ctx context.Context, adminID int64, m
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	_, err = tx.ExecContext(ctx, `UPDATE families set status=$1 WHERE admin_id = $2 AND member_id = $3 AND status = $4`, ente.REVOKED, adminID, memberID, ente.INVITED)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	return stacktrace.Propagate(tx.Commit(), "failed to commit")

--- a/server/pkg/repo/file.go
+++ b/server/pkg/repo/file.go
@@ -38,15 +38,16 @@ func (repo *FileRepository) Create(
 ) (ente.File, int64, error) {
 	hotDC := repo.S3Config.GetHotDataCenter()
 	dcsForNewEntry := pq.StringArray{hotDC}
+	if file.OwnerID != collectionOwnerID {
+		return file, -1, stacktrace.Propagate(errors.New("both file and collection should belong to same owner"), "")
+	}
 
 	ctx := context.Background()
 	tx, err := repo.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return file, -1, stacktrace.Propagate(err, "")
 	}
-	if file.OwnerID != collectionOwnerID {
-		return file, -1, stacktrace.Propagate(errors.New("both file and collection should belong to same owner"), "")
-	}
+	defer tx.Rollback()
 	var fileID int64
 	err = tx.QueryRowContext(ctx, `INSERT INTO files
 			(owner_id, encrypted_metadata,
@@ -58,7 +59,6 @@ func (repo *FileRepository) Create(
 		file.MagicMetadata, file.PubicMagicMetadata, file.Info,
 		file.UpdationTime).Scan(&fileID)
 	if err != nil {
-		tx.Rollback()
 		return file, -1, stacktrace.Propagate(err, "")
 	}
 	file.ID = fileID
@@ -67,19 +67,16 @@ func (repo *FileRepository) Create(
 			VALUES($1, $2, $3, $4, $5, $6, $7, $8)`, file.CollectionID, file.ID,
 		file.EncryptedKey, file.KeyDecryptionNonce, false, file.UpdationTime, file.OwnerID, collectionOwnerID)
 	if err != nil {
-		tx.Rollback()
 		return file, -1, stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
 			WHERE collection_id = $2`, file.UpdationTime, file.CollectionID)
 	if err != nil {
-		tx.Rollback()
 		return file, -1, stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `INSERT INTO object_keys(file_id, o_type, object_key, size, datacenters)
 			VALUES($1, $2, $3, $4, $5)`, fileID, ente.FILE, file.File.ObjectKey, fileSize, dcsForNewEntry)
 	if err != nil {
-		tx.Rollback()
 		if err.Error() == "pq: duplicate key value violates unique constraint \"object_keys_object_key_key\"" {
 			return file, -1, ente.ErrDuplicateFileObjectFound
 		}
@@ -88,7 +85,6 @@ func (repo *FileRepository) Create(
 	_, err = tx.ExecContext(ctx, `INSERT INTO object_keys(file_id, o_type, object_key, size, datacenters)
 			VALUES($1, $2, $3, $4, $5)`, fileID, ente.THUMBNAIL, file.Thumbnail.ObjectKey, thumbnailSize, dcsForNewEntry)
 	if err != nil {
-		tx.Rollback()
 		if err.Error() == "pq: duplicate key value violates unique constraint \"object_keys_object_key_key\"" {
 			return file, -1, ente.ErrDuplicateThumbnailObjectFound
 		}
@@ -97,23 +93,19 @@ func (repo *FileRepository) Create(
 
 	err = repo.ObjectCleanupRepo.RemoveTempObjectKey(ctx, tx, file.File.ObjectKey, hotDC)
 	if err != nil {
-		tx.Rollback()
 		return file, -1, stacktrace.Propagate(err, "")
 	}
 	err = repo.ObjectCleanupRepo.RemoveTempObjectKey(ctx, tx, file.Thumbnail.ObjectKey, hotDC)
 	if err != nil {
-		tx.Rollback()
 		return file, -1, stacktrace.Propagate(err, "")
 	}
 	usage, err := repo.updateUsage(ctx, tx, file.OwnerID, usageDiff)
 	if err != nil {
-		tx.Rollback()
 		return file, -1, stacktrace.Propagate(err, "")
 	}
 
 	err = repo.markAsNeedingReplication(ctx, tx, file, hotDC)
 	if err != nil {
-		tx.Rollback()
 		return file, -1, stacktrace.Propagate(err, "")
 	}
 
@@ -129,14 +121,15 @@ func (repo *FileRepository) CreateMetaFile(
 	collectionOwnerID int64,
 	app ente.App,
 ) (*ente.File, error) {
+	if metaFile.OwnerID != collectionOwnerID {
+		return nil, stacktrace.Propagate(errors.New("both file and collection should belong to same owner"), "")
+	}
 	ctx := context.Background()
 	tx, err := repo.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}
-	if metaFile.OwnerID != collectionOwnerID {
-		return nil, stacktrace.Propagate(errors.New("both file and collection should belong to same owner"), "")
-	}
+	defer tx.Rollback()
 
 	var fileID int64
 	info := &ente.FileInfo{
@@ -153,7 +146,6 @@ func (repo *FileRepository) CreateMetaFile(
 		metaFile.MagicMetadata, metaFile.PubicMagicMetadata, info,
 		metaFile.UpdationTime).Scan(&fileID)
 	if err != nil {
-		tx.Rollback()
 		return nil, stacktrace.Propagate(err, "")
 	}
 
@@ -162,13 +154,11 @@ func (repo *FileRepository) CreateMetaFile(
 			VALUES($1, $2, $3, $4, $5, $6, $7, $8)`, metaFile.CollectionID, fileID,
 		metaFile.EncryptedKey, metaFile.KeyDecryptionNonce, false, metaFile.UpdationTime, metaFile.OwnerID, collectionOwnerID)
 	if err != nil {
-		tx.Rollback()
 		return nil, stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
 			WHERE collection_id = $2`, metaFile.UpdationTime, metaFile.CollectionID)
 	if err != nil {
-		tx.Rollback()
 		return nil, stacktrace.Propagate(err, "")
 	}
 	err = tx.Commit()
@@ -270,6 +260,7 @@ func (repo *FileRepository) Update(file ente.File, fileSize int64, thumbnailSize
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	_, err = tx.ExecContext(ctx, `UPDATE files SET encrypted_metadata = $1,
 			file_decryption_header = $2, thumbnail_decryption_header = $3, 
 			metadata_decryption_header = $4, updation_time = $5 , info = $6 WHERE file_id = $7`,
@@ -277,14 +268,12 @@ func (repo *FileRepository) Update(file ente.File, fileSize int64, thumbnailSize
 		file.Thumbnail.DecryptionHeader, file.Metadata.DecryptionHeader,
 		file.UpdationTime, file.Info, file.ID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	updatedRows, err := tx.QueryContext(ctx, `UPDATE collection_files 
 			SET updation_time = $1 WHERE file_id = $2 RETURNING collection_id`, file.UpdationTime,
 		file.ID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	defer updatedRows.Close()
@@ -300,37 +289,31 @@ func (repo *FileRepository) Update(file ente.File, fileSize int64, thumbnailSize
 	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
 			WHERE collection_id = ANY($2)`, file.UpdationTime, pq.Array(updatedCIDs))
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `DELETE FROM object_copies WHERE object_key = ANY($1)`,
 		pq.Array(oldObjects))
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE object_keys 
 			SET object_key = $1, size = $2, datacenters = $3 WHERE file_id = $4 AND o_type = $5`,
 		file.File.ObjectKey, fileSize, dcsForNewEntry, file.ID, ente.FILE)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE object_keys 
 			SET object_key = $1, size = $2, datacenters = $3 WHERE file_id = $4 AND o_type = $5`,
 		file.Thumbnail.ObjectKey, thumbnailSize, dcsForNewEntry, file.ID, ente.THUMBNAIL)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = repo.updateUsage(ctx, tx, file.OwnerID, usageDiff)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	for _, objectKey := range stagedObjects {
 		if err = repo.ObjectCleanupRepo.RemoveTempObjectKey(ctx, tx, objectKey, hotDC); err != nil {
-			tx.Rollback()
 			return stacktrace.Propagate(err, "")
 		}
 	}
@@ -341,13 +324,11 @@ func (repo *FileRepository) Update(file ente.File, fileSize int64, thumbnailSize
 	} else {
 		err = repo.markAsNeedingReplication(ctx, tx, file, hotDC)
 		if err != nil {
-			tx.Rollback()
 			return stacktrace.Propagate(err, "")
 		}
 	}
 	err = repo.QueueRepo.AddItems(ctx, tx, OutdatedObjectsQueue, oldObjects)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	err = tx.Commit()
@@ -368,6 +349,7 @@ func (repo *FileRepository) UpdateMagicAttributes(
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	fileIDs := make([]int64, 0)
 	for _, update := range fileUpdates {
 		update.MagicMetadata.Version = update.MagicMetadata.Version + 1
@@ -380,10 +362,6 @@ func (repo *FileRepository) UpdateMagicAttributes(
 				update.MagicMetadata, updationTime, update.ID)
 		}
 		if err != nil {
-			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				log.WithError(rollbackErr).Error("transaction rollback failed")
-				return stacktrace.Propagate(rollbackErr, "")
-			}
 			return stacktrace.Propagate(err, "")
 		}
 	}
@@ -395,10 +373,6 @@ func (repo *FileRepository) UpdateMagicAttributes(
 			SET updation_time = $1 WHERE file_id = ANY($2) AND is_deleted= false RETURNING collection_id`, updationTime,
 		pq.Array(fileIDs))
 	if err != nil {
-		if rollbackErr := tx.Rollback(); rollbackErr != nil {
-			log.WithError(rollbackErr).Error("transaction rollback failed")
-			return stacktrace.Propagate(rollbackErr, "")
-		}
 		return stacktrace.Propagate(err, "")
 	}
 	defer updatedRows.Close()
@@ -414,10 +388,6 @@ func (repo *FileRepository) UpdateMagicAttributes(
 	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
 			WHERE collection_id = ANY($2)`, updationTime, pq.Array(updatedCIDs))
 	if err != nil {
-		if rollbackErr := tx.Rollback(); rollbackErr != nil {
-			log.WithError(rollbackErr).Error("transaction rollback failed")
-			return stacktrace.Propagate(rollbackErr, "")
-		}
 		return stacktrace.Propagate(err, "")
 	}
 	return tx.Commit()
@@ -439,14 +409,12 @@ func (repo *FileRepository) UpdateThumbnail(ctx context.Context, fileID int64, u
 		thumbnail.DecryptionHeader,
 		updationTime, fileID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	updatedRows, err := tx.QueryContext(ctx, `UPDATE collection_files 
 			SET updation_time = $1 WHERE file_id = $2 RETURNING collection_id`, updationTime,
 		fileID)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	defer updatedRows.Close()
@@ -462,14 +430,12 @@ func (repo *FileRepository) UpdateThumbnail(ctx context.Context, fileID int64, u
 	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
 			WHERE collection_id = ANY($2)`, updationTime, pq.Array(updatedCIDs))
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	if oldThumbnailObject != nil {
 		_, err = tx.ExecContext(ctx, `DELETE FROM object_copies WHERE object_key = $1`,
 			*oldThumbnailObject)
 		if err != nil {
-			tx.Rollback()
 			return stacktrace.Propagate(err, "")
 		}
 	}
@@ -477,18 +443,15 @@ func (repo *FileRepository) UpdateThumbnail(ctx context.Context, fileID int64, u
 			SET object_key = $1, size = $2, datacenters = $3 WHERE file_id = $4 AND o_type = $5`,
 		thumbnail.ObjectKey, thumbnailSize, dcsForNewEntry, fileID, ente.THUMBNAIL)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = repo.updateUsage(ctx, tx, userID, usageDiff)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 
 	if oldThumbnailObject != nil {
 		if err = repo.ObjectCleanupRepo.RemoveTempObjectKey(ctx, tx, thumbnail.ObjectKey, hotDC); err != nil {
-			tx.Rollback()
 			return stacktrace.Propagate(err, "")
 		}
 	}
@@ -499,7 +462,6 @@ func (repo *FileRepository) UpdateThumbnail(ctx context.Context, fileID int64, u
 	if oldThumbnailObject != nil {
 		err = repo.QueueRepo.AddItems(ctx, tx, OutdatedObjectsQueue, []string{*oldThumbnailObject})
 		if err != nil {
-			tx.Rollback()
 			return stacktrace.Propagate(err, "")
 		}
 	}

--- a/server/pkg/repo/filedata/repository.go
+++ b/server/pkg/repo/filedata/repository.go
@@ -58,10 +58,14 @@ func (r *Repository) InsertOrUpdate(ctx context.Context, data filedata.Row) erro
 }
 
 func (r *Repository) InsertOrUpdatePreviewData(ctx context.Context, data filedata.Row, previewObject string) error {
+	if data.ObjectID == nil {
+		return stacktrace.NewError("object ID is required")
+	}
 	tx, err := r.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	query := `
         INSERT INTO file_data 
             (file_id, user_id, data_type, size, latest_bucket, obj_id, obj_nonce, obj_size, sync_locked_till) 
@@ -90,12 +94,10 @@ func (r *Repository) InsertOrUpdatePreviewData(ctx context.Context, data filedat
 	_, err = tx.ExecContext(ctx, query,
 		data.FileID, data.UserID, string(data.Type), data.Size, data.LatestBucket, *data.ObjectID, data.ObjectNonce, data.ObjectSize)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "failed to insert file data")
 	}
 	err = r.ObjectCleanupRepo.RemoveTempObjectFromDC(ctx, tx, previewObject, data.LatestBucket)
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "failed to remove object from tempObjects")
 	}
 	return tx.Commit()

--- a/server/pkg/repo/filedata/repository_test.go
+++ b/server/pkg/repo/filedata/repository_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/ente/museum/internal/testutil"
 )
 
+func TestInsertOrUpdatePreviewDataRequiresObjectID(t *testing.T) {
+	if err := (&Repository{}).InsertOrUpdatePreviewData(t.Context(), enteFileData.Row{}, ""); err == nil {
+		t.Fatal("InsertOrUpdatePreviewData() error = nil")
+	}
+}
+
 func TestDeleteFileData(t *testing.T) {
 	testutil.WithServerRoot(t)
 

--- a/server/pkg/repo/object_copies.go
+++ b/server/pkg/repo/object_copies.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ente/museum/ente"
 	"github.com/ente/stacktrace"
-	log "github.com/sirupsen/logrus"
 )
 
 type ObjectCopiesRepository struct {
@@ -20,13 +19,7 @@ func (repo *ObjectCopiesRepository) GetAndLockUnreplicatedObject(ctx context.Con
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}
-
-	rollback := func() {
-		rerr := tx.Rollback()
-		if rerr != nil {
-			log.Errorf("Ignoring error when rolling back transaction: %s", rerr)
-		}
-	}
+	defer tx.Rollback()
 
 	row := tx.QueryRowContext(ctx, `
 	SELECT object_key, want_b2, b2, want_wasabi, wasabi, want_scw, scw
@@ -46,7 +39,6 @@ func (repo *ObjectCopiesRepository) GetAndLockUnreplicatedObject(ctx context.Con
 		&r.WantSCW, &r.SCW)
 
 	if err != nil {
-		rollback()
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, err
 		}
@@ -55,7 +47,6 @@ func (repo *ObjectCopiesRepository) GetAndLockUnreplicatedObject(ctx context.Con
 
 	err = repo.RegisterReplicationAttempt(tx, ctx, r.ObjectKey)
 	if err != nil {
-		rollback()
 		return nil, stacktrace.Propagate(err, "failed to register replication attempt")
 	}
 

--- a/server/pkg/repo/trash.go
+++ b/server/pkg/repo/trash.go
@@ -172,6 +172,7 @@ func (t *TrashRepository) CleanUpDeletedFilesFromCollection(ctx context.Context,
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
+	defer tx.Rollback()
 	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT collection_id FROM 
 		collection_files WHERE file_id = ANY($1) AND is_deleted = $2`, pq.Array(fileIDs), false)
 	if err != nil {
@@ -191,13 +192,11 @@ func (t *TrashRepository) CleanUpDeletedFilesFromCollection(ctx context.Context,
 		SET is_deleted = $1, updation_time = $2 WHERE file_id = ANY($3)`,
 		true, updationTime, pq.Array(fileIDs))
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
 		WHERE collection_id = ANY ($2)`, updationTime, pq.Array(cIDs))
 	if err != nil {
-		tx.Rollback()
 		return stacktrace.Propagate(err, "")
 	}
 	err = tx.Commit()


### PR DESCRIPTION
Use deferred rollbacks for locally owned transactions so errors and panics always release their connections. Validate preview object IDs before opening a transaction.