### PR TITLE
[auth] Add Lightyear icon

### DIFF
--- a/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
+++ b/mobile/apps/auth/assets/custom-icons/_data/custom-icons.json
@@ -1356,6 +1356,15 @@
       ]
     },
     {
+      "title": "Lightyear",
+      "hex": "000000",
+      "altNames": [
+        "Lightyear Investing",
+        "Lightyear: Invest in stocks",
+        "Lightyear: Stocks and ETFs"
+      ]
+    },
+    {
       "title": "lincolnfinancial",
       "altNames": [
         "Lincoln Financial",

--- a/mobile/apps/auth/assets/custom-icons/icons/lightyear.svg
+++ b/mobile/apps/auth/assets/custom-icons/icons/lightyear.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 181 180"><path fill="#000000" fill-rule="evenodd" d="M107 20l19 1-26 57-9-1 11-33-53 40h105v12l-78 62-20 1 26-58 9 1-11 33 53-40H28V83z"/></svg>


### PR DESCRIPTION
## Description

Adds a custom Lightyear icon to Ente Auth for Lightyear issuer names.

- Adds a compact transparent SVG based on Lightyear's current app mark.
- Registers `Lightyear` with common issuer names used by the app stores.
- Uses `hex: "000000"` so the existing adaptive icon colour handling keeps the mark visible in dark mode.
- Source: https://apps.apple.com/gb/app/lightyear-invest-in-stocks/id1562105616
- The SVG is 198 bytes, below the 20 KB limit.

## Tests

- Validated the custom icon registry as JSON.
- Confirmed the `Lightyear` entry resolves to `assets/custom-icons/icons/lightyear.svg`.
- Rendered the SVG successfully with Inkscape at 512px.
- No runtime/UI code changed, so before/after UI screenshots are not applicable.