### PR TITLE
Add --depth 1 to git clone command

### DIFF
--- a/docs/docs/self-hosting/installation/compose.md
+++ b/docs/docs/self-hosting/installation/compose.md
@@ -18,7 +18,7 @@ Clone the repository. Change into the `server/config` directory of the repositor
 Run the following command for the same:
 
 ```sh
-git clone https://github.com/ente/ente
+git clone --depth 1 https://github.com/ente/ente
 cd ente/server/config
 ```
 


### PR DESCRIPTION
## Description

I'm thinking that the average person reading these docs clones the repo simply to get the latest version of the files, cloning with `--depth 1` gets **much** less data. (65MiB versus 713MiB at time of writing).

### Before
```sh
$ git clone https://github.com/ente/ente
Cloning into 'ente'...
remote: Enumerating objects: 575011, done.
remote: Counting objects: 100% (3557/3557), done.
remote: Compressing objects: 100% (954/954), done.
remote: Total 575011 (delta 3006), reused 2603 (delta 2603), pack-reused 571454 (from 5)
Receiving objects: 100% (575011/575011), 713.52 MiB | 35.83 MiB/s, done.
Resolving deltas: 100% (433384/433384), done
```

### After
```sh
$ git clone --depth 1 https://github.com/ente/ente
Cloning into 'ente'...
remote: Enumerating objects: 8586, done.
remote: Counting objects: 100% (8586/8586), done.
remote: Compressing objects: 100% (7403/7403), done.
remote: Total 8586 (delta 1025), reused 5009 (delta 607), pack-reused 0 (from 0)
Receiving objects: 100% (8586/8586), 65.54 MiB | 30.60 MiB/s, done.
Resolving deltas: 100% (1025/1025), done.
```