### PR TITLE
[mobile][photos] Surface remote sync network errors

### DIFF
--- a/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
-import 'package:dio/dio.dart';
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -86,15 +85,9 @@ class RemoteSyncService {
     _localPhotosUpdatedSubscription?.cancel();
     _localPhotosUpdatedSubscription = Bus.instance
         .on<LocalPhotosUpdatedEvent>()
-        .listen((event) async {
-          if (event.type == EventType.addedOrUpdated) {
-            if (_existingSync == null) {
-              try {
-                await sync();
-              } on DeviceStorageFullError catch (e) {
-                Bus.instance.fire(SyncStatusUpdate(SyncStatus.error, error: e));
-              }
-            }
+        .listen((event) {
+          if (event.type == EventType.addedOrUpdated && _existingSync == null) {
+            SyncService.instance.sync().ignore();
           }
         });
   }
@@ -192,11 +185,12 @@ class RemoteSyncService {
         _existingSync = null;
       }
     } catch (e, s) {
-      _existingSync?.complete();
+      final existingSync = _existingSync;
       _existingSync = null;
       _logger.warning("Error executing remote sync", e, s);
 
-      if (e is DioException ||
+      final shouldRethrow =
+          isNetworkDioException(e) ||
           flagService.internalUser ||
           // The outer sync uses these errors to update UI state.
           {
@@ -207,9 +201,13 @@ class RemoteSyncService {
             DeviceStorageFullError,
             SyncStopRequestedError,
             NoMediaLocationAccessError,
-          }.contains(e.runtimeType)) {
+          }.contains(e.runtimeType);
+      if (shouldRethrow) {
+        existingSync?.future.ignore();
+        existingSync?.completeError(e, s);
         rethrow;
       }
+      existingSync?.complete();
     } finally {
       _isExistingSyncSilent = false;
     }

--- a/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/remote_sync_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/widgets.dart';
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -195,7 +196,8 @@ class RemoteSyncService {
       _existingSync = null;
       _logger.warning("Error executing remote sync", e, s);
 
-      if (flagService.internalUser ||
+      if (e is DioException ||
+          flagService.internalUser ||
           // The outer sync uses these errors to update UI state.
           {
             UnauthorizedError,

--- a/mobile/apps/photos/lib/services/sync/sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/sync_service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:dio/dio.dart';
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photos/core/configuration.dart';
@@ -23,6 +22,7 @@ import 'package:photos/services/sync/large_backup_session_tracker.dart';
 import 'package:photos/services/sync/local_sync_service.dart';
 import 'package:photos/services/sync/offline_import_metadata_service.dart';
 import 'package:photos/services/sync/remote_sync_service.dart';
+import 'package:photos/utils/network_util.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SyncService {
@@ -162,21 +162,12 @@ class SyncService {
         SyncStatusUpdate(SyncStatus.error, error: NoMediaLocationAccessError()),
       );
     } catch (e) {
-      if (e is DioException) {
-        if (e.type == DioExceptionType.connectionTimeout ||
-            e.type == DioExceptionType.sendTimeout ||
-            e.type == DioExceptionType.receiveTimeout ||
-            e.type == DioExceptionType.connectionError ||
-            e.type == DioExceptionType.unknown) {
-          Bus.instance.fire(
-            SyncStatusUpdate(
-              SyncStatus.paused,
-              reason: "Waiting for network...",
-            ),
-          );
-          _logger.severe("unable to connect", e, StackTrace.current);
-          return false;
-        }
+      if (isNetworkDioException(e)) {
+        Bus.instance.fire(
+          SyncStatusUpdate(SyncStatus.paused, reason: "Waiting for network..."),
+        );
+        _logger.severe("unable to connect", e, StackTrace.current);
+        return false;
       }
       _logger.severe("backup failed", e, StackTrace.current);
       Bus.instance.fire(SyncStatusUpdate(SyncStatus.error));

--- a/mobile/apps/photos/lib/utils/network_util.dart
+++ b/mobile/apps/photos/lib/utils/network_util.dart
@@ -1,5 +1,16 @@
 import "package:connectivity_plus/connectivity_plus.dart";
+import "package:dio/dio.dart";
 import "package:photos/service_locator.dart";
+
+bool isNetworkDioException(Object error) =>
+    error is DioException &&
+    const {
+      DioExceptionType.connectionTimeout,
+      DioExceptionType.sendTimeout,
+      DioExceptionType.receiveTimeout,
+      DioExceptionType.connectionError,
+      DioExceptionType.unknown,
+    }.contains(error.type);
 
 Future<bool> canUseHighBandwidth() async {
   // A VPN can be reported alongside Wi-Fi or mobile.


### PR DESCRIPTION
## Summary

- propagate remote sync network failures to the outer sync service
- pause backup through the existing network-error handling instead of reporting completion