### PR TITLE
[server] Use token hashes for authentication

### DIFF
--- a/server/pkg/api/admin.go
+++ b/server/pkg/api/admin.go
@@ -208,7 +208,8 @@ func (h *AdminHandler) DeleteUser(c *gin.Context) {
 
 func (h *AdminHandler) isFreshAdminToken(c *gin.Context) error {
 	token := auth.GetToken(c)
-	creationTime, err := h.UserAuthRepo.GetTokenCreationTime(token)
+	tokenHash := auth.HashToken(token)
+	creationTime, err := h.UserAuthRepo.GetTokenCreationTimeByHash(tokenHash[:])
 	if err != nil {
 		return err
 	}

--- a/server/pkg/controller/authsession/controller.go
+++ b/server/pkg/controller/authsession/controller.go
@@ -13,8 +13,8 @@ type cacheEntry struct {
 	revoked bool
 }
 
-func Authenticate(repo *repo.UserAuthRepository, authCache *cache.Cache, token string, app ente.App) (userID int64, expired, cached bool, err error) {
-	cacheKey := tokenCacheKey(app, token)
+func Authenticate(repo *repo.UserAuthRepository, authCache *cache.Cache, tokenHash []byte, app ente.App) (userID int64, expired, cached bool, err error) {
+	cacheKey := tokenCacheKey(app, tokenHash)
 	for {
 		if value, ok := authCache.Get(cacheKey); ok {
 			entry := value.(cacheEntry)
@@ -24,7 +24,7 @@ func Authenticate(repo *repo.UserAuthRepository, authCache *cache.Cache, token s
 			return entry.userID, false, true, nil
 		}
 
-		userID, expired, err = repo.GetUserIDWithToken(token, app)
+		userID, expired, err = repo.GetUserIDWithTokenHash(tokenHash, app)
 		if err != nil || expired {
 			return
 		}
@@ -36,10 +36,10 @@ func Authenticate(repo *repo.UserAuthRepository, authCache *cache.Cache, token s
 
 func MarkRevoked(authCache *cache.Cache, tokens []repo.RevokedToken) {
 	for _, token := range tokens {
-		authCache.Set(tokenCacheKey(token.App, token.Token), cacheEntry{revoked: true}, cache.DefaultExpiration)
+		authCache.Set(tokenCacheKey(token.App, token.TokenHash), cacheEntry{revoked: true}, cache.DefaultExpiration)
 	}
 }
 
-func tokenCacheKey(app ente.App, token string) string {
-	return string(app) + ":" + token
+func tokenCacheKey(app ente.App, tokenHash []byte) string {
+	return string(app) + ":" + string(tokenHash)
 }

--- a/server/pkg/controller/authsession/controller_test.go
+++ b/server/pkg/controller/authsession/controller_test.go
@@ -1,0 +1,50 @@
+package authsession_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/ente/museum/ente"
+	"github.com/ente/museum/internal/testutil"
+	"github.com/ente/museum/pkg/controller/authsession"
+	"github.com/ente/museum/pkg/controller/user"
+	"github.com/ente/museum/pkg/repo"
+	"github.com/ente/museum/pkg/utils/auth"
+	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashKeyedSessionRevocation(t *testing.T) {
+	testutil.WithServerRoot(t)
+	db := testutil.RequireTestDB(t)
+	testutil.ResetTables(t, db)
+	t.Cleanup(func() { testutil.ResetTables(t, db) })
+
+	userID := testutil.InsertUser(t, db, testutil.UserFixture{Email: "hash-revocation@example.com", CreationTime: 1})
+	userAuthRepo := &repo.UserAuthRepository{DB: db}
+	authCache := cache.New(time.Minute, time.Minute)
+	controller := &user.UserController{UserAuthRepo: userAuthRepo, Cache: authCache}
+	currentToken := "current-token"
+	otherToken := "other-token"
+	require.NoError(t, userAuthRepo.AddToken(userID, ente.Photos, currentToken, "127.0.0.1", "test"))
+	require.NoError(t, userAuthRepo.AddToken(userID, ente.Photos, otherToken, "127.0.0.1", "test"))
+
+	currentHash := auth.HashToken(currentToken)
+	otherHash := auth.HashToken(otherToken)
+	_, _, _, err := authsession.Authenticate(userAuthRepo, authCache, currentHash[:], ente.Photos)
+	require.NoError(t, err)
+	_, _, _, err = authsession.Authenticate(userAuthRepo, authCache, otherHash[:], ente.Photos)
+	require.NoError(t, err)
+
+	require.NoError(t, controller.RemoveAllOtherTokens(userID, currentToken))
+	_, _, _, err = authsession.Authenticate(userAuthRepo, authCache, otherHash[:], ente.Photos)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+	authCache.Flush()
+	_, _, _, err = authsession.Authenticate(userAuthRepo, authCache, currentHash[:], ente.Photos)
+	require.NoError(t, err)
+
+	require.NoError(t, controller.TerminateSession(userID, currentToken))
+	_, _, _, err = authsession.Authenticate(userAuthRepo, authCache, currentHash[:], ente.Photos)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+}

--- a/server/pkg/controller/public/actor.go
+++ b/server/pkg/controller/public/actor.go
@@ -23,7 +23,8 @@ func resolvePublicActor(c *gin.Context, userAuthRepo *repo.UserAuthRepository, j
 	}
 	if token := auth.GetToken(c); token != "" {
 		app := auth.GetApp(c)
-		userID, expired, err := userAuthRepo.GetUserIDWithToken(token, app)
+		tokenHash := auth.HashToken(token)
+		userID, expired, err := userAuthRepo.GetUserIDWithTokenHash(tokenHash[:], app)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return socialcontroller.Actor{}, ente.ErrAuthenticationRequired

--- a/server/pkg/controller/public/comments.go
+++ b/server/pkg/controller/public/comments.go
@@ -212,7 +212,8 @@ func (c *CommentsController) resolveModeratorActor(ctx *gin.Context) (*socialcon
 		return nil, nil
 	}
 	app := auth.GetApp(ctx)
-	userID, expired, err := c.UserAuthRepo.GetUserIDWithToken(token, app)
+	tokenHash := auth.HashToken(token)
+	userID, expired, err := c.UserAuthRepo.GetUserIDWithTokenHash(tokenHash[:], app)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ente.ErrAuthenticationRequired

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -543,11 +543,13 @@ func (c *UserController) RemoveAllTokens(userID int64) error {
 }
 
 func (c *UserController) RemoveAllOtherTokens(userID int64, token string) error {
-	return c.finishTokenRevocation(c.UserAuthRepo.RemoveAllOtherTokens(userID, token))
+	tokenHash := auth.HashToken(token)
+	return c.finishTokenRevocation(c.UserAuthRepo.RemoveAllOtherTokensByHash(userID, tokenHash[:]))
 }
 
 func (c *UserController) TerminateSession(userID int64, token string) error {
-	return c.finishTokenRevocation(c.UserAuthRepo.RemoveToken(userID, token))
+	tokenHash := auth.HashToken(token)
+	return c.finishTokenRevocation(c.UserAuthRepo.RemoveTokenByHash(userID, tokenHash[:]))
 }
 
 func (c *UserController) finishTokenRevocation(tokens []repo.RevokedToken, err error) error {

--- a/server/pkg/middleware/auth.go
+++ b/server/pkg/middleware/auth.go
@@ -38,9 +38,10 @@ func (m *AuthMiddleware) TokenAuthMiddleware(jwtClaimScope *jwt.ClaimScope) gin.
 		app := auth.GetApp(c)
 		var userID int64
 		if jwtClaimScope == nil {
+			tokenHash := auth.HashToken(token)
 			var expired, cached bool
 			var err error
-			userID, expired, cached, err = authsession.Authenticate(m.UserAuthRepo, m.Cache, token, app)
+			userID, expired, cached, err = authsession.Authenticate(m.UserAuthRepo, m.Cache, tokenHash[:], app)
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				logrus.Errorf("Failed to validate token: %s", err)
 				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to validate token"})
@@ -61,7 +62,7 @@ func (m *AuthMiddleware) TokenAuthMiddleware(jwtClaimScope *jwt.ClaimScope) gin.
 				// skip updating last used for requests routed via CF worker
 				if !network.IsCFWorkerIP(ip) {
 					go func() {
-						_ = m.UserAuthRepo.UpdateLastUsedAt(userID, token, ip, userAgent)
+						_ = m.UserAuthRepo.UpdateLastUsedAtByTokenHash(userID, tokenHash[:], ip, userAgent)
 					}()
 				}
 			}

--- a/server/pkg/repo/userauth.go
+++ b/server/pkg/repo/userauth.go
@@ -16,8 +16,8 @@ type UserAuthRepository struct {
 }
 
 type RevokedToken struct {
-	App   ente.App
-	Token string
+	App       ente.App
+	TokenHash []byte
 }
 
 func (repo *UserAuthRepository) AddOTT(emailHash string, app ente.App, ott string, expirationTime int64) error {
@@ -46,8 +46,8 @@ func (repo *UserAuthRepository) RemoveExpiredOTTs() error {
 	return stacktrace.Propagate(err, "")
 }
 
-func (repo *UserAuthRepository) GetTokenCreationTime(token string) (int64, error) {
-	row := repo.DB.QueryRow(`SELECT creation_time from tokens where token = $1`, token)
+func (repo *UserAuthRepository) GetTokenCreationTimeByHash(tokenHash []byte) (int64, error) {
+	row := repo.DB.QueryRow(`SELECT creation_time from tokens where token_hash = $1`, tokenHash)
 	var result int64
 	if err := row.Scan(&result); err != nil {
 		return 0, stacktrace.Propagate(err, "Failed to scan row")
@@ -163,7 +163,7 @@ func (repo *UserAuthRepository) AddToken(userID int64, app ente.App, token strin
 	return stacktrace.Propagate(err, "")
 }
 
-func (repo *UserAuthRepository) GetUserIDWithToken(token string, app ente.App) (int64, bool, error) {
+func (repo *UserAuthRepository) GetUserIDWithTokenHash(tokenHash []byte, app ente.App) (int64, bool, error) {
 	row := repo.DB.QueryRow(`
 		SELECT 
 			user_id,
@@ -173,7 +173,7 @@ func (repo *UserAuthRepository) GetUserIDWithToken(token string, app ente.App) (
 				ELSE false 
 			END as is_expired
 		FROM tokens 
-		WHERE token = $1 AND app = $2 AND is_deleted = false`, token, app)
+		WHERE token_hash = $1 AND app = $2 AND is_deleted = false`, tokenHash, app)
 	var id int64
 	var isExpired bool
 	err := row.Scan(&id, &isExpired)
@@ -183,23 +183,23 @@ func (repo *UserAuthRepository) GetUserIDWithToken(token string, app ente.App) (
 	return id, isExpired, nil
 }
 
-func (repo *UserAuthRepository) RemoveToken(userID int64, token string) ([]RevokedToken, error) {
+func (repo *UserAuthRepository) RemoveTokenByHash(userID int64, tokenHash []byte) ([]RevokedToken, error) {
 	return repo.markTokensDeleted(
-		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND token = $2 RETURNING app, token`,
-		userID, token,
+		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND token_hash = $2 RETURNING app, token_hash`,
+		userID, tokenHash,
 	)
 }
 
-func (repo *UserAuthRepository) UpdateLastUsedAt(userID int64, token string, ip string, userAgent string) error {
-	_, err := repo.DB.Exec(`UPDATE tokens SET ip = $1, user_agent = $2, last_used_at = $3 WHERE user_id = $4 AND token = $5`,
-		ip, userAgent, time.Microseconds(), userID, token)
+func (repo *UserAuthRepository) UpdateLastUsedAtByTokenHash(userID int64, tokenHash []byte, ip string, userAgent string) error {
+	_, err := repo.DB.Exec(`UPDATE tokens SET ip = $1, user_agent = $2, last_used_at = $3 WHERE user_id = $4 AND token_hash = $5`,
+		ip, userAgent, time.Microseconds(), userID, tokenHash)
 	return stacktrace.Propagate(err, "")
 }
 
-func (repo *UserAuthRepository) RemoveAllOtherTokens(userID int64, token string) ([]RevokedToken, error) {
+func (repo *UserAuthRepository) RemoveAllOtherTokensByHash(userID int64, tokenHash []byte) ([]RevokedToken, error) {
 	return repo.markTokensDeleted(
-		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND token <> $2 AND is_deleted = false RETURNING app, token`,
-		userID, token,
+		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND token_hash <> $2 AND is_deleted = false RETURNING app, token_hash`,
+		userID, tokenHash,
 	)
 }
 
@@ -217,14 +217,14 @@ func (repo *UserAuthRepository) RemoveTokensForApps(userID int64, apps []ente.Ap
 		dbApps = append(dbApps, string(app))
 	}
 	return repo.markTokensDeleted(
-		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND app = ANY($2) AND is_deleted = false RETURNING app, token`,
+		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND app = ANY($2) AND is_deleted = false RETURNING app, token_hash`,
 		userID, pq.Array(dbApps),
 	)
 }
 
 func (repo *UserAuthRepository) RemoveAllTokens(userID int64) ([]RevokedToken, error) {
 	return repo.markTokensDeleted(
-		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND is_deleted = false RETURNING app, token`,
+		`UPDATE tokens SET is_deleted = true WHERE user_id = $1 AND is_deleted = false RETURNING app, token_hash`,
 		userID,
 	)
 }
@@ -239,7 +239,7 @@ func (repo *UserAuthRepository) markTokensDeleted(query string, args ...interfac
 	tokens := make([]RevokedToken, 0)
 	for rows.Next() {
 		var token RevokedToken
-		if err = rows.Scan(&token.App, &token.Token); err != nil {
+		if err = rows.Scan(&token.App, &token.TokenHash); err != nil {
 			return nil, stacktrace.Propagate(err, "")
 		}
 		tokens = append(tokens, token)

--- a/server/pkg/utils/auth/auth.go
+++ b/server/pkg/utils/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"math/big"
 	"net/http"
@@ -46,6 +47,10 @@ func GenerateRandomInt(n int64) (int64, error) {
 
 func GenerateURLSafeRandomString(s int) string {
 	return base64.URLEncoding.EncodeToString(GenerateRandomBytes(s))
+}
+
+func HashToken(token string) [sha256.Size]byte {
+	return sha256.Sum256([]byte(token))
 }
 
 func GetHashedPassword(password string) (string, error) {

--- a/server/space/controller/auth.go
+++ b/server/space/controller/auth.go
@@ -48,7 +48,8 @@ func (a authDeps) resolveViewer(c *gin.Context, rawViewerSpaceID string) (*viewe
 		if app != ente.Photos {
 			return nil, ente.ErrPermissionDenied
 		}
-		userID, expired, err := a.UserAuthRepo.GetUserIDWithToken(token, app)
+		tokenHash := auth.HashToken(token)
+		userID, expired, err := a.UserAuthRepo.GetUserIDWithTokenHash(tokenHash[:], app)
 		if err == nil && !expired && userID > 0 {
 			viewer := &viewerAuth{UserID: userID}
 			if viewerSpaceID != "" {

--- a/server/space/controller/sessions.go
+++ b/server/space/controller/sessions.go
@@ -42,8 +42,9 @@ func (c *SessionsController) CreateBrowserSession(ctx *gin.Context, userID int64
 	}
 	sessionToken := auth.GenerateURLSafeRandomString(32)
 	sessionHash := sha256.Sum256([]byte(sessionToken))
+	authTokenHash := auth.HashToken(authToken)
 	expiresAt := timeutil.NDaysFromNow(spaceBrowserSessionDurationDays)
-	if err := c.SessionsRepo.ExchangeBrowserSession(ctx, authToken, sessionHash[:], userID, sessionWrapKey, expiresAt); err != nil {
+	if err := c.SessionsRepo.ExchangeBrowserSession(ctx, authTokenHash[:], sessionHash[:], userID, sessionWrapKey, expiresAt); err != nil {
 		return nil, err
 	}
 	return &CreatedBrowserSession{

--- a/server/space/repo/module_test.go
+++ b/server/space/repo/module_test.go
@@ -433,6 +433,7 @@ func TestExchangeBrowserSessionConsumesTokenOnce(t *testing.T) {
 	module := newSpaceTestModule(t)
 	userID := insertSpaceUser(t, module, "browser-session-exchange@example.com", "browser-session-exchange-public")
 	authToken := "browser-session-exchange-token"
+	authTokenHash := sha256.Sum256([]byte(authToken))
 	_, err := module.Sessions.DB.Exec(`
 		INSERT INTO tokens (user_id, token, creation_time, app)
 		VALUES ($1, $2, $3, 'photos')
@@ -444,7 +445,7 @@ func TestExchangeBrowserSessionConsumesTokenOnce(t *testing.T) {
 	for _, tokenHash := range [][]byte{[]byte("first-space-token-hash"), []byte("second-space-token-hash")} {
 		go func(tokenHash []byte) {
 			<-start
-			errs <- module.Sessions.ExchangeBrowserSession(ctx, authToken, tokenHash, userID, "session-wrap-key", timeutil.NDaysFromNow(1))
+			errs <- module.Sessions.ExchangeBrowserSession(ctx, authTokenHash[:], tokenHash, userID, "session-wrap-key", timeutil.NDaysFromNow(1))
 		}(tokenHash)
 	}
 	close(start)
@@ -470,6 +471,7 @@ func TestExchangeBrowserSessionKeepsTokenWhenSessionCreationFails(t *testing.T) 
 	module := newSpaceTestModule(t)
 	userID := insertSpaceUser(t, module, "browser-session-rollback@example.com", "browser-session-rollback-public")
 	authToken := "browser-session-rollback-token"
+	authTokenHash := sha256.Sum256([]byte(authToken))
 	tokenHash := []byte("duplicate-space-token-hash")
 	_, err := module.Sessions.DB.Exec(`
 		INSERT INTO tokens (user_id, token, creation_time, app)
@@ -478,7 +480,7 @@ func TestExchangeBrowserSessionKeepsTokenWhenSessionCreationFails(t *testing.T) 
 	require.NoError(t, err)
 	require.NoError(t, module.Sessions.CreateBrowserSession(ctx, tokenHash, userID, "existing-wrap-key", timeutil.NDaysFromNow(1)))
 
-	err = module.Sessions.ExchangeBrowserSession(ctx, authToken, tokenHash, userID, "new-wrap-key", timeutil.NDaysFromNow(1))
+	err = module.Sessions.ExchangeBrowserSession(ctx, authTokenHash[:], tokenHash, userID, "new-wrap-key", timeutil.NDaysFromNow(1))
 	require.Error(t, err)
 	var isDeleted bool
 	require.NoError(t, module.Sessions.DB.QueryRow(`SELECT is_deleted FROM tokens WHERE token = $1`, authToken).Scan(&isDeleted))

--- a/server/space/repo/sessions.go
+++ b/server/space/repo/sessions.go
@@ -8,13 +8,13 @@ import (
 	"github.com/ente/stacktrace"
 )
 
-func (r *SessionsRepository) ExchangeBrowserSession(ctx context.Context, authToken string, tokenHash []byte, userID int64, sessionWrapKey string, expiresAt int64) error {
+func (r *SessionsRepository) ExchangeBrowserSession(ctx context.Context, authTokenHash []byte, tokenHash []byte, userID int64, sessionWrapKey string, expiresAt int64) error {
 	result, err := r.DB.ExecContext(ctx, `
 		WITH consumed_token AS (
 			UPDATE tokens
 			SET is_deleted = TRUE
 			WHERE user_id = $1
-			  AND token = $2
+			  AND token_hash = $2
 			  AND is_deleted = FALSE
 			  AND (last_used_at IS NULL OR last_used_at >= now_utc_micro_seconds() - (365::BIGINT * 24 * 60 * 60 * 1000 * 1000))
 			RETURNING user_id
@@ -22,7 +22,7 @@ func (r *SessionsRepository) ExchangeBrowserSession(ctx context.Context, authTok
 		INSERT INTO space_browser_sessions (token_hash, user_id, session_wrap_key, expires_at)
 		SELECT $3, user_id, $4, $5
 		FROM consumed_token
-	`, userID, authToken, tokenHash, sessionWrapKey, expiresAt)
+	`, userID, authTokenHash, tokenHash, sessionWrapKey, expiresAt)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}


### PR DESCRIPTION
Use token hashes as the internal identity for Museum sessions.

- Hash raw bearer tokens at server boundaries and use the digest for authentication, activity updates, admin freshness, revocation, and cache keys.
- Use token hashes for Space viewer authentication and session exchange, and for public actor and comment authentication.
- Continue writing and returning raw tokens so existing clients and older Museum instances remain compatible.