### PR TITLE
[server] Store new tokens by hash

### DIFF
--- a/server/migrations/140_store_token_hash_only.down.sql
+++ b/server/migrations/140_store_token_hash_only.down.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+ALTER TABLE tokens ALTER COLUMN token SET NOT NULL;
+
+CREATE OR REPLACE FUNCTION sync_token_hash() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.token IS NOT NULL THEN
+        NEW.token_hash := sha256(convert_to(NEW.token, 'UTF8'));
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/server/migrations/140_store_token_hash_only.up.sql
+++ b/server/migrations/140_store_token_hash_only.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE tokens ALTER COLUMN token DROP NOT NULL;
+
+CREATE OR REPLACE FUNCTION sync_token_hash() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.token IS NOT NULL THEN
+        NEW.token_hash := sha256(convert_to(NEW.token, 'UTF8'));
+        NEW.token := NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/server/pkg/repo/userauth.go
+++ b/server/pkg/repo/userauth.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 
 	"github.com/ente/museum/ente"
+	"github.com/ente/museum/pkg/utils/auth"
 	"github.com/ente/museum/pkg/utils/network"
-
 	"github.com/ente/museum/pkg/utils/time"
 	"github.com/ente/stacktrace"
 	"github.com/lib/pq"
@@ -158,8 +158,9 @@ func (repo *UserAuthRepository) ReserveOTTVerificationAttempt(emailHash string, 
 }
 
 func (repo *UserAuthRepository) AddToken(userID int64, app ente.App, token string, ip string, userAgent string) error {
-	_, err := repo.DB.Exec(`INSERT INTO tokens(user_id, app, token, creation_time, ip, user_agent) VALUES($1, $2, $3, $4, $5, $6)`,
-		userID, app, token, time.Microseconds(), ip, userAgent)
+	tokenHash := auth.HashToken(token)
+	_, err := repo.DB.Exec(`INSERT INTO tokens(user_id, app, token_hash, creation_time, ip, user_agent) VALUES($1, $2, $3, $4, $5, $6)`,
+		userID, app, tokenHash[:], time.Microseconds(), ip, userAgent)
 	return stacktrace.Propagate(err, "")
 }
 

--- a/server/pkg/repo/userauth_test.go
+++ b/server/pkg/repo/userauth_test.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"bytes"
 	"crypto/sha256"
+	"database/sql"
 	"testing"
 
 	"github.com/ente/museum/ente"
@@ -10,7 +11,7 @@ import (
 	"github.com/ente/museum/pkg/utils/time"
 )
 
-func TestTokenHashCompatibilityTrigger(t *testing.T) {
+func TestTokenHashTrigger(t *testing.T) {
 	testutil.WithServerRoot(t)
 
 	db := testutil.RequireTestDB(t)
@@ -21,8 +22,8 @@ func TestTokenHashCompatibilityTrigger(t *testing.T) {
 		Email:        "token-hash@example.com",
 		CreationTime: 1,
 	})
-	rawToken := "existing-bearer-token"
-	var storedToken string
+	rawToken := "existing-bearer-token-π"
+	var storedToken sql.NullString
 	var storedHash []byte
 	err := db.QueryRow(
 		`INSERT INTO tokens(user_id, token, token_hash, creation_time, last_used_at, app)
@@ -35,8 +36,8 @@ func TestTokenHashCompatibilityTrigger(t *testing.T) {
 	}
 
 	expectedHash := sha256.Sum256([]byte(rawToken))
-	if storedToken != rawToken {
-		t.Fatalf("raw token changed: got %q want %q", storedToken, rawToken)
+	if storedToken.Valid {
+		t.Fatalf("raw token was stored: %q", storedToken.String)
 	}
 	if !bytes.Equal(storedHash, expectedHash[:]) {
 		t.Fatalf("unexpected token hash: got %x want %x", storedHash, expectedHash)
@@ -44,13 +45,38 @@ func TestTokenHashCompatibilityTrigger(t *testing.T) {
 
 	rawToken = "updated-bearer-token"
 	if err := db.QueryRow(
-		`UPDATE tokens SET token = $1 WHERE user_id = $2 RETURNING token_hash`, rawToken, userID,
-	).Scan(&storedHash); err != nil {
+		`UPDATE tokens SET token = $1 WHERE user_id = $2 RETURNING token, token_hash`, rawToken, userID,
+	).Scan(&storedToken, &storedHash); err != nil {
 		t.Fatalf("failed to update token: %v", err)
+	}
+	if storedToken.Valid {
+		t.Fatalf("updated raw token was stored: %q", storedToken.String)
 	}
 	expectedHash = sha256.Sum256([]byte(rawToken))
 	if !bytes.Equal(storedHash, expectedHash[:]) {
 		t.Fatalf("unexpected updated token hash: got %x want %x", storedHash, expectedHash)
+	}
+
+	explicitHash := sha256.Sum256([]byte("explicit-token-hash"))
+	err = db.QueryRow(
+		`INSERT INTO tokens(user_id, token_hash, creation_time, last_used_at, app)
+		 VALUES($1, $2, $3, $4, $5)
+		 RETURNING token, token_hash`,
+		userID, explicitHash[:], 2, 2, ente.Photos,
+	).Scan(&storedToken, &storedHash)
+	if err != nil {
+		t.Fatalf("failed to insert explicit token hash: %v", err)
+	}
+	if storedToken.Valid || !bytes.Equal(storedHash, explicitHash[:]) {
+		t.Fatalf("explicit token hash changed: token=%q hash=%x", storedToken.String, storedHash)
+	}
+	if err := db.QueryRow(
+		`UPDATE tokens SET token = NULL WHERE token_hash = $1 RETURNING token_hash`, explicitHash[:],
+	).Scan(&storedHash); err != nil {
+		t.Fatalf("failed to clear token: %v", err)
+	}
+	if !bytes.Equal(storedHash, explicitHash[:]) {
+		t.Fatalf("clearing token changed hash: got %x want %x", storedHash, explicitHash)
 	}
 }
 

--- a/server/space/repo/module_test.go
+++ b/server/space/repo/module_test.go
@@ -483,7 +483,7 @@ func TestExchangeBrowserSessionKeepsTokenWhenSessionCreationFails(t *testing.T) 
 	err = module.Sessions.ExchangeBrowserSession(ctx, authTokenHash[:], tokenHash, userID, "new-wrap-key", timeutil.NDaysFromNow(1))
 	require.Error(t, err)
 	var isDeleted bool
-	require.NoError(t, module.Sessions.DB.QueryRow(`SELECT is_deleted FROM tokens WHERE token = $1`, authToken).Scan(&isDeleted))
+	require.NoError(t, module.Sessions.DB.QueryRow(`SELECT is_deleted FROM tokens WHERE token_hash = $1`, authTokenHash[:]).Scan(&isDeleted))
 	require.False(t, isDeleted)
 }
 


### PR DESCRIPTION
- Store new sessions using `token_hash` without binding raw bearers in persistence SQL.
- Make `tokens.token` nullable and hash-and-clear raw writes from previous Museum instances.
- Leave existing token rows unchanged.