### PR TITLE
[mobile][photos] generate memory lane schedule on startup

### DIFF
--- a/mobile/apps/photos/lib/events/people_changed_event.dart
+++ b/mobile/apps/photos/lib/events/people_changed_event.dart
@@ -8,6 +8,7 @@ class PeopleChangedEvent extends Event {
   final PeopleEventType type;
   final String source;
   final PersonEntity? person;
+  final List<PersonEntity>? persons;
   final Set<String>? newClusterIDs;
 
   PeopleChangedEvent({
@@ -16,6 +17,7 @@ class PeopleChangedEvent extends Event {
     this.type = PeopleEventType.defaultType,
     this.source = "",
     this.person,
+    this.persons,
     this.newClusterIDs,
   });
 

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
@@ -60,6 +60,33 @@ class MemoryLaneCacheService {
     return cache[personId];
   }
 
+  Future<MemoryLanePersonTimeline?> getScheduledMemoriesStripTimeline() async {
+    final cache = await getCache();
+    final nowMicros = DateTime.now().microsecondsSinceEpoch;
+    MemoryLanePersonTimeline? currentTimeline;
+    int? currentBeginShowingAt;
+    for (final entry in cache.memoriesStripSchedule.entries) {
+      final timeline = cache.timelines[entry.key];
+      final schedule = entry.value;
+      final endShowingAt =
+          schedule.beginShowingAt +
+          MemoryLaneSchedule.displayDuration.inMicroseconds;
+      if (schedule.beginShowingAt > nowMicros ||
+          nowMicros >= endShowingAt ||
+          timeline == null ||
+          !timeline.isEligible ||
+          timeline.entries.isEmpty) {
+        continue;
+      }
+      if (currentBeginShowingAt == null ||
+          schedule.beginShowingAt > currentBeginShowingAt) {
+        currentTimeline = timeline;
+        currentBeginShowingAt = schedule.beginShowingAt;
+      }
+    }
+    return currentTimeline;
+  }
+
   Future<MemoryLaneComputeLogEntry?> getComputeLogEntry(String personId) async {
     final cache = await getCache();
     return cache.computeLog[personId];

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
@@ -6,7 +6,6 @@ import "package:logging/logging.dart";
 import "package:path/path.dart" as p;
 import "package:path_provider/path_provider.dart";
 import "package:photos/models/memory_lane/memory_lane_models.dart";
-import "package:photos/services/search_service.dart";
 import "package:synchronized/synchronized.dart";
 
 class MemoryLaneCacheService {
@@ -62,35 +61,23 @@ class MemoryLaneCacheService {
     return cache[personId];
   }
 
-  Future<MemoryLanePersonTimeline?> getScheduledMemoriesStripTimeline() async {
+  Future<MemoryLaneSchedule?> getCurrentMemoriesStripSchedule() async {
     final cache = await getCache();
     final nowMicros = DateTime.now().microsecondsSinceEpoch;
-    final timelineKey = maxBy(
-      cache.memoriesStripSchedule.entries.where((e) {
-        final timeline = cache.timelines[e.key];
-        final schedule = e.value;
+    return maxBy(
+      cache.memoriesStripSchedule.entries.where((entry) {
+        final timeline = cache.timelines[entry.key];
         final endShowingAt =
-            schedule.beginShowingAt +
+            entry.value.beginShowingAt +
             MemoryLaneSchedule.displayDuration.inMicroseconds;
-        final inWindow =
-            schedule.beginShowingAt <= nowMicros && nowMicros < endShowingAt;
-        return inWindow &&
+        return entry.value.beginShowingAt <= nowMicros &&
+            nowMicros < endShowingAt &&
             timeline != null &&
             timeline.isEligible &&
             timeline.entries.isNotEmpty;
       }),
       (entry) => entry.value.beginShowingAt,
-    )?.key;
-    final currentTimeline = cache.timelines[timelineKey];
-    if (currentTimeline == null) return null;
-    final hiddenFileIds = (await SearchService.instance.getHiddenFiles())
-        .map((f) => f.uploadedFileID)
-        .whereType<int>()
-        .toSet();
-    if (currentTimeline.entries.any((e) => hiddenFileIds.contains(e.fileId))) {
-      return null;
-    }
-    return currentTimeline;
+    )?.value;
   }
 
   Future<MemoryLaneComputeLogEntry?> getComputeLogEntry(String personId) async {

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
@@ -1,10 +1,12 @@
 import "dart:convert";
 import "dart:io";
 
+import "package:collection/collection.dart";
 import "package:logging/logging.dart";
 import "package:path/path.dart" as p;
 import "package:path_provider/path_provider.dart";
 import "package:photos/models/memory_lane/memory_lane_models.dart";
+import "package:photos/services/search_service.dart";
 import "package:synchronized/synchronized.dart";
 
 class MemoryLaneCacheService {
@@ -63,26 +65,30 @@ class MemoryLaneCacheService {
   Future<MemoryLanePersonTimeline?> getScheduledMemoriesStripTimeline() async {
     final cache = await getCache();
     final nowMicros = DateTime.now().microsecondsSinceEpoch;
-    MemoryLanePersonTimeline? currentTimeline;
-    int? currentBeginShowingAt;
-    for (final entry in cache.memoriesStripSchedule.entries) {
-      final timeline = cache.timelines[entry.key];
-      final schedule = entry.value;
-      final endShowingAt =
-          schedule.beginShowingAt +
-          MemoryLaneSchedule.displayDuration.inMicroseconds;
-      if (schedule.beginShowingAt > nowMicros ||
-          nowMicros >= endShowingAt ||
-          timeline == null ||
-          !timeline.isEligible ||
-          timeline.entries.isEmpty) {
-        continue;
-      }
-      if (currentBeginShowingAt == null ||
-          schedule.beginShowingAt > currentBeginShowingAt) {
-        currentTimeline = timeline;
-        currentBeginShowingAt = schedule.beginShowingAt;
-      }
+    final timelineKey = maxBy(
+      cache.memoriesStripSchedule.entries.where((e) {
+        final timeline = cache.timelines[e.key];
+        final schedule = e.value;
+        final endShowingAt =
+            schedule.beginShowingAt +
+            MemoryLaneSchedule.displayDuration.inMicroseconds;
+        final inWindow =
+            schedule.beginShowingAt <= nowMicros && nowMicros < endShowingAt;
+        return inWindow &&
+            timeline != null &&
+            timeline.isEligible &&
+            timeline.entries.isNotEmpty;
+      }),
+      (entry) => entry.value.beginShowingAt,
+    )?.key;
+    final currentTimeline = cache.timelines[timelineKey];
+    if (currentTimeline == null) return null;
+    final hiddenFileIds = (await SearchService.instance.getHiddenFiles())
+        .map((f) => f.uploadedFileID)
+        .whereType<int>()
+        .toSet();
+    if (currentTimeline.entries.any((e) => hiddenFileIds.contains(e.fileId))) {
+      return null;
     }
     return currentTimeline;
   }

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
@@ -1,7 +1,6 @@
 import "dart:convert";
 import "dart:io";
 
-import "package:collection/collection.dart";
 import "package:logging/logging.dart";
 import "package:path/path.dart" as p;
 import "package:path_provider/path_provider.dart";
@@ -64,20 +63,20 @@ class MemoryLaneCacheService {
   Future<MemoryLaneSchedule?> getCurrentMemoriesStripSchedule() async {
     final cache = await getCache();
     final nowMicros = DateTime.now().microsecondsSinceEpoch;
-    return maxBy(
-      cache.memoriesStripSchedule.entries.where((entry) {
-        final timeline = cache.timelines[entry.key];
-        final endShowingAt =
-            entry.value.beginShowingAt +
-            MemoryLaneSchedule.displayDuration.inMicroseconds;
-        return entry.value.beginShowingAt <= nowMicros &&
-            nowMicros < endShowingAt &&
-            timeline != null &&
-            timeline.isEligible &&
-            timeline.entries.isNotEmpty;
-      }),
-      (entry) => entry.value.beginShowingAt,
-    )?.value;
+    for (final entry in cache.memoriesStripSchedule.entries) {
+      final timeline = cache.timelines[entry.key];
+      final endShowingAt =
+          entry.value.beginShowingAt +
+          MemoryLaneSchedule.displayDuration.inMicroseconds;
+      if (entry.value.beginShowingAt <= nowMicros &&
+          nowMicros < endShowingAt &&
+          timeline != null &&
+          timeline.isEligible &&
+          timeline.entries.isNotEmpty) {
+        return entry.value;
+      }
+    }
+    return null;
   }
 
   Future<MemoryLaneComputeLogEntry?> getComputeLogEntry(String personId) async {

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
@@ -70,6 +70,30 @@ class MemoryLaneCacheService {
     return Map<String, MemoryLaneComputeLogEntry>.from(cache.computeLog);
   }
 
+  Future<void> updateMemoriesStripSchedule(
+    Set<String> invalid,
+    MemoryLaneSchedule? schedule,
+  ) async {
+    if (invalid.isEmpty && schedule == null) {
+      return;
+    }
+    await _ensureInitialized();
+    await _lock.synchronized(() async {
+      final currentCache = await _loadCacheUnsafe();
+      var updatedCache = currentCache.copyWithoutMemoriesStripScheduleEntries(
+        invalid,
+      );
+      if (schedule != null) {
+        updatedCache = updatedCache.copyWithMemoriesStripScheduleEntry(
+          schedule.personID,
+          schedule,
+        );
+      }
+      _cache = updatedCache;
+      await _writeCacheUnsafe();
+    });
+  }
+
   Future<void> upsertTimelineAndLog(
     MemoryLanePersonTimeline timeline,
     MemoryLaneComputeLogEntry log,

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_cache_service.dart
@@ -113,6 +113,18 @@ class MemoryLaneCacheService {
     });
   }
 
+  Future<void> removeMemoriesStripSchedule(String personId) async {
+    await _ensureInitialized();
+    await _lock.synchronized(() async {
+      final currentCache = await _loadCacheUnsafe();
+      if (!currentCache.memoriesStripSchedule.containsKey(personId)) {
+        return;
+      }
+      _cache = currentCache.copyWithoutMemoriesStripScheduleEntries({personId});
+      await _writeCacheUnsafe();
+    });
+  }
+
   Future<void> upsertTimelineAndLog(
     MemoryLanePersonTimeline timeline,
     MemoryLaneComputeLogEntry log,

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -116,7 +116,11 @@ class MemoryLaneService {
           assigned.add(cluster.id);
         }
       }
-      _topNClusters = await _mlDataDB.getClustersForMemoryLane(assigned);
+      try {
+        _topNClusters = await _mlDataDB.getClustersForMemoryLane(assigned);
+      } catch (e, s) {
+        _logger.severe("getClustersForMemoryLane failed:", e, s);
+      }
     }
     if (flagService.internalUser) {
       try {

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -82,13 +82,6 @@ class MemoryLaneService {
       Bus.instance.on<MLConsentChangedEvent>().listen(_handleMlConsentChange);
       _scheduleStartupBackfill();
       _initialized = true;
-      if (flagService.internalUser) {
-        try {
-          await _scheduleTimelinesForMemoriesStrip();
-        } catch (e, s) {
-          _logger.severe("_scheduleTimelinesForMemoriesStrip failed:", e, s);
-        }
-      }
       await _queueFullRecompute();
     } catch (e, s) {
       _logger.severe("Initialization failed", e, s);
@@ -115,13 +108,6 @@ class MemoryLaneService {
         return;
       }
       persons.addAll(await PersonService.instance.getPersons());
-      for (final person in persons) {
-        if (person.data.isIgnored) {
-          await _invalidateTimeline(person.remoteID);
-          continue;
-        }
-        schedulePersonRecompute(person.remoteID, force: force);
-      }
     }
     if (flagService.internalUser) {
       final assigned = <String>{};
@@ -131,6 +117,24 @@ class MemoryLaneService {
         }
       }
       _topNClusters = await _mlDataDB.getClustersForMemoryLane(assigned);
+    }
+    if (flagService.internalUser) {
+      try {
+        await _scheduleTimelinesForMemoriesStrip();
+      } catch (e, s) {
+        _logger.severe("_scheduleTimelinesForMemoriesStrip failed:", e, s);
+      }
+    }
+    if (!isLocalGalleryMode) {
+      for (final person in persons) {
+        if (person.data.isIgnored) {
+          await _invalidateTimeline(person.remoteID);
+          continue;
+        }
+        schedulePersonRecompute(person.remoteID, force: force);
+      }
+    }
+    if (flagService.internalUser) {
       final cache = await _cacheService.getCache();
       final List<Future<void>> tasks = [];
       for (final timeline in cache.allTimelines) {

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -82,6 +82,9 @@ class MemoryLaneService {
       Bus.instance.on<MLConsentChangedEvent>().listen(_handleMlConsentChange);
       _scheduleStartupBackfill();
       _initialized = true;
+      if (flagService.internalUser) {
+        await _scheduleTimelinesForMemoriesStrip();
+      }
       await _queueFullRecompute();
     } catch (e, s) {
       _logger.severe("Initialization failed", e, s);
@@ -896,6 +899,69 @@ class MemoryLaneService {
     );
     return Map.fromEntries(
       files.map((file) => MapEntry(localIdToId[file.localID]!, file)),
+    );
+  }
+
+  Future<void> _scheduleTimelinesForMemoriesStrip() async {
+    final scheduleWindowMs = MemoryLaneSchedule.displayDuration.inMicroseconds;
+    final cooldownMs = const Duration(days: 30).inMicroseconds;
+    final cache = await _cacheService.getCache();
+    final nowMicros = DateTime.now().microsecondsSinceEpoch;
+
+    final invalid = <String>{};
+    for (final entry in cache.memoriesStripSchedule.entries) {
+      final timeline = cache.timelines[entry.key];
+      final isInCooldown = nowMicros - entry.value.beginShowingAt < cooldownMs;
+      if (timeline == null ||
+          !timeline.isEligible ||
+          timeline.entries.isEmpty ||
+          !isInCooldown) {
+        invalid.add(entry.key);
+      }
+    }
+
+    final valid = cache.memoriesStripSchedule.entries
+        .where((entry) => !invalid.contains(entry.key))
+        .toList();
+    final alreadyScheduledAhead = valid.any(
+      (s) => s.value.beginShowingAt >= nowMicros + scheduleWindowMs,
+    );
+    if (alreadyScheduledAhead) {
+      await _cacheService.updateMemoriesStripSchedule(invalid, null);
+      return;
+    }
+
+    final timelines = cache.allTimelines.toList()..shuffle();
+    final timeline = timelines.firstWhereOrNull(
+      (t) =>
+          t.isEligible &&
+          t.entries.isNotEmpty &&
+          (!cache.memoriesStripSchedule.containsKey(t.personId) ||
+              invalid.contains(t.personId)),
+    );
+    if (timeline == null) {
+      await _cacheService.updateMemoriesStripSchedule(invalid, null);
+      return;
+    }
+
+    final newBeginShowingAt = valid
+        .map((entry) => entry.value.beginShowingAt + scheduleWindowMs)
+        .followedBy([nowMicros])
+        .max;
+    await _cacheService.updateMemoriesStripSchedule(
+      invalid,
+      MemoryLaneSchedule(
+        personID: timeline.personId,
+        isCluster: timeline.isCluster,
+        beginShowingAt: newBeginShowingAt,
+      ),
+    );
+
+    unawaited(
+      ensureTimelineReachability(
+        timeline.personId,
+        isCluster: timeline.isCluster,
+      ),
     );
   }
 }

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -109,10 +109,6 @@ class MemoryLaneService {
       }
       persons.addAll(await PersonService.instance.getPersons());
     }
-    final hiddenFromMemoriesPersonIds = persons
-        .where((person) => person.data.hideFromMemories)
-        .map((person) => person.remoteID)
-        .toSet();
     if (flagService.internalUser) {
       final assigned = <String>{};
       for (final person in persons) {
@@ -128,7 +124,7 @@ class MemoryLaneService {
     }
     if (flagService.internalUser) {
       try {
-        await _scheduleTimelinesForMemoriesStrip(hiddenFromMemoriesPersonIds);
+        await _scheduleTimelinesForMemoriesStrip();
       } catch (e, s) {
         _logger.severe("_scheduleTimelinesForMemoriesStrip failed:", e, s);
       }
@@ -238,29 +234,23 @@ class MemoryLaneService {
     if (timeline == null || timeline.entries.isEmpty) {
       return timeline;
     }
-
-    final hiddenFiles = await SearchService.instance.getHiddenFiles();
-    final hiddenFileIds = hiddenFiles
-        .map((e) => e.uploadedFileID)
+    final hiddenFileIds = (await SearchService.instance.getHiddenFiles())
+        .map((file) => file.uploadedFileID)
         .whereType<int>()
         .toSet();
-    final containsHiddenEntry = timeline.entries.any(
-      (entry) => hiddenFileIds.contains(entry.fileId),
-    );
-    if (!containsHiddenEntry) {
-      if (timeline.isEligible && !await _areTimelineFaceCropsCached(timeline)) {
-        _logger.info("Missing face crops for $personId");
-        _queueTimelineCropReadiness(personId, isCluster: isCluster);
-        await _refreshReadyPersonIds();
-        return null;
-      }
-      return timeline;
+    if (timeline.entries.any((entry) => hiddenFileIds.contains(entry.fileId))) {
+      _logger.info("Removing timeline with hidden files for $personId");
+      await _invalidateTimeline(personId);
+      schedulePersonRecompute(personId, isCluster: isCluster, force: true);
+      return null;
     }
-
-    _logger.info("Removing timeline with hidden files for $personId");
-    await _invalidateTimeline(personId);
-    schedulePersonRecompute(personId, isCluster: isCluster, force: true);
-    return null;
+    if (timeline.isEligible && !await _areTimelineFaceCropsCached(timeline)) {
+      _logger.info("Missing face crops for $personId");
+      _queueTimelineCropReadiness(personId, isCluster: isCluster);
+      await _refreshReadyPersonIds();
+      return null;
+    }
+    return timeline;
   }
 
   Future<MemoryLanePersonTimeline?> getScheduledMemoriesStripTimeline() async {
@@ -271,14 +261,28 @@ class MemoryLaneService {
     if (schedule == null) {
       return null;
     }
-    if (!schedule.isCluster) {
-      if (!PersonService.isInitialized) return null;
-      final person = await PersonService.instance.getPerson(schedule.personID);
-      if (person?.data.hideFromMemories ?? false) return null;
-    }
-
     final timeline = await _cacheService.getTimeline(schedule.personID);
     if (timeline == null || timeline.entries.isEmpty) {
+      return null;
+    }
+    if (!schedule.isCluster) {
+      if (!PersonService.isInitialized) {
+        return null;
+      }
+      final person = await PersonService.instance.getPerson(schedule.personID);
+      if (person == null) {
+        await _invalidateTimeline(schedule.personID);
+        return null;
+      }
+      if (person.data.isIgnored || person.data.hideFromMemories) {
+        return null;
+      }
+    }
+    final hiddenFileIds = (await SearchService.instance.getHiddenFiles())
+        .map((file) => file.uploadedFileID)
+        .whereType<int>()
+        .toSet();
+    if (timeline.entries.any((entry) => hiddenFileIds.contains(entry.fileId))) {
       return null;
     }
 
@@ -953,9 +957,7 @@ class MemoryLaneService {
     );
   }
 
-  Future<void> _scheduleTimelinesForMemoriesStrip(
-    Set<String> hiddenFromMemoriesPersonIds,
-  ) async {
+  Future<void> _scheduleTimelinesForMemoriesStrip() async {
     if (!isFeatureEnabled) {
       return;
     }
@@ -971,11 +973,9 @@ class MemoryLaneService {
       final isInCooldown =
           nowMicros - entry.value.beginShowingAt < cooldownMicros;
       if (timeline == null ||
-          (timeline.isCluster && !_topNClusters.contains(timeline.personId)) ||
-          (!timeline.isCluster &&
-              hiddenFromMemoriesPersonIds.contains(timeline.personId)) ||
           !timeline.isEligible ||
           timeline.entries.isEmpty ||
+          (timeline.isCluster && !_topNClusters.contains(timeline.personId)) ||
           !isInCooldown) {
         invalid.add(entry.key);
       }
@@ -1003,7 +1003,6 @@ class MemoryLaneService {
           t.isEligible &&
           t.entries.isNotEmpty &&
           (!t.isCluster || _topNClusters.contains(t.personId)) &&
-          (t.isCluster || !hiddenFromMemoriesPersonIds.contains(t.personId)) &&
           (!cache.memoriesStripSchedule.containsKey(t.personId) ||
               invalid.contains(t.personId)),
     );

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -83,7 +83,11 @@ class MemoryLaneService {
       _scheduleStartupBackfill();
       _initialized = true;
       if (flagService.internalUser) {
-        await _scheduleTimelinesForMemoriesStrip();
+        try {
+          await _scheduleTimelinesForMemoriesStrip();
+        } catch (e, s) {
+          _logger.severe("_scheduleTimelinesForMemoriesStrip failed:", e, s);
+        }
       }
       await _queueFullRecompute();
     } catch (e, s) {
@@ -906,15 +910,17 @@ class MemoryLaneService {
     if (!isFeatureEnabled) {
       return;
     }
-    final scheduleWindowMs = MemoryLaneSchedule.displayDuration.inMicroseconds;
-    final cooldownMs = const Duration(days: 30).inMicroseconds;
+    final scheduleWindowMicros =
+        MemoryLaneSchedule.displayDuration.inMicroseconds;
+    final cooldownMicros = const Duration(days: 30).inMicroseconds;
     final cache = await _cacheService.getCache();
     final nowMicros = DateTime.now().microsecondsSinceEpoch;
 
     final invalid = <String>{};
     for (final entry in cache.memoriesStripSchedule.entries) {
       final timeline = cache.timelines[entry.key];
-      final isInCooldown = nowMicros - entry.value.beginShowingAt < cooldownMs;
+      final isInCooldown =
+          nowMicros - entry.value.beginShowingAt < cooldownMicros;
       if (timeline == null ||
           !timeline.isEligible ||
           timeline.entries.isEmpty ||
@@ -927,7 +933,7 @@ class MemoryLaneService {
         .where((entry) => !invalid.contains(entry.key))
         .toList();
     final alreadyScheduledAhead = valid.any(
-      (s) => s.value.beginShowingAt >= nowMicros + scheduleWindowMs,
+      (s) => s.value.beginShowingAt >= nowMicros + scheduleWindowMicros,
     );
     if (alreadyScheduledAhead) {
       await _cacheService.updateMemoriesStripSchedule(invalid, null);
@@ -948,7 +954,7 @@ class MemoryLaneService {
     }
 
     final newBeginShowingAt = valid
-        .map((entry) => entry.value.beginShowingAt + scheduleWindowMs)
+        .map((entry) => entry.value.beginShowingAt + scheduleWindowMicros)
         .followedBy([nowMicros])
         .max;
     await _cacheService.updateMemoriesStripSchedule(

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -271,17 +271,31 @@ class MemoryLaneService {
     if (schedule == null) {
       return null;
     }
-    if (schedule.isCluster) {
-      return getTimeline(schedule.personID, isCluster: schedule.isCluster);
+    if (!schedule.isCluster) {
+      if (!PersonService.isInitialized) return null;
+      final person = await PersonService.instance.getPerson(schedule.personID);
+      if (person?.data.hideFromMemories ?? false) return null;
     }
-    if (!PersonService.isInitialized) {
+
+    final timeline = await _cacheService.getTimeline(schedule.personID);
+    if (timeline == null || timeline.entries.isEmpty) {
       return null;
     }
-    final person = await PersonService.instance.getPerson(schedule.personID);
-    if (person?.data.hideFromMemories ?? false) {
+
+    if (!await areFullFaceCropsCached({
+      minBy(timeline.entries, (entry) => entry.creationTimeMicros)!.faceId,
+      maxBy(timeline.entries, (entry) => entry.creationTimeMicros)!.faceId,
+    }, useTempCache: false)) {
+      _logger.info(
+        "Missing memories strip face crops for ${schedule.personID}",
+      );
+      _queueTimelineCropReadiness(
+        schedule.personID,
+        isCluster: schedule.isCluster,
+      );
       return null;
     }
-    return getTimeline(schedule.personID, isCluster: schedule.isCluster);
+    return timeline;
   }
 
   bool hasReadyTimelineSync(String personId, {bool isCluster = false}) {

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -926,6 +926,7 @@ class MemoryLaneService {
       final isInCooldown =
           nowMicros - entry.value.beginShowingAt < cooldownMicros;
       if (timeline == null ||
+          (timeline.isCluster && !_topNClusters.contains(timeline.personId)) ||
           !timeline.isEligible ||
           timeline.entries.isEmpty ||
           !isInCooldown) {
@@ -949,6 +950,7 @@ class MemoryLaneService {
       (t) =>
           t.isEligible &&
           t.entries.isNotEmpty &&
+          (!t.isCluster || _topNClusters.contains(t.personId)) &&
           (!cache.memoriesStripSchedule.containsKey(t.personId) ||
               invalid.contains(t.personId)),
     );

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -129,7 +129,7 @@ class MemoryLaneService {
     }
     if (flagService.internalUser) {
       try {
-        await _scheduleTimelinesForMemoriesStrip();
+        await _scheduleTimelinesForMemoriesStrip(persons);
       } catch (e, s) {
         _logger.severe("_scheduleTimelinesForMemoriesStrip failed:", e, s);
       }
@@ -955,7 +955,9 @@ class MemoryLaneService {
     );
   }
 
-  Future<void> _scheduleTimelinesForMemoriesStrip() async {
+  Future<void> _scheduleTimelinesForMemoriesStrip(
+    List<PersonEntity> persons,
+  ) async {
     if (!isFeatureEnabled) {
       return;
     }
@@ -964,12 +966,20 @@ class MemoryLaneService {
     final cooldownMicros = const Duration(days: 30).inMicroseconds;
     final cache = await _cacheService.getCache();
     final nowMicros = DateTime.now().microsecondsSinceEpoch;
+    final eligiblePersonIds = persons
+        .where(
+          (person) => !person.data.isIgnored && !person.data.hideFromMemories,
+        )
+        .map((person) => person.remoteID)
+        .toSet();
 
     final invalid = <String>{};
     for (final entry in cache.memoriesStripSchedule.entries) {
       final isInCooldown =
           nowMicros - entry.value.beginShowingAt < cooldownMicros;
-      if ((entry.value.isCluster && !_topNClusters.contains(entry.key)) ||
+      if ((entry.value.isCluster
+              ? !_topNClusters.contains(entry.key)
+              : !eligiblePersonIds.contains(entry.key)) ||
           !isInCooldown) {
         invalid.add(entry.key);
       }
@@ -991,7 +1001,9 @@ class MemoryLaneService {
       (t) =>
           t.isEligible &&
           t.entries.isNotEmpty &&
-          (!t.isCluster || _topNClusters.contains(t.personId)) &&
+          (t.isCluster
+              ? _topNClusters.contains(t.personId)
+              : eligiblePersonIds.contains(t.personId)) &&
           (!cache.memoriesStripSchedule.containsKey(t.personId) ||
               invalid.contains(t.personId)),
     );

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -962,13 +962,9 @@ class MemoryLaneService {
 
     final invalid = <String>{};
     for (final entry in cache.memoriesStripSchedule.entries) {
-      final timeline = cache.timelines[entry.key];
       final isInCooldown =
           nowMicros - entry.value.beginShowingAt < cooldownMicros;
-      if (timeline == null ||
-          !timeline.isEligible ||
-          timeline.entries.isEmpty ||
-          (timeline.isCluster && !_topNClusters.contains(timeline.personId)) ||
+      if ((entry.value.isCluster && !_topNClusters.contains(entry.key)) ||
           !isInCooldown) {
         invalid.add(entry.key);
       }

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -120,6 +120,11 @@ class MemoryLaneService {
         _topNClusters = await _mlDataDB.getClustersForMemoryLane(assigned);
       } catch (e, s) {
         _logger.severe("getClustersForMemoryLane failed:", e, s);
+        final cache = await _cacheService.getCache();
+        _topNClusters = cache.timelines.entries
+            .where((entry) => entry.value.isCluster)
+            .map((entry) => entry.key)
+            .toSet();
       }
     }
     if (flagService.internalUser) {

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -903,6 +903,9 @@ class MemoryLaneService {
   }
 
   Future<void> _scheduleTimelinesForMemoriesStrip() async {
+    if (!isFeatureEnabled) {
+      return;
+    }
     final scheduleWindowMs = MemoryLaneSchedule.displayDuration.inMicroseconds;
     final cooldownMs = const Duration(days: 30).inMicroseconds;
     final cache = await _cacheService.getCache();

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -984,15 +984,10 @@ class MemoryLaneService {
     final valid = cache.memoriesStripSchedule.entries
         .where((entry) => !invalid.contains(entry.key))
         .toList();
-    final hasCurrentSchedule = valid.any((entry) {
-      final endShowingAt = entry.value.beginShowingAt + scheduleWindowMicros;
-      return entry.value.beginShowingAt <= nowMicros &&
-          nowMicros < endShowingAt;
-    });
     final alreadyScheduledAhead = valid.any(
       (s) => s.value.beginShowingAt >= nowMicros + scheduleWindowMicros,
     );
-    if (hasCurrentSchedule && alreadyScheduledAhead) {
+    if (alreadyScheduledAhead) {
       await _cacheService.updateMemoriesStripSchedule(invalid, null);
       return;
     }
@@ -1011,15 +1006,10 @@ class MemoryLaneService {
       return;
     }
 
-    final int newBeginShowingAt;
-    if (hasCurrentSchedule) {
-      newBeginShowingAt = valid
-          .map((entry) => entry.value.beginShowingAt + scheduleWindowMicros)
-          .followedBy([nowMicros])
-          .max;
-    } else {
-      newBeginShowingAt = nowMicros;
-    }
+    final newBeginShowingAt = valid
+        .map((entry) => entry.value.beginShowingAt + scheduleWindowMicros)
+        .followedBy([nowMicros])
+        .max;
     await _cacheService.updateMemoriesStripSchedule(
       invalid,
       MemoryLaneSchedule(

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -109,6 +109,10 @@ class MemoryLaneService {
       }
       persons.addAll(await PersonService.instance.getPersons());
     }
+    final hiddenFromMemoriesPersonIds = persons
+        .where((person) => person.data.hideFromMemories)
+        .map((person) => person.remoteID)
+        .toSet();
     if (flagService.internalUser) {
       final assigned = <String>{};
       for (final person in persons) {
@@ -124,7 +128,7 @@ class MemoryLaneService {
     }
     if (flagService.internalUser) {
       try {
-        await _scheduleTimelinesForMemoriesStrip();
+        await _scheduleTimelinesForMemoriesStrip(hiddenFromMemoriesPersonIds);
       } catch (e, s) {
         _logger.severe("_scheduleTimelinesForMemoriesStrip failed:", e, s);
       }
@@ -257,6 +261,27 @@ class MemoryLaneService {
     await _invalidateTimeline(personId);
     schedulePersonRecompute(personId, isCluster: isCluster, force: true);
     return null;
+  }
+
+  Future<MemoryLanePersonTimeline?> getScheduledMemoriesStripTimeline() async {
+    if (!isFeatureEnabled) {
+      return null;
+    }
+    final schedule = await _cacheService.getCurrentMemoriesStripSchedule();
+    if (schedule == null) {
+      return null;
+    }
+    if (schedule.isCluster) {
+      return getTimeline(schedule.personID, isCluster: schedule.isCluster);
+    }
+    if (!PersonService.isInitialized) {
+      return null;
+    }
+    final person = await PersonService.instance.getPerson(schedule.personID);
+    if (person?.data.hideFromMemories ?? false) {
+      return null;
+    }
+    return getTimeline(schedule.personID, isCluster: schedule.isCluster);
   }
 
   bool hasReadyTimelineSync(String personId, {bool isCluster = false}) {
@@ -914,7 +939,9 @@ class MemoryLaneService {
     );
   }
 
-  Future<void> _scheduleTimelinesForMemoriesStrip() async {
+  Future<void> _scheduleTimelinesForMemoriesStrip(
+    Set<String> hiddenFromMemoriesPersonIds,
+  ) async {
     if (!isFeatureEnabled) {
       return;
     }
@@ -931,6 +958,8 @@ class MemoryLaneService {
           nowMicros - entry.value.beginShowingAt < cooldownMicros;
       if (timeline == null ||
           (timeline.isCluster && !_topNClusters.contains(timeline.personId)) ||
+          (!timeline.isCluster &&
+              hiddenFromMemoriesPersonIds.contains(timeline.personId)) ||
           !timeline.isEligible ||
           timeline.entries.isEmpty ||
           !isInCooldown) {
@@ -941,10 +970,15 @@ class MemoryLaneService {
     final valid = cache.memoriesStripSchedule.entries
         .where((entry) => !invalid.contains(entry.key))
         .toList();
+    final hasCurrentSchedule = valid.any((entry) {
+      final endShowingAt = entry.value.beginShowingAt + scheduleWindowMicros;
+      return entry.value.beginShowingAt <= nowMicros &&
+          nowMicros < endShowingAt;
+    });
     final alreadyScheduledAhead = valid.any(
       (s) => s.value.beginShowingAt >= nowMicros + scheduleWindowMicros,
     );
-    if (alreadyScheduledAhead) {
+    if (hasCurrentSchedule && alreadyScheduledAhead) {
       await _cacheService.updateMemoriesStripSchedule(invalid, null);
       return;
     }
@@ -955,6 +989,7 @@ class MemoryLaneService {
           t.isEligible &&
           t.entries.isNotEmpty &&
           (!t.isCluster || _topNClusters.contains(t.personId)) &&
+          (t.isCluster || !hiddenFromMemoriesPersonIds.contains(t.personId)) &&
           (!cache.memoriesStripSchedule.containsKey(t.personId) ||
               invalid.contains(t.personId)),
     );
@@ -963,10 +998,15 @@ class MemoryLaneService {
       return;
     }
 
-    final newBeginShowingAt = valid
-        .map((entry) => entry.value.beginShowingAt + scheduleWindowMicros)
-        .followedBy([nowMicros])
-        .max;
+    final int newBeginShowingAt;
+    if (hasCurrentSchedule) {
+      newBeginShowingAt = valid
+          .map((entry) => entry.value.beginShowingAt + scheduleWindowMicros)
+          .followedBy([nowMicros])
+          .max;
+    } else {
+      newBeginShowingAt = nowMicros;
+    }
     await _cacheService.updateMemoriesStripSchedule(
       invalid,
       MemoryLaneSchedule(

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -287,16 +287,9 @@ class MemoryLaneService {
     }
 
     if (!await areFullFaceCropsCached({
-      minBy(timeline.entries, (entry) => entry.creationTimeMicros)!.faceId,
-      maxBy(timeline.entries, (entry) => entry.creationTimeMicros)!.faceId,
+      timeline.entries.first.faceId,
+      timeline.entries.last.faceId,
     }, useTempCache: false)) {
-      _logger.info(
-        "Missing memories strip face crops for ${schedule.personID}",
-      );
-      _queueTimelineCropReadiness(
-        schedule.personID,
-        isCluster: schedule.isCluster,
-      );
       return null;
     }
     return timeline;

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -985,9 +985,9 @@ class MemoryLaneService {
       }
     }
 
-    final valid = cache.memoriesStripSchedule.entries
-        .where((entry) => !invalid.contains(entry.key))
-        .toList();
+    final valid = cache.memoriesStripSchedule.entries.where(
+      (entry) => !invalid.contains(entry.key),
+    );
     final alreadyScheduledAhead = valid.any(
       (s) => s.value.beginShowingAt >= nowMicros + scheduleWindowMicros,
     );

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -428,6 +428,13 @@ class MemoryLaneService {
     }
     if (person.data.isIgnored) {
       await _invalidateTimeline(person.remoteID);
+      for (final cluster
+          in person.data.assigned
+              .map((c) => c.id)
+              .followedBy(event.newClusterIDs ?? [])) {
+        if (!_topNClusters.contains(cluster)) continue;
+        await _invalidateTimeline(cluster);
+      }
       return;
     }
     final logEntry = await _cacheService.getComputeLogEntry(person.remoteID);

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -420,11 +420,32 @@ class MemoryLaneService {
   }
 
   Future<void> _processPeopleChange(PeopleChangedEvent event) async {
+    final persons = event.persons;
+    if (persons != null) {
+      final hiddenTimelineIds = <String>{
+        for (final person in persons)
+          if (person.data.hideFromMemories) ...{
+            person.remoteID,
+            ...person.data.assigned.map((cluster) => cluster.id),
+          },
+      };
+      await _cacheService.updateMemoriesStripSchedule(hiddenTimelineIds, null);
+      return;
+    }
     final person = event.person;
     if (person == null) {
       _logger.warning("${event.type.name} event missing person");
       _scheduleStartupBackfill();
       return;
+    }
+    if (person.data.hideFromMemories) {
+      for (final id in {
+        person.remoteID,
+        ...person.data.assigned.map((cluster) => cluster.id),
+        ...?event.newClusterIDs,
+      }) {
+        await _cacheService.removeMemoriesStripSchedule(id);
+      }
     }
     if (person.data.isIgnored) {
       await _invalidateTimeline(person.remoteID);

--- a/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
+++ b/mobile/apps/photos/lib/services/memory_lane/memory_lane_service.dart
@@ -122,7 +122,11 @@ class MemoryLaneService {
         _logger.severe("getClustersForMemoryLane failed:", e, s);
         final cache = await _cacheService.getCache();
         _topNClusters = cache.timelines.entries
-            .where((entry) => entry.value.isCluster)
+            .where(
+              (entry) =>
+                  entry.value.isCluster &&
+                  !assigned.contains(entry.value.personId),
+            )
             .map((entry) => entry.key)
             .toSet();
       }

--- a/mobile/apps/photos/lib/ui/viewer/actions/people_selection_action_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/actions/people_selection_action_widget.dart
@@ -382,23 +382,26 @@ class _PeopleSelectionActionWidgetState
   }
 
   Future<void> _updateHideFromMemoriesState(bool shouldHide) async {
+    final updatedPersons = <PersonEntity>[];
     try {
       final personMap = await personEntitiesMapFuture;
       final selectedPersonIds = _getSelectedPersonIds(personMap);
-      if (selectedPersonIds.isEmpty) return;
       for (final personID in selectedPersonIds) {
         final person = personMap[personID];
         if (person == null || person.data.name.isEmpty) continue;
         if (person.data.hideFromMemories == shouldHide) continue;
-        await PersonService.instance.updateAttributes(
+        final updatedPerson = await PersonService.instance.updateAttributes(
           person.remoteID,
           hideFromMemories: shouldHide,
         );
+        updatedPersons.add(updatedPerson);
       }
-      Bus.instance.fire(PeopleChangedEvent());
     } catch (e, s) {
       _logger.severe('Failed to update hide from memories state', e, s);
     } finally {
+      if (updatedPersons.isNotEmpty) {
+        Bus.instance.fire(PeopleChangedEvent(persons: updatedPersons));
+      }
       widget.selectedPeople.clearAll();
     }
   }


### PR DESCRIPTION
## Summary

- generate and persist a memories-strip schedule on startup for eligible person and cluster timelines
- expose the currently scheduled timeline with feature, visibility, hidden-file, and face-crop validation
- invalidate unusable schedule entries and retain a 30-day cooldown before rescheduling a timeline

## Scope

This PR only appends to the existing valid schedule when the future scheduling horizon needs another entry. If the current entry becomes invalid while a future entry still exists, repairing the resulting gap or rebuilding the schedule is intentionally out of scope.
