### PR TITLE
[mobile][photos] Prune orphaned unclustered faces

### DIFF
--- a/mobile/apps/photos/lib/db/ml/base.dart
+++ b/mobile/apps/photos/lib/db/ml/base.dart
@@ -71,6 +71,7 @@ abstract class IMLDataDB<T> {
   Future<int> getErroredFaceCount();
   Future<Set<T>> getErroredFileIDs();
   Future<void> deleteFaceIndexForFiles(List<T> fileIDs);
+  Future<void> deleteUnclusteredFaceIndexForFiles(List<T> fileIDs);
   Future<int> getClusteredOrFacelessFileCount();
   Future<double> getClusteredToIndexableFilesRatio();
   Future<int> getUnclusteredFaceCount();

--- a/mobile/apps/photos/lib/db/ml/db.dart
+++ b/mobile/apps/photos/lib/db/ml/db.dart
@@ -1252,6 +1252,23 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
   }
 
   @override
+  Future<void> deleteUnclusteredFaceIndexForFiles(List<int> fileIDs) async {
+    if (fileIDs.isEmpty) return;
+    final db = await asyncDB;
+    for (final chunk in fileIDs.chunks(_maxSqlBindParamsPerQuery)) {
+      final placeholders = List.filled(chunk.length, '?').join(', ');
+      await db.execute('''
+        DELETE FROM $facesTable
+        WHERE $fileIDColumn IN ($placeholders)
+        AND NOT EXISTS (
+          SELECT 1 FROM $faceClustersTable
+          WHERE $faceClustersTable.$faceIDColumn = $facesTable.$faceIDColumn
+        )
+        ''', chunk);
+    }
+  }
+
+  @override
   Future<int> getClusteredOrFacelessFileCount() async {
     final db = await asyncDB;
     final List<Map<String, dynamic>> clustered = await db.getAll(

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -731,6 +731,24 @@ class MLService {
         'and ${missingFileIDs.length} missing fileIDs',
       );
 
+      if (missingFileIDs.isNotEmpty) {
+        await mlDataDB.deleteUnclusteredFaceIndexForFiles(
+          missingFileIDs.toList(),
+        );
+        _logger.info(
+          'Pruned unclustered face data for ${missingFileIDs.length} missing files',
+        );
+      }
+
+      if (allFaceInfoForClustering.every((face) => face.clusterId != null)) {
+        _logger.info('All faces clustered');
+        _logger.info(
+          'clusterAllImages() finished, in '
+          '${DateTime.now().difference(clusterAllImagesTime).inSeconds} seconds',
+        );
+        return;
+      }
+
       final Map<String, (Uint8List, int)> oldClusterSummaries = await mlDataDB
           .getAllClusterSummary();
 


### PR DESCRIPTION
## Description

Prune unclustered face embeddings for files that are no longer present when clustering encounters them. This makes the cheap unclustered-face pre-check accurate after at most one unnecessary clustering run, while deliberately leaving clustered face data, mappings, summaries, and centroids untouched.