### PR TITLE
[mobile][photos] Retry pending Android media reads

### DIFF
--- a/mobile/apps/photos/changes/android-pending-photo-read.md
+++ b/mobile/apps/photos/changes/android-pending-photo-read.md
@@ -1,0 +1,1 @@
+- Fixed an issue that could prevent newly captured photos from opening in Ente on Android.

--- a/mobile/apps/photos/ios/Podfile.lock
+++ b/mobile/apps/photos/ios/Podfile.lock
@@ -151,8 +151,6 @@ PODS:
   - Mantle (2.2.0):
     - Mantle/extobjc (= 2.2.0)
   - Mantle/extobjc (2.2.0)
-  - media_extension (0.0.1):
-    - Flutter
   - media_kit_libs_ios_video (1.0.4):
     - Flutter
   - media_kit_video (0.0.1):
@@ -277,7 +275,6 @@ DEPENDENCIES:
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
   - launcher_icon_switcher (from `.symlinks/plugins/launcher_icon_switcher/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
-  - media_extension (from `.symlinks/plugins/media_extension/ios`)
   - media_kit_libs_ios_video (from `.symlinks/plugins/media_kit_libs_ios_video/ios`)
   - media_kit_video (from `.symlinks/plugins/media_kit_video/ios`)
   - mobile_ocr (from `.symlinks/plugins/mobile_ocr/ios`)
@@ -393,8 +390,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/launcher_icon_switcher/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
-  media_extension:
-    :path: ".symlinks/plugins/media_extension/ios"
   media_kit_libs_ios_video:
     :path: ".symlinks/plugins/media_kit_libs_ios_video/ios"
   media_kit_video:
@@ -486,7 +481,6 @@ SPEC CHECKSUMS:
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
-  media_extension: 671e2567880d96c95c65c9a82ccceed8f2e309fd
   media_kit_libs_ios_video: 5a18affdb97d1f5d466dc79988b13eff6c5e2854
   media_kit_video: 1746e198cb697d1ffb734b1d05ec429d1fcd1474
   mobile_ocr: bb5125a6810b4eead3c69778e6b7f3c61fb3c24d

--- a/mobile/apps/photos/lib/ui/viewer/actions/file_viewer.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/file_viewer.dart
@@ -35,6 +35,12 @@ class FileViewer extends StatefulWidget {
 class FileViewerState extends State<FileViewer> {
   static const int _reviewGalleryWindowSize = 80;
   static const int _reviewGallerySearchPageSize = 200;
+  static const List<Duration> _grantedImageReadRetryDelays = [
+    Duration(milliseconds: 250),
+    Duration(milliseconds: 500),
+    Duration(milliseconds: 1000),
+    Duration(milliseconds: 2000),
+  ];
 
   final action = AppLifecycleService.instance.mediaExtensionAction;
   ChewieController? controller;
@@ -388,17 +394,43 @@ class FileViewerState extends State<FileViewer> {
   }
 
   Future<Uint8List?> _readGrantedImageBytes(String uri) async {
-    try {
-      final bytes = await MediaExtension().readUriBytes(uri);
-      if (bytes == null || bytes.isEmpty) {
+    final mediaExtension = MediaExtension();
+    final maxAttempts = _grantedImageReadRetryDelays.length + 1;
+
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        final bytes = await mediaExtension.readUriBytes(uri);
+        if (bytes != null && bytes.isNotEmpty) {
+          return bytes;
+        }
         _logger.severe("failed to read image bytes for $uri");
         return null;
+      } on PlatformException catch (error, stackTrace) {
+        if (error.code != "readUriBytes-pending" ||
+            attempt == maxAttempts - 1) {
+          _logger.severe(
+            "failed to read image bytes for $uri",
+            error,
+            stackTrace,
+          );
+          return null;
+        }
+        final retryDelay = _grantedImageReadRetryDelays[attempt];
+        _logger.warning(
+          "image is still pending for $uri, retrying in "
+          "${retryDelay.inMilliseconds} ms",
+        );
+        await Future<void>.delayed(retryDelay);
+      } catch (error, stackTrace) {
+        _logger.severe(
+          "failed to read image bytes for $uri",
+          error,
+          stackTrace,
+        );
+        return null;
       }
-      return bytes;
-    } catch (e, s) {
-      _logger.severe("failed to read image bytes for $uri", e, s);
-      return null;
     }
+    return null;
   }
 
   Widget _buildGrantedImageFallback(String data) {

--- a/mobile/apps/photos/plugins/media_extension/android/build.gradle
+++ b/mobile/apps/photos/plugins/media_extension/android/build.gradle
@@ -1,0 +1,66 @@
+group = "io.ente.photos.media_extension"
+version = "1.0-SNAPSHOT"
+
+buildscript {
+    ext.kotlin_version = "1.8.22"
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+
+android {
+    namespace = "io.ente.photos.media_extension"
+
+    compileSdk = 35
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_11
+    }
+
+    sourceSets {
+        main.java.srcDirs += "src/main/kotlin"
+        test.java.srcDirs += "src/test/kotlin"
+    }
+
+    defaultConfig {
+        minSdk = 16
+    }
+
+    dependencies {
+        testImplementation("org.jetbrains.kotlin:kotlin-test")
+        testImplementation("org.mockito:mockito-core:5.0.0")
+    }
+
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+
+            testLogging {
+               events "passed", "skipped", "failed", "standardOut", "standardError"
+               outputs.upToDateWhen {false}
+               showStandardStreams = true
+            }
+        }
+    }
+}

--- a/mobile/apps/photos/plugins/media_extension/android/src/main/AndroidManifest.xml
+++ b/mobile/apps/photos/plugins/media_extension/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/mobile/apps/photos/plugins/media_extension/android/src/main/AndroidManifest.xml
+++ b/mobile/apps/photos/plugins/media_extension/android/src/main/AndroidManifest.xml
@@ -1,2 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <provider
+            android:name=".MediaExtensionFileProvider"
+            android:authorities="${applicationId}.file_provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/media_extension_provider_paths" />
+        </provider>
+    </application>
 </manifest>

--- a/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionFileProvider.kt
+++ b/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionFileProvider.kt
@@ -1,0 +1,5 @@
+package io.ente.photos.media_extension
+
+import androidx.core.content.FileProvider
+
+class MediaExtensionFileProvider : FileProvider()

--- a/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
+++ b/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
@@ -26,6 +26,12 @@ import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import kotlin.collections.HashMap
 
+private const val MediaStorePendingItemErrorPrefix =
+    "Only owner is able to interact with pending"
+
+internal fun isMediaStorePendingItemError(message: String?): Boolean {
+    return message?.contains(MediaStorePendingItemErrorPrefix, ignoreCase = true) == true
+}
 
 /// The Class which implements Activity Aware FlutterPlugin
 class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
@@ -41,7 +47,7 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
     private var activityBinding: ActivityPluginBinding? = null
     private val mainHandler = Handler(Looper.getMainLooper())
     private val ioExecutor: ExecutorService = Executors.newSingleThreadExecutor()
-    private val logTag = "EnteMediaExtensionPlugin"
+    private val logTag = "EnteMediaExtension"
 
     ///ENUM of all the possible IntentAction for a gallery app.
     enum class IntentAction {
@@ -401,13 +407,9 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
             return false
         }
 
-        // MediaProvider uses the same text for its pending ContentResolver check and
-        // its pending/trashed FUSE check. Only the former propagates this exception;
-        // FUSE converts trashed access to a generic I/O failure.
-        return error.message?.contains(
-            MediaStorePendingOrTrashedItemError,
-            ignoreCase = true,
-        ) == true
+        // Only the ContentResolver pending check propagates this exception;
+        // the FUSE pending/trashed check converts it to a generic I/O failure.
+        return isMediaStorePendingItemError(error.message)
     }
 
     private fun InputStream.readBytesWithLimit(maxBytes: Long): ByteArray {
@@ -578,8 +580,6 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
     private companion object {
         private const val MediaStoreAuthority = "media"
         private const val MediaDocumentsAuthority = "com.android.providers.media.documents"
-        private const val MediaStorePendingOrTrashedItemError =
-            "Only owner is able to interact with pending/trashed item"
         private const val MaxReadUriBytes = 100L * 1024L * 1024L
     }
 

--- a/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
+++ b/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
@@ -1,0 +1,558 @@
+package io.ente.photos.media_extension
+
+import android.app.Activity
+import android.content.ClipData
+import android.content.ContentResolver
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.*
+import android.provider.OpenableColumns
+import android.util.Log
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.PluginRegistry
+import java.io.*
+import java.util.*
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import kotlin.collections.HashMap
+
+
+/// The Class which implements Activity Aware FlutterPlugin
+class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
+    PluginRegistry.ActivityResultListener, PluginRegistry.NewIntentListener {
+
+    /// The MethodChannel that will the communication between Flutter and native Android
+    ///
+    /// This local reference serves to register the plugin with the Flutter Engine and unregister it
+    /// when the Flutter Engine is detached from the Activity
+    private lateinit var methodChannel: MethodChannel
+    private lateinit var context: Context
+    private var activity: Activity? = null
+    private var activityBinding: ActivityPluginBinding? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val ioExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val logTag = "EnteMediaExtensionPlugin"
+
+    ///ENUM of all the possible IntentAction for a gallery app.
+    enum class IntentAction {
+        MAIN,
+        PICK,
+        EDIT,
+        VIEW
+    }
+
+    /// The Method invoked when FlutterEngine is attached to the app
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        ///Application context is assigned to variable context
+        context = flutterPluginBinding.applicationContext
+
+        ///Method Channel instance is created for channel [media_extension]
+        methodChannel = MethodChannel(flutterPluginBinding.binaryMessenger, "media_extension")
+
+        /// Method Channel handler which handles all the methods
+        /// invoked from flutter thread
+        methodChannel.setMethodCallHandler(this)
+    }
+
+    /// The Method invoked when a methodCall is executed from flutter thread
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        when (call.method) {
+            "getPlatformVersion" -> {
+                result.success("Android ${Build.VERSION.RELEASE}")
+            }
+            "getIntentAction" -> {
+                result.success(getIntentAction())
+            }
+            "setResult" -> {
+                setResult(call, result)
+            }
+            "setResults" -> {
+                setResults(call, result)
+            }
+            "cancelResult" -> {
+                cancelResult(result)
+            }
+            "setAs" -> {
+                setAs(call, result)
+            }
+            "edit" -> {
+                edit(call, result)
+            }
+            "openWith" -> {
+                openWith(call, result)
+            }
+            "readUriBytes" -> {
+                readUriBytes(call, result)
+            }
+            else -> {
+                result.notImplemented()
+            }
+        }
+    }
+
+    /// The Method is triggered by the Flutter thread with arguments containing
+    /// and [uri] of the received media of type content://xyz.
+    /// MediaStore/file image URIs are passed through directly so callers can
+    /// render them without base64 overhead. Other image content providers keep
+    /// the base64 fallback for compatibility with transient grants.
+    private fun getResolvedContent(
+        contentUri: Uri,
+        contentType: String,
+        resolvedContent: HashMap<String, String>
+    ) {
+        val resolver = context.contentResolver
+        val resolvedName = try {
+            resolver.query(
+                contentUri,
+                arrayOf(OpenableColumns.DISPLAY_NAME),
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (nameIndex >= 0) {
+                        cursor.getString(nameIndex)
+                    } else {
+                        null
+                    }
+                } else {
+                    null
+                }
+            }
+        } catch (e: IllegalArgumentException) {
+            Log.w(logTag, "failed to get display name for uri=$contentUri", e)
+            null
+        } catch (e: SecurityException) {
+            Log.w(logTag, "failed to get display name for uri=$contentUri", e)
+            null
+        }
+
+        resolvedContent["name"] = resolvedName ?: fallbackDisplayName(contentUri, contentType)
+        val fileType = contentType.split("/", limit = 2)
+        resolvedContent["type"] = fileType.getOrElse(0) { "" }
+        resolvedContent["extension"] = fileType.getOrElse(1) { "" }
+        if (contentType.startsWith("video")) {
+            resolvedContent["data"] = contentUri.toString()
+        } else if (contentType.startsWith("image")) {
+            resolvedContent["data"] = if (contentUri.canBeRenderedFromUri()) {
+                contentUri.toString()
+            } else {
+                resolver.encodeAsBase64(contentUri)
+            }
+        }
+    }
+
+    private fun Uri.canBeRenderedFromUri(): Boolean {
+        return scheme == ContentResolver.SCHEME_FILE ||
+            authority == MediaStoreAuthority ||
+            authority == MediaDocumentsAuthority
+    }
+
+    private fun ContentResolver.encodeAsBase64(contentUri: Uri): String {
+        val imageBytes = openInputStream(contentUri)?.use { contentStream ->
+            contentStream.readBytes()
+        } ?: ByteArray(0)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Base64.getEncoder().encodeToString(imageBytes)
+        } else {
+            android.util.Base64.encodeToString(
+                imageBytes,
+                android.util.Base64.DEFAULT
+            )
+        }
+    }
+
+    private fun fallbackDisplayName(contentUri: Uri, contentType: String): String {
+        val lastSegment = contentUri.lastPathSegment?.substringAfterLast('/')
+        if (!lastSegment.isNullOrBlank()) {
+            return lastSegment
+        }
+
+        val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(contentType)
+        return if (extension.isNullOrBlank()) {
+            "shared_${System.currentTimeMillis()}"
+        } else {
+            "shared_${System.currentTimeMillis()}.$extension"
+        }
+    }
+
+    private fun resolveMimeType(intent: Intent, uri: Uri): String? {
+        return intent.resolveType(context.contentResolver)
+            ?: typeFromContentResolver(uri)
+            ?: typeFromExtension(uri)
+    }
+
+    private fun typeFromContentResolver(uri: Uri): String? {
+        return try {
+            context.contentResolver.getType(uri)
+        } catch (e: IllegalArgumentException) {
+            Log.w(logTag, "failed to get content type for uri=$uri", e)
+            null
+        } catch (e: SecurityException) {
+            Log.w(logTag, "failed to get content type for uri=$uri", e)
+            null
+        }
+    }
+
+    private fun typeFromExtension(uri: Uri): String? {
+        val extension = uri.lastPathSegment
+            ?.substringAfterLast('.', missingDelimiterValue = "")
+            ?.lowercase(Locale.ROOT)
+            ?.takeIf { it.isNotBlank() }
+            ?: return null
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+    }
+
+    /// The Method is triggered when the app is opened and it sends the [intent-action]
+    /// and [uri] information in a HashMap Structure to the Flutter thread.
+    private fun emitIntentAction(intent: Intent) {
+        Handler(Looper.getMainLooper()).post {
+            methodChannel.invokeMethod("getIntentAction", getIntentAction(intent))
+        }
+    }
+
+    private fun getIntentAction(intent: Intent? = activity?.intent): HashMap<String, String> {
+        val result = HashMap<String, String>()
+        var resAction = IntentAction.valueOf("MAIN")
+        if (intent != null) {
+            val data: Uri? = intent.data
+            val type: String? = intent.type
+            when (intent.action) {
+                Intent.ACTION_PICK -> {
+                    type?.putMediaType(result)
+                    intent.putAllowMultiple(result)
+                    resAction = IntentAction.valueOf("PICK")
+                }
+                Intent.ACTION_GET_CONTENT -> {
+                    type?.putMediaType(result)
+                    intent.putAllowMultiple(result)
+                    resAction = IntentAction.valueOf("PICK")
+                }
+                Intent.ACTION_EDIT -> {
+                    resAction = IntentAction.valueOf("EDIT")
+                }
+                Intent.ACTION_VIEW -> {
+                    if (data != null) {
+                        result["uri"] = data.toString()
+                        Log.i(logTag, " dataValueView=$data")
+                    }
+                    val resolvedType = data?.let { type ?: resolveMimeType(intent, it) }
+                    if (data != null && resolvedType != null) {
+                        try {
+                            getResolvedContent(data, resolvedType, result)
+                        } catch (e: Exception) {
+                            Log.w(logTag, "failed to resolve intent data for uri=$data type=$resolvedType", e)
+                        }
+                    }
+                    resAction = IntentAction.valueOf("VIEW")
+                }
+                else -> {
+                    resAction = IntentAction.valueOf("MAIN")
+                }
+            }
+        }
+        result["action"] = resAction.toString()
+        return result
+    }
+
+    /// The Method is triggered by the Flutter thread with arguments containing
+    /// and [uri] of the selected image and sends the image to the requested app
+    /// via RESULT_ACTION Intent using Content Provider
+    private fun setResult(call: MethodCall, result: Result) {
+        val uri = call.argument<String>("uri")?.let { Uri.parse(it) }
+        if (uri == null) {
+            result.error("setResult-args", "missing uri", null)
+            return
+        }
+        setResultUris(listOf(uri), result)
+    }
+
+    private fun setResults(call: MethodCall, result: Result) {
+        val uriStrings = call.argument<List<String>>("uris")
+        if (uriStrings.isNullOrEmpty()) {
+            result.error("setResults-args", "missing uris", null)
+            return
+        }
+        setResultUris(uriStrings.map { Uri.parse(it) }, result)
+    }
+
+    private fun setResultUris(uris: List<Uri>, result: Result) {
+        val shareableUris = uris.mapNotNull { getShareableUri(context, it) }
+        if (shareableUris.isEmpty()) {
+            result.error("setResults-args", "no shareable uris", null)
+            return
+        }
+        val intent = Intent("io.ente.RESULT_ACTION")
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        val uri = shareableUris.first()
+        intent.data = uri
+        if (shareableUris.size > 1) {
+            val clipData = ClipData.newUri(context.contentResolver, "media", uri)
+            shareableUris.drop(1).forEach { clipData.addItem(ClipData.Item(it)) }
+            intent.clipData = clipData
+            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+        }
+        activity!!.setResult(Activity.RESULT_OK, intent)
+        result.success(null)
+        activity!!.finish()
+    }
+
+    private fun cancelResult(result: Result) {
+        activity!!.setResult(Activity.RESULT_CANCELED)
+        result.success(null)
+        activity!!.finish()
+    }
+
+    private fun String.putMediaType(result: HashMap<String, String>) {
+        val normalized = lowercase(Locale.ROOT)
+        val mediaType = when {
+            normalized.startsWith("image/") ||
+                normalized == "vnd.android.cursor.dir/image" -> "image"
+            normalized.startsWith("video/") ||
+                normalized == "vnd.android.cursor.dir/video" -> "video"
+            else -> null
+        }
+        if (mediaType != null) {
+            result["type"] = mediaType
+        }
+        split("/", limit = 2).getOrNull(1)?.let { extension ->
+            if (extension.isNotBlank() && extension != "*") {
+                result["extension"] = extension
+            }
+        }
+    }
+
+    private fun Intent.putAllowMultiple(result: HashMap<String, String>) {
+        if (getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)) {
+            result["allowMultiple"] = "true"
+        }
+    }
+
+    private fun readUriBytes(call: MethodCall, result: Result) {
+        val uri = call.argument<String>("uri")?.let { Uri.parse(it) }
+        if (uri == null) {
+            result.error("readUriBytes-args", "missing uri", null)
+            return
+        }
+        try {
+            ioExecutor.execute {
+                readUriBytesOnIoThread(uri, result)
+            }
+        } catch (e: RejectedExecutionException) {
+            Log.w(logTag, "read uri executor is unavailable for uri=$uri", e)
+            result.error("readUriBytes-unavailable", e.message, null)
+        }
+    }
+
+    private fun readUriBytesOnIoThread(uri: Uri, result: Result) {
+        try {
+            val bytes = context.contentResolver.openInputStream(uri)?.use { input ->
+                input.readBytesWithLimit(MaxReadUriBytes)
+            }
+            if (bytes == null) {
+                mainHandler.post {
+                    result.error("readUriBytes-open", "failed to open uri", null)
+                }
+                return
+            }
+            mainHandler.post {
+                result.success(bytes)
+            }
+        } catch (e: UriTooLargeException) {
+            Log.w(logTag, "uri exceeds read limit for uri=$uri", e)
+            mainHandler.post {
+                result.error("readUriBytes-too-large", e.message, null)
+            }
+        } catch (e: Exception) {
+            Log.w(logTag, "failed to read uri bytes for uri=$uri", e)
+            mainHandler.post {
+                result.error("readUriBytes-failed", e.message, null)
+            }
+        }
+    }
+
+    private fun InputStream.readBytesWithLimit(maxBytes: Long): ByteArray {
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var totalBytes = 0L
+        while (true) {
+            val bytesRead = read(buffer)
+            if (bytesRead == -1) {
+                return output.toByteArray()
+            }
+            if (totalBytes + bytesRead > maxBytes) {
+                throw UriTooLargeException(maxBytes)
+            }
+            output.write(buffer, 0, bytesRead)
+            totalBytes += bytesRead
+        }
+    }
+
+    /// The Method is triggered by the Flutter thread with arguments containing
+    /// and [uri] of the selected image and sends the image to the chosen app
+    /// which can handle the `ACTION_ATTACH_DATA` Intent
+    private fun setAs(call: MethodCall, result: Result) {
+        val title = "Set as"
+        val uri = call.argument<String>("uri")?.let { Uri.parse(it) }
+        val mimeType = call.argument<String>("mimeType")
+        if (uri == null) {
+            result.error("setAs-args", "missing arguments", null)
+            return
+        }
+        val intent = Intent(Intent.ACTION_ATTACH_DATA)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            .putExtra("mimeType", mimeType)
+            .setDataAndType(getShareableUri(activity!!.applicationContext, uri), mimeType)
+        val started = safeStartActivityChooser(title, intent)
+        result.success(started)
+    }
+
+    /// The Method is triggered by the Flutter thread with arguments containing
+    /// and [uri] of the selected image and sends the image to the chosen app
+    /// which can handle the `ACTION_VIEW` Intent
+    private fun openWith(call: MethodCall, result: Result) {
+        val title = call.argument<String>("title")
+        val uri = call.argument<String>("uri")?.let { Uri.parse(it) }
+        val mimeType = call.argument<String>("mimeType")
+        if (uri == null) {
+            result.error("open-args", "missing arguments", null)
+            return
+        }
+
+        val intent = Intent(Intent.ACTION_VIEW)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            .setDataAndType(getShareableUri(activity!!.applicationContext, uri), mimeType)
+        val started = safeStartActivityChooser(title, intent)
+
+        result.success(started)
+    }
+
+    /// The Method is triggered by the Flutter thread with arguments containing
+    /// and [uri] of the selected image and sends the image to the chosen app
+    /// which can handle the `ACTION_EDIT` Intent
+    private fun edit(call: MethodCall, result: Result) {
+        val title = call.argument<String>("title")
+        val uri = call.argument<String>("uri")?.let { Uri.parse(it) }
+        val mimeType = call.argument<String>("mimeType")
+        if (uri == null) {
+            result.error("edit-args", "missing arguments", null)
+            return
+        }
+
+        val intent = Intent(Intent.ACTION_EDIT)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            .setDataAndType(getShareableUri(activity!!.applicationContext, uri), mimeType)
+        val started = safeStartActivityChooser(title, intent)
+
+        result.success(started)
+    }
+
+    /// The Method is creates content of the file which needs to be shared to
+    /// other app using content resolver.
+    private fun getShareableUri(context: Context, uri: Uri): Uri? {
+        /* https://developer.android.com/training/secure-file-sharing/setup-sharing.html
+        https://developer.android.com/training/secure-file-sharing/setup-sharing.html
+         */
+        return when (uri.scheme?.lowercase(Locale.ROOT)) {
+            ContentResolver.SCHEME_FILE -> {
+                uri.path?.let { path ->
+                    FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.file_provider",
+                        File(path)
+                    )
+                }
+            }
+            else -> uri
+        }
+    }
+
+    /// The Method is used to list out all the available apps
+    ///  which can handle the Supplied Intent Action.
+    private fun safeStartActivityChooser(title: String?, intent: Intent): Boolean {
+        if (activity?.let { intent.resolveActivity(it.packageManager) } == null) {
+            Log.i(logTag, " intent=$intent resolved activity return null")
+            //return false
+        }
+        try {
+            activity?.startActivity(Intent.createChooser(intent, title))
+            return true
+        } catch (e: SecurityException) {
+            if (intent.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION != 0) {
+                // in some environments, providing the write flag yields a `SecurityException`:
+                // "UID `xyz` does not have permission to `content://xyz`"
+                // so we retry without it
+                Log.i(logTag, "retry intent=$intent without FLAG_GRANT_WRITE_URI_PERMISSION")
+                intent.flags = intent.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION.inv()
+                return safeStartActivityChooser(title, intent)
+            } else {
+                Log.w(logTag, "failed to start activity chooser for intent=$intent", e)
+            }
+        }
+        return false
+    }
+
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        methodChannel.setMethodCallHandler(null)
+        ioExecutor.shutdown()
+    }
+
+    /// The Method Invoked after the Plugin is attached to Flutter engine
+    /// Provides the activity context of the application
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activityBinding = binding
+        activity = binding.activity
+        binding.addActivityResultListener(this)
+        binding.addOnNewIntentListener(this)
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+        detachFromActivity()
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        onAttachedToActivity(binding)
+    }
+
+    override fun onDetachedFromActivity() {
+        detachFromActivity()
+    }
+
+    private fun detachFromActivity() {
+        activityBinding?.removeActivityResultListener(this)
+        activityBinding?.removeOnNewIntentListener(this)
+        activityBinding = null
+        activity = null
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        return true
+    }
+
+    override fun onNewIntent(intent: Intent): Boolean {
+        activity?.setIntent(intent)
+        emitIntentAction(intent)
+        return false
+    }
+
+    private companion object {
+        private const val MediaStoreAuthority = "media"
+        private const val MediaDocumentsAuthority = "com.android.providers.media.documents"
+        private const val MaxReadUriBytes = 100L * 1024L * 1024L
+    }
+
+    private class UriTooLargeException(maxBytes: Long) :
+        IOException("uri content exceeds ${maxBytes / (1024L * 1024L)} MiB")
+}

--- a/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
+++ b/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
@@ -374,12 +374,26 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
             mainHandler.post {
                 result.error("readUriBytes-too-large", e.message, null)
             }
+        } catch (e: IllegalStateException) {
+            val errorCode = if (e.isPendingOrTrashedMediaItemError()) {
+                "readUriBytes-pending"
+            } else {
+                "readUriBytes-failed"
+            }
+            Log.w(logTag, "failed to read uri bytes for uri=$uri", e)
+            mainHandler.post {
+                result.error(errorCode, e.message, null)
+            }
         } catch (e: Exception) {
             Log.w(logTag, "failed to read uri bytes for uri=$uri", e)
             mainHandler.post {
                 result.error("readUriBytes-failed", e.message, null)
             }
         }
+    }
+
+    private fun IllegalStateException.isPendingOrTrashedMediaItemError(): Boolean {
+        return message?.contains("pending/trashed item", ignoreCase = true) == true
     }
 
     private fun InputStream.readBytesWithLimit(maxBytes: Long): ByteArray {

--- a/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
+++ b/mobile/apps/photos/plugins/media_extension/android/src/main/kotlin/io/ente/photos/media_extension/MediaExtensionPlugin.kt
@@ -155,8 +155,12 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
 
     private fun Uri.canBeRenderedFromUri(): Boolean {
         return scheme == ContentResolver.SCHEME_FILE ||
-            authority == MediaStoreAuthority ||
-            authority == MediaDocumentsAuthority
+            hasProviderAuthority(MediaStoreAuthority) ||
+            hasProviderAuthority(MediaDocumentsAuthority)
+    }
+
+    private fun Uri.hasProviderAuthority(providerAuthority: String): Boolean {
+        return host == providerAuthority
     }
 
     private fun ContentResolver.encodeAsBase64(contentUri: Uri): String {
@@ -375,7 +379,7 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
                 result.error("readUriBytes-too-large", e.message, null)
             }
         } catch (e: IllegalStateException) {
-            val errorCode = if (e.isPendingOrTrashedMediaItemError()) {
+            val errorCode = if (uri.isRetryablePendingMediaStoreError(e)) {
                 "readUriBytes-pending"
             } else {
                 "readUriBytes-failed"
@@ -392,8 +396,18 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
         }
     }
 
-    private fun IllegalStateException.isPendingOrTrashedMediaItemError(): Boolean {
-        return message?.contains("pending/trashed item", ignoreCase = true) == true
+    private fun Uri.isRetryablePendingMediaStoreError(error: IllegalStateException): Boolean {
+        if (!hasProviderAuthority(MediaStoreAuthority)) {
+            return false
+        }
+
+        // MediaProvider uses the same text for its pending ContentResolver check and
+        // its pending/trashed FUSE check. Only the former propagates this exception;
+        // FUSE converts trashed access to a generic I/O failure.
+        return error.message?.contains(
+            MediaStorePendingOrTrashedItemError,
+            ignoreCase = true,
+        ) == true
     }
 
     private fun InputStream.readBytesWithLimit(maxBytes: Long): ByteArray {
@@ -564,6 +578,8 @@ class MediaExtensionPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
     private companion object {
         private const val MediaStoreAuthority = "media"
         private const val MediaDocumentsAuthority = "com.android.providers.media.documents"
+        private const val MediaStorePendingOrTrashedItemError =
+            "Only owner is able to interact with pending/trashed item"
         private const val MaxReadUriBytes = 100L * 1024L * 1024L
     }
 

--- a/mobile/apps/photos/plugins/media_extension/android/src/main/res/xml/media_extension_provider_paths.xml
+++ b/mobile/apps/photos/plugins/media_extension/android/src/main/res/xml/media_extension_provider_paths.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path
+        name="cache"
+        path="." />
+    <files-path
+        name="files"
+        path="." />
+    <external-path
+        name="external"
+        path="." />
+</paths>

--- a/mobile/apps/photos/plugins/media_extension/android/src/test/kotlin/io/ente/photos/media_extension/MediaExtensionPluginTest.kt
+++ b/mobile/apps/photos/plugins/media_extension/android/src/test/kotlin/io/ente/photos/media_extension/MediaExtensionPluginTest.kt
@@ -1,0 +1,26 @@
+package io.ente.photos.media_extension
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MediaExtensionPluginTest {
+    @Test
+    fun matchesSupportedMediaProviderPendingMessages() {
+        val messages = listOf(
+            "Only owner is able to interact with pending media content://media/item",
+            "Only owner is able to interact with pending item content://media/item",
+            "Only owner is able to interact with pending/trashed item content://media/item",
+        )
+
+        for (message in messages) {
+            assertTrue(isMediaStorePendingItemError(message), message)
+        }
+    }
+
+    @Test
+    fun rejectsUnrelatedMediaProviderErrors() {
+        assertFalse(isMediaStorePendingItemError(null))
+        assertFalse(isMediaStorePendingItemError("Permission denied"))
+    }
+}

--- a/mobile/apps/photos/plugins/media_extension/lib/media_extension.dart
+++ b/mobile/apps/photos/plugins/media_extension/lib/media_extension.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:media_extension/media_extension_action_types.dart';
+import 'package:media_extension/media_extension_platform_interface.dart';
+
+/// Class which contains all the methods of the plugin
+class MediaExtension {
+  Future<String?> getPlatformVersion() =>
+      MediaExtensionPlatform.instance.getPlatformVersion();
+
+  Future<bool> setAs(String uri, String mimeType) =>
+      MediaExtensionPlatform.instance.setAs(uri, mimeType);
+
+  Future<bool> edit(String uri, String mimeType) =>
+      MediaExtensionPlatform.instance.edit(uri, mimeType);
+
+  Future<bool> openWith(String uri, String mimeType) =>
+      MediaExtensionPlatform.instance.edit(uri, mimeType);
+
+  Future<MediaExtentionAction> getIntentAction() =>
+      MediaExtensionPlatform.instance.getIntentAction();
+
+  Future<Uint8List?> readUriBytes(String uri) =>
+      MediaExtensionPlatform.instance.readUriBytes(uri);
+
+  Stream<MediaExtentionAction> get intentActionStream =>
+      MediaExtensionPlatform.instance.intentActionStream;
+
+  Future<void> setResult(String uri) =>
+      MediaExtensionPlatform.instance.setResult(uri);
+
+  Future<void> setResults(List<String> uris) =>
+      MediaExtensionPlatform.instance.setResults(uris);
+
+  Future<void> cancelResult() => MediaExtensionPlatform.instance.cancelResult();
+}

--- a/mobile/apps/photos/plugins/media_extension/lib/media_extension.dart
+++ b/mobile/apps/photos/plugins/media_extension/lib/media_extension.dart
@@ -15,7 +15,7 @@ class MediaExtension {
       MediaExtensionPlatform.instance.edit(uri, mimeType);
 
   Future<bool> openWith(String uri, String mimeType) =>
-      MediaExtensionPlatform.instance.edit(uri, mimeType);
+      MediaExtensionPlatform.instance.openWith(uri, mimeType);
 
   Future<MediaExtentionAction> getIntentAction() =>
       MediaExtensionPlatform.instance.getIntentAction();

--- a/mobile/apps/photos/plugins/media_extension/lib/media_extension_action_types.dart
+++ b/mobile/apps/photos/plugins/media_extension/lib/media_extension_action_types.dart
@@ -1,0 +1,110 @@
+/// The Enum represents the IntentAction which as invoked the app.
+///
+/// * main: invoked normally by user
+/// * pick: invoked by other app with ACTION_PICK Intent
+/// * edit: invoked by other app with ACTION_EDIT Intent
+/// * view: invoked by other app with ACTION_VIEW Intent
+/// * unknown: when unexpected case as occured
+enum IntentAction { main, pick, edit, view, unknown }
+
+/// Method which extracts the value of the IntentAction as a string
+///
+/// Example:
+/// ```dart
+///  IntentAction action = IntentAction.main
+///  print(action.toShortString());
+/// ```
+/// Output:
+/// ```bash
+///  pick
+/// ```
+extension ParseToString on IntentAction {
+  String toShortString() => toString().split('.').last;
+}
+
+/// * Method which converts the string value to the IntentAction
+/// * Used for converting the string from native code to dart type
+///
+/// Example:
+///  ```dart
+///   String actionString = 'MAIN'
+///   IntentAction action = actionParser(actionString);
+///   print(action);
+///   ```
+/// Output:
+/// ```bash
+///  intentAction.main
+/// ```
+IntentAction actionParser(String actionString) {
+  IntentAction? action;
+
+  switch (actionString) {
+    case 'PICK':
+      action = IntentAction.pick;
+      break;
+    case 'EDIT':
+      action = IntentAction.edit;
+      break;
+    case 'VIEW':
+      action = IntentAction.view;
+      break;
+    default:
+      action = IntentAction.main;
+  }
+
+  return action;
+}
+
+/// MediaExtensionAction is custom data class
+/// * IntentAction action: Intent Action Which Invoked the app.
+/// * String uri: uri passed via the Intent.
+class MediaExtentionAction {
+  final IntentAction? action;
+  final String? data;
+  final MediaType? type;
+  final String? extension;
+  final String? name;
+  final bool allowMultiple;
+
+  MediaExtentionAction({
+    this.name,
+    this.type,
+    this.extension,
+    this.action,
+    this.data,
+    this.allowMultiple = false,
+  });
+}
+
+/// The Enum represents the MediaType of uri which as invoked the app.
+///
+/// * video
+/// * image
+enum MediaType { video, image }
+
+/// * Method which converts the string value to the MediaType
+/// * Used for converting the string from native code to dart type
+///
+/// Example:
+///  ```dart
+///   String actionString = 'video'
+///   MediaType type = mediaParser(actionString);
+///   print(type);
+///   ```
+/// Output:
+/// ```bash
+///  MediaType.video
+/// ```
+MediaType? mediaParser(String? mediaString) {
+  MediaType? type;
+
+  switch (mediaString) {
+    case 'video':
+      type = MediaType.video;
+      break;
+    case 'image':
+      type = MediaType.image;
+      break;
+  }
+  return type;
+}

--- a/mobile/apps/photos/plugins/media_extension/lib/media_extension_method_channel.dart
+++ b/mobile/apps/photos/plugins/media_extension/lib/media_extension_method_channel.dart
@@ -129,16 +129,10 @@ class MethodChannelMediaExtension extends MediaExtensionPlatform {
     if (defaultTargetPlatform != TargetPlatform.android) {
       return null;
     }
-
-    try {
-      return await methodChannel.invokeMethod<Uint8List>(
-        'readUriBytes',
-        <String, dynamic>{'uri': uri},
-      );
-    } on PlatformException catch (e) {
-      debugPrint(e.message);
-    }
-    return null;
+    return methodChannel.invokeMethod<Uint8List>(
+      'readUriBytes',
+      <String, dynamic>{'uri': uri},
+    );
   }
 
   @override

--- a/mobile/apps/photos/plugins/media_extension/lib/media_extension_method_channel.dart
+++ b/mobile/apps/photos/plugins/media_extension/lib/media_extension_method_channel.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:media_extension/media_extension_action_types.dart';
+import 'package:media_extension/media_extension_platform_interface.dart';
+
+/// An implementation of [MediaExtensionPlatform] that uses method channels.
+class MethodChannelMediaExtension extends MediaExtensionPlatform {
+  /// The method channel used to interact with the native platform.
+  @visibleForTesting
+  final methodChannel = const MethodChannel('media_extension');
+
+  final _intentActionController =
+      StreamController<MediaExtentionAction>.broadcast();
+  bool _hasMethodCallHandler = false;
+
+  void _ensureMethodCallHandler() {
+    if (_hasMethodCallHandler) {
+      return;
+    }
+    methodChannel.setMethodCallHandler((call) async {
+      if (call.method != 'getIntentAction') {
+        return;
+      }
+      _intentActionController.add(_parseIntentAction(call.arguments));
+    });
+    _hasMethodCallHandler = true;
+  }
+
+  MediaExtentionAction _parseIntentAction(dynamic args) {
+    final map = args is Map ? args : const <String, dynamic>{};
+    return MediaExtentionAction(
+      action: actionParser(map['action'] as String? ?? ''),
+      name: map['name'] as String?,
+      type: mediaParser(map['type'] as String?),
+      extension: map['extension'] as String?,
+      data: map['data'] as String?,
+      allowMultiple:
+          map['allowMultiple'] == true ||
+          map['allowMultiple']?.toString() == 'true',
+    );
+  }
+
+  /// This Method retrivies the platform version from native thread.
+  @override
+  Future<String?> getPlatformVersion() async {
+    final version = await methodChannel.invokeMethod<String>(
+      'getPlatformVersion',
+    );
+    return version;
+  }
+
+  /// This Method sends the selected Image's [uri] to the native thread.
+  /// from the Flutter thread to send results to apps
+  /// which can handle [ACTION_ATTACH_DATA] Intent of [mimeType] `images/*`.
+  @override
+  Future<bool> setAs(
+    String uri,
+    String mimeType, {
+    String title = 'Set as',
+  }) async {
+    try {
+      final result = await methodChannel.invokeMethod(
+        'setAs',
+        <String, dynamic>{'uri': uri, 'mimeType': mimeType, 'title': title},
+      );
+      if (result != null) return result as bool;
+    } on PlatformException catch (e) {
+      debugPrint(e.message);
+    }
+    return false;
+  }
+
+  /// This Method sends the selected Image's [uri] to the native thread.
+  /// from the Flutter thread to send results to apps
+  /// which can handle [ACTION_EDIT] Intent of [mimeType] `images/*`.
+  @override
+  Future<bool> edit(
+    String uri,
+    String mimeType, {
+    String title = 'Edit',
+  }) async {
+    try {
+      final result = await methodChannel.invokeMethod('edit', <String, dynamic>{
+        'uri': uri,
+        'mimeType': mimeType,
+        'title': title,
+      });
+      if (result != null) return result as bool;
+    } on PlatformException catch (e) {
+      debugPrint(e.message);
+    }
+    return false;
+  }
+
+  /// This Method sends the selected Image's [uri] to the native thread.
+  /// from the Flutter thread to send results
+  /// to apps which can handle [ACTION_VIEW] Intent of [mimeType] `images/*`.
+  @override
+  Future<bool> openWith(
+    String uri,
+    String mimeType, {
+    String title = 'Open With',
+  }) async {
+    try {
+      final result = await methodChannel.invokeMethod(
+        'openWith',
+        <String, dynamic>{'uri': uri, 'mimeType': mimeType, 'title': title},
+      );
+      if (result != null) return result as bool;
+    } on PlatformException catch (e) {
+      debugPrint(e.message);
+    }
+    return false;
+  }
+
+  /// This Method is triggered by the Native Thread which sends the [intentAction]
+  /// and [uri] information in a [HashMap] Structure to the Flutter thread.
+  @override
+  Future<MediaExtentionAction> getIntentAction() async {
+    _ensureMethodCallHandler();
+    final args = await methodChannel.invokeMethod('getIntentAction');
+    return _parseIntentAction(args);
+  }
+
+  @override
+  Future<Uint8List?> readUriBytes(String uri) async {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return null;
+    }
+
+    try {
+      return await methodChannel.invokeMethod<Uint8List>(
+        'readUriBytes',
+        <String, dynamic>{'uri': uri},
+      );
+    } on PlatformException catch (e) {
+      debugPrint(e.message);
+    }
+    return null;
+  }
+
+  @override
+  Stream<MediaExtentionAction> get intentActionStream {
+    _ensureMethodCallHandler();
+    return _intentActionController.stream;
+  }
+
+  /// This Method sends the selected Image's [uri] to the native thread.
+  /// from the Flutter thread to send results to the app
+  /// which invoked our app using [ACTION_PICK] INTENT.
+  @override
+  Future<void> setResult(String uri) async {
+    try {
+      await methodChannel.invokeMethod('setResult', {'uri': uri});
+    } on PlatformException catch (e) {
+      debugPrint(e.message);
+    }
+  }
+
+  /// This Method sends selected media [uris] to the native thread.
+  /// from the Flutter thread to send results to the app
+  /// which invoked our app using [ACTION_PICK] INTENT.
+  @override
+  Future<void> setResults(List<String> uris) async {
+    try {
+      await methodChannel.invokeMethod('setResults', {'uris': uris});
+    } on PlatformException catch (e) {
+      debugPrint(e.message);
+    }
+  }
+
+  /// This Method cancels the result to the app
+  /// which invoked our app using [ACTION_PICK] INTENT.
+  @override
+  Future<void> cancelResult() async {
+    try {
+      await methodChannel.invokeMethod('cancelResult');
+    } on PlatformException catch (e) {
+      debugPrint(e.message);
+    }
+  }
+}

--- a/mobile/apps/photos/plugins/media_extension/lib/media_extension_platform_interface.dart
+++ b/mobile/apps/photos/plugins/media_extension/lib/media_extension_platform_interface.dart
@@ -1,0 +1,89 @@
+import 'dart:typed_data';
+
+import 'package:media_extension/media_extension_action_types.dart';
+import 'package:media_extension/media_extension_method_channel.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+abstract class MediaExtensionPlatform extends PlatformInterface {
+  /// Constructs a MediaExtensionPlatform.
+  MediaExtensionPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static MediaExtensionPlatform _instance = MethodChannelMediaExtension();
+
+  /// The default instance of [MediaExtensionPlatform] to use.
+  ///
+  /// Defaults to [MethodChannelMediaExtension].
+  static MediaExtensionPlatform get instance => _instance;
+
+  /// Platform-specific implementations should set this with their own
+  /// platform-specific class that extends [MediaExtensionPlatform] when
+  /// they register themselves.
+  static set instance(MediaExtensionPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  /// abstract method for `getPlatformVersion` method.
+  Future<String?> getPlatformVersion() {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
+  /// abstract method for `setAs` method.
+  Future<bool> setAs(
+    String uri,
+    String mimeType, {
+    String title = 'Set as',
+  }) async {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
+  /// abstract method for `edit` method.
+  Future<bool> edit(
+    String uri,
+    String mimeType, {
+    String title = 'Edit',
+  }) async {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
+  /// abstract method `openWith` method.
+  Future<bool> openWith(
+    String uri,
+    String mimeType, {
+    String title = 'Open with',
+  }) async {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
+  /// abstract method `getIntentAction` method.
+  Future<MediaExtentionAction> getIntentAction() async {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
+  /// abstract method `readUriBytes` method.
+  Future<Uint8List?> readUriBytes(String uri) async {
+    throw UnimplementedError('readUriBytes() has not been implemented.');
+  }
+
+  /// abstract stream for warm intent actions received after startup.
+  Stream<MediaExtentionAction> get intentActionStream {
+    throw UnimplementedError('intentActionStream has not been implemented.');
+  }
+
+  /// abstract method `setResult` method.
+  Future<void> setResult(String uri) async {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
+  /// abstract method `setResults` method.
+  Future<void> setResults(List<String> uris) async {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
+  /// abstract method `cancelResult` method.
+  Future<void> cancelResult() async {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+}

--- a/mobile/apps/photos/plugins/media_extension/pubspec.yaml
+++ b/mobile/apps/photos/plugins/media_extension/pubspec.yaml
@@ -1,0 +1,24 @@
+name: media_extension
+description: Native gallery integration for Ente Photos
+version: 1.0.2
+publish_to: none
+
+resolution: workspace
+environment:
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  plugin_platform_interface: 2.1.8
+
+dev_dependencies:
+  flutter_lints: 6.0.0
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: io.ente.photos.media_extension
+        pluginClass: MediaExtensionPlugin

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -138,9 +138,7 @@ dependencies:
   logging: 1.3.0
   lottie: 3.3.1
   media_extension:
-    git:
-      url: https://github.com/ente/media_extension.git
-      ref: 7dfca297926ad113780e8151d58262bf5f8c8e9c
+    path: plugins/media_extension
   media_kit: 1.2.2
   media_kit_libs_video: 1.0.7
   media_kit_video: 2.0.0

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1600,15 +1600,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
-  media_extension:
-    dependency: transitive
-    description:
-      path: "."
-      ref: "7dfca297926ad113780e8151d58262bf5f8c8e9c"
-      resolved-ref: "7dfca297926ad113780e8151d58262bf5f8c8e9c"
-      url: "https://github.com/ente/media_extension.git"
-    source: git
-    version: "1.0.2"
   media_kit:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -12,6 +12,7 @@ workspace:
   - apps/photos/plugins/ente_crypto
   - apps/photos/plugins/ente_panorama_viewer
   - apps/photos/plugins/ente_photos_platform
+  - apps/photos/plugins/media_extension
   - packages/accounts
   - packages/account_deletion
   - packages/backup_exclusion


### PR DESCRIPTION
## Summary

- Inline the Android media extension plugin so Photos can classify URI read failures.
- Retry with bounded backoff while MediaStore finalizes newly captured photos.
- Fail immediately for deterministic errors such as the 100 MiB read limit.

After merging this, https://github.com/ente/media_extension can be archived