### PR TITLE
[mobile][photos] Record and skip repeated ML failures

### DIFF
--- a/mobile/apps/photos/lib/db/ml/base.dart
+++ b/mobile/apps/photos/lib/db/ml/base.dart
@@ -70,6 +70,7 @@ abstract class IMLDataDB<T> {
   Future<int> getTotalFaceCount();
   Future<int> getErroredFaceCount();
   Future<Set<T>> getErroredFileIDs();
+  Future<Set<T>> getFileIDsWithErrorResults(List<T> fileIDs);
   Future<void> deleteFaceIndexForFiles(List<T> fileIDs);
   Future<void> deleteUnclusteredFaceIndexForFiles(List<T> fileIDs);
   Future<int> getClusteredOrFacelessFileCount();

--- a/mobile/apps/photos/lib/db/ml/base.dart
+++ b/mobile/apps/photos/lib/db/ml/base.dart
@@ -70,6 +70,7 @@ abstract class IMLDataDB<T> {
   Future<int> getTotalFaceCount();
   Future<int> getErroredFaceCount();
   Future<Set<T>> getErroredFileIDs();
+  Future<void> pruneResolvedFaceErrorResults(List<T> fileIDs);
   Future<Set<T>> getFileIDsWithErrorResults(List<T> fileIDs);
   Future<void> deleteFaceIndexForFiles(List<T> fileIDs);
   Future<void> deleteUnclusteredFaceIndexForFiles(List<T> fileIDs);

--- a/mobile/apps/photos/lib/db/ml/db.dart
+++ b/mobile/apps/photos/lib/db/ml/db.dart
@@ -1242,6 +1242,32 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
   }
 
   @override
+  Future<Set<int>> getFileIDsWithErrorResults(List<int> fileIDs) async {
+    if (fileIDs.isEmpty) return {};
+    final db = await asyncDB;
+    final result = <int>{};
+    const chunkSize = _maxSqlBindParamsPerQuery ~/ 3;
+    for (final chunk in fileIDs.chunks(chunkSize)) {
+      final placeholders = List.filled(chunk.length, '?').join(', ');
+      final rows = await db.getAll(
+        '''
+        SELECT $fileIDColumn FROM $facesTable
+        WHERE $fileIDColumn IN ($placeholders) AND $faceScore < 0
+        UNION
+        SELECT $fileIDColumn FROM $clipTable
+        WHERE $fileIDColumn IN ($placeholders) AND LENGTH($embeddingColumn) = 0
+        UNION
+        SELECT $fileIDColumn FROM $petFacesTable
+        WHERE $fileIDColumn IN ($placeholders) AND $faceScore < 0
+        ''',
+        [...chunk, ...chunk, ...chunk],
+      );
+      result.addAll(rows.map((row) => row[fileIDColumn] as int));
+    }
+    return result;
+  }
+
+  @override
   Future<void> deleteFaceIndexForFiles(List<int> fileIDs) async {
     final db = await asyncDB;
     final String sql =

--- a/mobile/apps/photos/lib/db/ml/db.dart
+++ b/mobile/apps/photos/lib/db/ml/db.dart
@@ -1242,6 +1242,26 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
   }
 
   @override
+  Future<void> pruneResolvedFaceErrorResults(List<int> fileIDs) async {
+    if (fileIDs.isEmpty) return;
+    final db = await asyncDB;
+    for (final chunk in fileIDs.chunks(_maxSqlBindParamsPerQuery)) {
+      final placeholders = List.filled(chunk.length, '?').join(', ');
+      await db.execute('''
+        DELETE FROM $facesTable
+        WHERE $fileIDColumn IN ($placeholders)
+          AND $faceScore < 0
+          AND EXISTS (
+            SELECT 1 FROM $facesTable AS successful
+            WHERE successful.$fileIDColumn = $facesTable.$fileIDColumn
+              AND successful.$faceScore >= 0
+              AND successful.$mlVersionColumn >= $facesTable.$mlVersionColumn
+          )
+        ''', chunk);
+    }
+  }
+
+  @override
   Future<Set<int>> getFileIDsWithErrorResults(List<int> fileIDs) async {
     if (fileIDs.isEmpty) return {};
     final db = await asyncDB;
@@ -1251,8 +1271,15 @@ class MLDataDB with SqlDbBase implements IMLDataDB<int> {
       final placeholders = List.filled(chunk.length, '?').join(', ');
       final rows = await db.getAll(
         '''
-        SELECT $fileIDColumn FROM $facesTable
-        WHERE $fileIDColumn IN ($placeholders) AND $faceScore < 0
+        SELECT failed.$fileIDColumn FROM $facesTable AS failed
+        WHERE failed.$fileIDColumn IN ($placeholders)
+          AND failed.$faceScore < 0
+          AND NOT EXISTS (
+            SELECT 1 FROM $facesTable AS successful
+            WHERE successful.$fileIDColumn = failed.$fileIDColumn
+              AND successful.$faceScore >= 0
+              AND successful.$mlVersionColumn >= failed.$mlVersionColumn
+          )
         UNION
         SELECT $fileIDColumn FROM $clipTable
         WHERE $fileIDColumn IN ($placeholders) AND LENGTH($embeddingColumn) = 0

--- a/mobile/apps/photos/lib/module/download/decrypt.dart
+++ b/mobile/apps/photos/lib/module/download/decrypt.dart
@@ -28,6 +28,13 @@ class DownloadFailedError implements Exception {
   String toString() => message;
 }
 
+class DownloadDecryptionError extends DownloadFailedError {
+  final String encryptedFileSha1;
+
+  DownloadDecryptionError(this.encryptedFileSha1)
+    : super('Failed to decrypt downloaded file');
+}
+
 class DownloadNoConnectionError extends DownloadFailedError {
   DownloadNoConnectionError() : super('No connection');
 }
@@ -103,7 +110,7 @@ Future<File?> _downloadAndDecryptPublicFile(
       fakeProgress?.stop();
       final metadata = await _fileMetadataForLogging(file, encryptedFilePath);
       _logger.severe(
-        'Critical: $logPrefix failed to decrypt, $metadata',
+        'Critical: $logPrefix failed to decrypt, ${metadata.log}',
         error,
         stackTrace,
       );
@@ -220,10 +227,18 @@ Future<File?> downloadAndDecrypt(
       fakeProgress?.stop();
       final metadata = await _fileMetadataForLogging(file, encryptedFilePath);
       _logger.severe(
-        'Critical: $logPrefix failed to decrypt, $metadata',
+        'Critical: $logPrefix failed to decrypt, ${metadata.log}',
         error,
         stackTrace,
       );
+      await _deleteFailedDecryptionArtifacts(
+        file,
+        encryptedFilePath,
+        decryptedFilePath,
+      );
+      if (error is StreamPullErr && metadata.encryptedFileSha1 != null) {
+        throw DownloadDecryptionError(metadata.encryptedFileSha1!);
+      }
       if (throwOnFailure) {
         throw DownloadFailedError('Failed to decrypt downloaded file');
       }
@@ -232,6 +247,9 @@ Future<File?> downloadAndDecrypt(
     await encryptedFile.delete();
     return File(decryptedFilePath);
   } catch (error, stackTrace) {
+    if (error is DownloadDecryptionError) {
+      rethrow;
+    }
     _logger.severe(
       '$logPrefix failed to download or decrypt',
       error,
@@ -263,20 +281,44 @@ Exception _toDownloadFailure(String? error) {
   return DownloadFailedError(error ?? 'Download failed');
 }
 
-Future<String> _fileMetadataForLogging(
+Future<({String log, String? encryptedFileSha1})> _fileMetadataForLogging(
   EnteFile file,
   String encryptedFilePath,
 ) async {
   final buffer = StringBuffer();
   final encryptedFile = File(encryptedFilePath);
+  String? encryptedFileSha1;
   if (encryptedFile.existsSync()) {
-    final hash = await sha1.bind(encryptedFile.openRead()).first;
-    buffer.write('encFileSha1: $hash, ');
+    encryptedFileSha1 = (await sha1.bind(encryptedFile.openRead()).first)
+        .toString();
+    buffer.write('encFileSha1: $encryptedFileSha1, ');
   } else {
     buffer.write('encFileSha1: file not found, ');
   }
   buffer.write('metadataVersion: ${file.metadataVersion}, ');
   buffer.write('fileSize: ${file.fileSize ?? "null"}, ');
   buffer.write('viaMobile: ${(file.deviceFolder ?? '') != ''}');
-  return buffer.toString();
+  return (log: buffer.toString(), encryptedFileSha1: encryptedFileSha1);
+}
+
+Future<void> _deleteFailedDecryptionArtifacts(
+  EnteFile file,
+  String encryptedFilePath,
+  String decryptedFilePath,
+) async {
+  try {
+    await downloadManager.cancel(file.uploadedFileID!);
+    for (final path in [encryptedFilePath, decryptedFilePath]) {
+      final artifact = File(path);
+      if (await artifact.exists()) {
+        await artifact.delete();
+      }
+    }
+  } catch (error, stackTrace) {
+    _logger.warning(
+      'Failed to delete decryption artifacts for File-${file.uploadedFileID}',
+      error,
+      stackTrace,
+    );
+  }
 }

--- a/mobile/apps/photos/lib/module/download/file.dart
+++ b/mobile/apps/photos/lib/module/download/file.dart
@@ -34,6 +34,7 @@ Future<File?> getFile(
   bool liveVideo = false,
   bool isOrigin = false,
   bool forGalleryDownload = false, // only relevant for live photos
+  bool throwOnDecryptionFailure = false,
 }) async {
   try {
     if (file.isRemoteOnlyFile) {
@@ -41,6 +42,7 @@ Future<File?> getFile(
         file,
         liveVideo: liveVideo,
         forGalleryDownload: forGalleryDownload,
+        throwOnDecryptionFailure: throwOnDecryptionFailure,
       );
     } else {
       final String key = file.tag + liveVideo.toString() + isOrigin.toString();
@@ -62,7 +64,8 @@ Future<File?> getFile(
     }
   } catch (e, s) {
     _logger.warning("Failed to get file", e, s);
-    if (forGalleryDownload) {
+    if (forGalleryDownload ||
+        (throwOnDecryptionFailure && e is DownloadDecryptionError)) {
       rethrow;
     }
     return null;
@@ -160,6 +163,7 @@ Future<File?> getFileFromServer(
   ProgressCallback? progressCallback,
   bool liveVideo = false, // only needed in case of live photos
   bool forGalleryDownload = false,
+  bool throwOnDecryptionFailure = false,
 }) async {
   final cacheManager = (file.fileType == FileType.video || liveVideo)
       ? VideoCacheManager.instance
@@ -174,7 +178,7 @@ Future<File?> getFileFromServer(
     _progressCallbacks[downloadID] = progressCallback;
   }
 
-  return _runOncePerKey(
+  final download = _runOncePerKey(
     _fileDownloadsInProgress,
     downloadID,
     () {
@@ -202,6 +206,14 @@ Future<File?> getFileFromServer(
     },
     onComplete: () => _progressCallbacks.remove(downloadID),
   );
+  try {
+    return await download;
+  } on DownloadDecryptionError {
+    if (forGalleryDownload || throwOnDecryptionFailure) {
+      rethrow;
+    }
+    return null;
+  }
 }
 
 Future<bool> isFileCached(EnteFile file, {bool liveVideo = false}) async {
@@ -238,7 +250,7 @@ Future<File?> _getLivePhotoFromServer(
     return needLiveVideo ? livePhoto.video : livePhoto.image;
   } catch (e, s) {
     _logger.warning("live photo get failed", e, s);
-    if (forGalleryDownload) {
+    if (forGalleryDownload || e is DownloadDecryptionError) {
       rethrow;
     }
     return null;

--- a/mobile/apps/photos/lib/service_locator.dart
+++ b/mobile/apps/photos/lib/service_locator.dart
@@ -35,6 +35,7 @@ import "package:photos/services/library_sharing_service.dart";
 import "package:photos/services/library_sharing_store.dart";
 import "package:photos/services/location_service.dart";
 import "package:photos/services/machine_learning/compute_controller.dart";
+import "package:photos/services/machine_learning/ml_decryption_record_store.dart";
 import "package:photos/services/magic_cache_service.dart";
 import "package:photos/services/memories_cache_service.dart";
 import "package:photos/services/permission/service.dart";
@@ -62,6 +63,7 @@ class ServiceLocator {
   late final LocalSettings localSettings;
   late final BackupSettings backupSettings;
   late final EnteWakeLockService wakeLockService;
+  late final MlDecryptionRecordStore mlDecryptionRecordStore;
 
   ServiceLocator._privateConstructor();
 
@@ -83,6 +85,7 @@ class ServiceLocator {
     localSettings = LocalSettings(prefs);
     backupSettings = BackupSettings(prefs);
     wakeLockService = EnteWakeLockService();
+    mlDecryptionRecordStore = MlDecryptionRecordStore(prefs);
   }
 }
 
@@ -122,6 +125,9 @@ BackupSettings get backupSettings => ServiceLocator.instance.backupSettings;
 
 EnteWakeLockService get wakeLockService =>
     ServiceLocator.instance.wakeLockService;
+
+MlDecryptionRecordStore get mlDecryptionRecordStore =>
+    ServiceLocator.instance.mlDecryptionRecordStore;
 
 // True when showing local-device photos instead of an Ente account. Network
 // access may still be used.

--- a/mobile/apps/photos/lib/services/machine_learning/ml_decryption_record_store.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_decryption_record_store.dart
@@ -1,0 +1,58 @@
+import "package:logging/logging.dart";
+import "package:shared_preferences/shared_preferences.dart";
+import "package:synchronized/synchronized.dart";
+
+class MlDecryptionRecordStore {
+  static const _preferenceKey = "ml_decryption_record_file_ids";
+
+  final SharedPreferences _preferences;
+  final Lock _lock = Lock();
+  final Logger _logger = Logger("MlDecryptionRecordStore");
+
+  MlDecryptionRecordStore(this._preferences);
+
+  List<int> get fileIDs {
+    final result = <int>{};
+    for (final value
+        in _preferences.getStringList(_preferenceKey) ?? const []) {
+      final fileID = int.tryParse(value);
+      if (fileID != null) {
+        result.add(fileID);
+      }
+    }
+    return result.toList()..sort();
+  }
+
+  int get count => fileIDs.length;
+
+  Future<void> add(int fileID) async {
+    await _lock.synchronized(() async {
+      final updatedFileIDs = fileIDs.toSet();
+      if (!updatedFileIDs.add(fileID)) {
+        return;
+      }
+      final values = updatedFileIDs.toList()..sort();
+      try {
+        final stored = await _preferences.setStringList(
+          _preferenceKey,
+          values.map((id) => id.toString()).toList(),
+        );
+        if (!stored) {
+          _logger.warning(
+            "Failed to store ML decryption record for fileID $fileID",
+          );
+        }
+      } catch (error, stackTrace) {
+        _logger.warning(
+          "Failed to store ML decryption record for fileID $fileID",
+          error,
+          stackTrace,
+        );
+      }
+    });
+  }
+
+  void logFileIDs() {
+    _logger.info("ML decryption record fileIDs: $fileIDs");
+  }
+}

--- a/mobile/apps/photos/lib/services/machine_learning/ml_decryption_record_store.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_decryption_record_store.dart
@@ -31,25 +31,40 @@ class MlDecryptionRecordStore {
       if (!updatedFileIDs.add(fileID)) {
         return;
       }
-      final values = updatedFileIDs.toList()..sort();
-      try {
-        final stored = await _preferences.setStringList(
-          _preferenceKey,
-          values.map((id) => id.toString()).toList(),
-        );
-        if (!stored) {
-          _logger.warning(
-            "Failed to store ML decryption record for fileID $fileID",
-          );
-        }
-      } catch (error, stackTrace) {
-        _logger.warning(
-          "Failed to store ML decryption record for fileID $fileID",
-          error,
-          stackTrace,
-        );
-      }
+      await _store(
+        updatedFileIDs,
+        "Failed to store ML decryption record for fileID $fileID",
+      );
     });
+  }
+
+  Future<void> removeAll(Iterable<int> fileIDs) async {
+    final fileIDsToRemove = fileIDs.toSet();
+    if (fileIDsToRemove.isEmpty) return;
+    await _lock.synchronized(() async {
+      final updatedFileIDs = this.fileIDs.toSet();
+      final previousCount = updatedFileIDs.length;
+      updatedFileIDs.removeAll(fileIDsToRemove);
+      if (updatedFileIDs.length == previousCount) {
+        return;
+      }
+      await _store(updatedFileIDs, "Failed to prune ML decryption records");
+    });
+  }
+
+  Future<void> _store(Set<int> fileIDs, String failureMessage) async {
+    final values = fileIDs.toList()..sort();
+    try {
+      final stored = await _preferences.setStringList(
+        _preferenceKey,
+        values.map((id) => id.toString()).toList(),
+      );
+      if (!stored) {
+        _logger.warning(failureMessage);
+      }
+    } catch (error, stackTrace) {
+      _logger.warning(failureMessage, error, stackTrace);
+    }
   }
 
   void logFileIDs() {

--- a/mobile/apps/photos/lib/services/machine_learning/ml_exceptions.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_exceptions.dart
@@ -13,3 +13,5 @@ class ThumbnailRetrievalException implements Exception {
 }
 
 class CouldNotRetrieveAnyFileData implements Exception, LocallyHandledError {}
+
+class RepeatedFileDecryptionError implements Exception, LocallyHandledError {}

--- a/mobile/apps/photos/lib/services/machine_learning/ml_file_retrieval.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_file_retrieval.dart
@@ -1,0 +1,24 @@
+import "dart:io";
+
+import "package:photos/module/download/decrypt.dart";
+import "package:photos/services/machine_learning/ml_exceptions.dart";
+
+typedef MlFileLoader = Future<File?> Function();
+
+Future<File?> loadFileForMlWithDecryptionRetry(MlFileLoader load) async {
+  late final DownloadDecryptionError firstFailure;
+  try {
+    return await load();
+  } on DownloadDecryptionError catch (error) {
+    firstFailure = error;
+  }
+
+  try {
+    return await load();
+  } on DownloadDecryptionError catch (error) {
+    if (error.encryptedFileSha1 == firstFailure.encryptedFileSha1) {
+      throw RepeatedFileDecryptionError();
+    }
+    rethrow;
+  }
+}

--- a/mobile/apps/photos/lib/services/machine_learning/ml_file_retrieval.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_file_retrieval.dart
@@ -3,22 +3,24 @@ import "dart:io";
 import "package:photos/module/download/decrypt.dart";
 import "package:photos/services/machine_learning/ml_exceptions.dart";
 
-typedef MlFileLoader = Future<File?> Function();
+typedef MlFileDownloadAndLoader = Future<File?> Function();
 
-Future<File?> loadFileForMlWithDecryptionRetry(MlFileLoader load) async {
-  late final DownloadDecryptionError firstFailure;
-  try {
-    return await load();
-  } on DownloadDecryptionError catch (error) {
-    firstFailure = error;
-  }
-
-  try {
-    return await load();
-  } on DownloadDecryptionError catch (error) {
-    if (error.encryptedFileSha1 == firstFailure.encryptedFileSha1) {
-      throw RepeatedFileDecryptionError();
+Future<File?> downloadAndLoadFileForMlWithDecryptionRetry(
+  MlFileDownloadAndLoader downloadAndLoad,
+) async {
+  const retryCount = 3;
+  DownloadDecryptionError? firstFailure;
+  for (var attempt = 0; ; attempt++) {
+    try {
+      return await downloadAndLoad();
+    } on DownloadDecryptionError catch (error) {
+      firstFailure ??= error;
+      if (error.encryptedFileSha1 != firstFailure.encryptedFileSha1) {
+        rethrow;
+      }
+      if (attempt == retryCount) {
+        throw RepeatedFileDecryptionError();
+      }
     }
-    rethrow;
   }
 }

--- a/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/ml_service.dart
@@ -27,6 +27,7 @@ import "package:photos/services/machine_learning/face_ml/face_clustering/face_cl
 import "package:photos/services/machine_learning/face_ml/face_clustering/face_db_info_for_clustering.dart";
 import "package:photos/services/machine_learning/face_ml/face_detection/detection.dart";
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
+import "package:photos/services/machine_learning/ml_exceptions.dart";
 import "package:photos/services/machine_learning/ml_indexing_isolate.dart";
 import "package:photos/services/machine_learning/ml_model_download_service.dart";
 import "package:photos/services/machine_learning/ml_process_lock.dart";
@@ -1081,6 +1082,9 @@ class MLService {
         _logger.info(
           "Stored empty ML result markers for fileID ${instruction.fileKey}: ${storedMarkers.join(', ')}",
         );
+        if (e is RepeatedFileDecryptionError) {
+          await mlDecryptionRecordStore.add(instruction.fileKey);
+        }
         indexedOrSkipped = true;
         return true;
       }

--- a/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
@@ -591,37 +591,61 @@ class _MLProcessingIssuesBlurb extends StatelessWidget {
       ),
       child: Padding(
         padding: const EdgeInsets.all(Spacing.lg),
-        child: Column(
+        child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              context.strings.mlCouldNotProcessItems(count: itemCount),
-              style: TextStyles.bodyBold.copyWith(color: colors.warning),
-            ),
-            const SizedBox(height: Spacing.xs),
-            Text(
-              context.strings.mlItemsCouldNotBeProcessed(count: itemCount),
-              style: TextStyles.mini.copyWith(color: colors.textLight),
-            ),
-            const SizedBox(height: Spacing.sm),
-            ButtonComponent(
-              label: context.strings.contactUs,
-              variant: ButtonComponentVariant.link,
-              size: ButtonComponentSize.small,
-              shouldSurfaceExecutionStates: false,
-              onTap: () async {
-                mlDecryptionRecordStore.logFileIDs();
-                await sendLogs(
-                  context,
-                  context.strings.contactUs,
-                  "support@ente.com",
-                  postShare: () {},
-                  subject: "Machine learning processing issue",
-                  body: context.strings.mlItemsCouldNotBeProcessed(
-                    count: itemCount,
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: colors.cautionLight,
+                shape: BoxShape.circle,
+              ),
+              child: SizedBox.square(
+                dimension: 32,
+                child: Center(
+                  child: HugeIcon(
+                    icon: HugeIcons.strokeRoundedAlert02,
+                    size: IconSizes.small,
+                    color: colors.caution,
                   ),
-                );
-              },
+                ),
+              ),
+            ),
+            const SizedBox(width: Spacing.md),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    context.strings.mlCouldNotProcessItems(count: itemCount),
+                    style: TextStyles.bodyBold.copyWith(color: colors.textBase),
+                  ),
+                  const SizedBox(height: Spacing.xs),
+                  Text(
+                    context.strings.mlProcessingIssueReachOut,
+                    style: TextStyles.mini.copyWith(color: colors.textLight),
+                  ),
+                  const SizedBox(height: Spacing.xs),
+                  Transform.translate(
+                    offset: const Offset(-Spacing.sm, 0),
+                    child: SettingsLink(
+                      label: context.strings.contactUs,
+                      onTap: () {
+                        mlDecryptionRecordStore.logFileIDs();
+                        sendLogs(
+                          context,
+                          context.strings.contactUs,
+                          "support@ente.com",
+                          postShare: () {},
+                          subject: "Machine learning processing issue",
+                          body: context.strings.mlItemsCouldNotBeProcessed(
+                            count: itemCount,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
@@ -5,7 +5,10 @@ import "package:ente_strings/ente_strings.dart";
 import "package:ente_ui/components/loading_widget.dart";
 import "package:flutter/material.dart";
 import "package:hugeicons/hugeicons.dart";
+import "package:logging/logging.dart";
 import "package:photos/core/event_bus.dart";
+import "package:photos/db/files_db.dart";
+import "package:photos/db/ml/db.dart";
 import "package:photos/events/notification_event.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/machine_learning/ml_indexing_isolate.dart";
@@ -32,6 +35,7 @@ class MachineLearningSettingsPage extends StatefulWidget {
 
 class _MachineLearningSettingsPageState
     extends State<MachineLearningSettingsPage> {
+  static final _logger = Logger("MachineLearningSettingsPage");
   Timer? _timer;
   int _titleTapCount = 0;
   Timer? _advancedOptionsTimer;
@@ -41,7 +45,7 @@ class _MachineLearningSettingsPageState
   @override
   void initState() {
     super.initState();
-    mlDecryptionRecordStore.logFileIDs();
+    unawaited(_pruneMlDecryptionRecords());
     wakeLockService.updateWakeLock(
       enable: true,
       wakeLockFor: WakeLockFor.machineLearningSettingsScreen,
@@ -59,6 +63,40 @@ class _MachineLearningSettingsPageState
     _advancedOptionsTimer = Timer.periodic(const Duration(seconds: 7), (timer) {
       _titleTapCount = 0;
     });
+  }
+
+  Future<void> _pruneMlDecryptionRecords() async {
+    final recordedFileIDs = mlDecryptionRecordStore.fileIDs;
+    if (recordedFileIDs.isEmpty) {
+      mlDecryptionRecordStore.logFileIDs();
+      return;
+    }
+    try {
+      final existingFiles = await FilesDB.instance.getFileIDToFileFromIDs(
+        recordedFileIDs,
+      );
+      final errorResultFileIDs = await MLDataDB.instance
+          .getFileIDsWithErrorResults(recordedFileIDs);
+      final staleFileIDs = recordedFileIDs
+          .where(
+            (fileID) =>
+                !existingFiles.containsKey(fileID) ||
+                !errorResultFileIDs.contains(fileID),
+          )
+          .toSet();
+      await mlDecryptionRecordStore.removeAll(staleFileIDs);
+      if (staleFileIDs.isNotEmpty && mounted) {
+        setState(() {});
+      }
+    } catch (error, stackTrace) {
+      _logger.warning(
+        "Failed to prune ML decryption records",
+        error,
+        stackTrace,
+      );
+    } finally {
+      mlDecryptionRecordStore.logFileIDs();
+    }
   }
 
   @override
@@ -461,6 +499,7 @@ class MLStatusWidget extends StatefulWidget {
 class MLStatusWidgetState extends State<MLStatusWidget> {
   Timer? _timer;
   bool _isDeviceHealthy = computeController.isDeviceHealthy;
+
   @override
   void initState() {
     super.initState();

--- a/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
@@ -41,6 +41,7 @@ class _MachineLearningSettingsPageState
   Timer? _advancedOptionsTimer;
   bool _hasAcknowledgedMLConsent = false;
   bool _hasHandledDisabledExit = false;
+  bool _mlDecryptionRecordsReady = false;
 
   @override
   void initState() {
@@ -67,26 +68,22 @@ class _MachineLearningSettingsPageState
 
   Future<void> _pruneMlDecryptionRecords() async {
     final recordedFileIDs = mlDecryptionRecordStore.fileIDs;
-    if (recordedFileIDs.isEmpty) {
-      mlDecryptionRecordStore.logFileIDs();
-      return;
-    }
     try {
-      final existingFiles = await FilesDB.instance.getFileIDToFileFromIDs(
-        recordedFileIDs,
-      );
-      final errorResultFileIDs = await MLDataDB.instance
-          .getFileIDsWithErrorResults(recordedFileIDs);
-      final staleFileIDs = recordedFileIDs
-          .where(
-            (fileID) =>
-                !existingFiles.containsKey(fileID) ||
-                !errorResultFileIDs.contains(fileID),
-          )
-          .toSet();
-      await mlDecryptionRecordStore.removeAll(staleFileIDs);
-      if (staleFileIDs.isNotEmpty && mounted) {
-        setState(() {});
+      if (recordedFileIDs.isNotEmpty) {
+        await MLDataDB.instance.pruneResolvedFaceErrorResults(recordedFileIDs);
+        final existingFiles = await FilesDB.instance.getFileIDToFileFromIDs(
+          recordedFileIDs,
+        );
+        final errorResultFileIDs = await MLDataDB.instance
+            .getFileIDsWithErrorResults(recordedFileIDs);
+        final staleFileIDs = recordedFileIDs
+            .where(
+              (fileID) =>
+                  !existingFiles.containsKey(fileID) ||
+                  !errorResultFileIDs.contains(fileID),
+            )
+            .toSet();
+        await mlDecryptionRecordStore.removeAll(staleFileIDs);
       }
     } catch (error, stackTrace) {
       _logger.warning(
@@ -96,6 +93,9 @@ class _MachineLearningSettingsPageState
       );
     } finally {
       mlDecryptionRecordStore.logFileIDs();
+      if (mounted) {
+        setState(() => _mlDecryptionRecordsReady = true);
+      }
     }
   }
 
@@ -374,7 +374,7 @@ class _MachineLearningSettingsPageState
                   onlyIndexingModels: true,
                 ) ||
                 !localSettings.isMLLocalIndexingEnabled
-            ? const MLStatusWidget()
+            ? MLStatusWidget(showDecryptionWarning: _mlDecryptionRecordsReady)
             : const ModelLoadingState(),
       ],
     );
@@ -490,7 +490,9 @@ class _ModelLoadingStateState extends State<ModelLoadingState> {
 }
 
 class MLStatusWidget extends StatefulWidget {
-  const MLStatusWidget({super.key});
+  final bool showDecryptionWarning;
+
+  const MLStatusWidget({required this.showDecryptionWarning, super.key});
 
   @override
   State<MLStatusWidget> createState() => MLStatusWidgetState();
@@ -524,7 +526,9 @@ class MLStatusWidgetState extends State<MLStatusWidget> {
   @override
   Widget build(BuildContext context) {
     final colors = context.componentColors;
-    final decryptionIssueCount = mlDecryptionRecordStore.count;
+    final decryptionIssueCount = widget.showDecryptionWarning
+        ? mlDecryptionRecordStore.count
+        : 0;
     return Column(
       children: [
         Padding(

--- a/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
@@ -18,6 +18,7 @@ import "package:photos/services/remote_assets_service.dart";
 import "package:photos/services/wake_lock_service.dart";
 import "package:photos/ui/common/web_page.dart";
 import "package:photos/ui/settings/ml/ml_user_dev_screen.dart";
+import "package:photos/utils/email_util.dart";
 import "package:photos/utils/ml_util.dart";
 import "package:photos/utils/network_util.dart";
 
@@ -40,6 +41,7 @@ class _MachineLearningSettingsPageState
   @override
   void initState() {
     super.initState();
+    mlDecryptionRecordStore.logFileIDs();
     wakeLockService.updateWakeLock(
       enable: true,
       wakeLockFor: WakeLockFor.machineLearningSettingsScreen,
@@ -483,6 +485,7 @@ class MLStatusWidgetState extends State<MLStatusWidget> {
   @override
   Widget build(BuildContext context) {
     final colors = context.componentColors;
+    final decryptionIssueCount = mlDecryptionRecordStore.count;
     return Column(
       children: [
         Padding(
@@ -564,7 +567,65 @@ class MLStatusWidgetState extends State<MLStatusWidget> {
             return const EnteLoadingWidget();
           },
         ),
+        if (decryptionIssueCount > 0) ...[
+          const SizedBox(height: 8),
+          _MLProcessingIssuesBlurb(itemCount: decryptionIssueCount),
+        ],
       ],
+    );
+  }
+}
+
+class _MLProcessingIssuesBlurb extends StatelessWidget {
+  final int itemCount;
+
+  const _MLProcessingIssuesBlurb({required this.itemCount});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.componentColors;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colors.fillLight,
+        borderRadius: BorderRadius.circular(Radii.button),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(Spacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              context.strings.mlCouldNotProcessItems(count: itemCount),
+              style: TextStyles.bodyBold.copyWith(color: colors.warning),
+            ),
+            const SizedBox(height: Spacing.xs),
+            Text(
+              context.strings.mlItemsCouldNotBeProcessed(count: itemCount),
+              style: TextStyles.mini.copyWith(color: colors.textLight),
+            ),
+            const SizedBox(height: Spacing.sm),
+            ButtonComponent(
+              label: context.strings.contactUs,
+              variant: ButtonComponentVariant.link,
+              size: ButtonComponentSize.small,
+              shouldSurfaceExecutionStates: false,
+              onTap: () async {
+                mlDecryptionRecordStore.logFileIDs();
+                await sendLogs(
+                  context,
+                  context.strings.contactUs,
+                  "support@ente.com",
+                  postShare: () {},
+                  subject: "Machine learning processing issue",
+                  body: context.strings.mlItemsCouldNotBeProcessed(
+                    count: itemCount,
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
+++ b/mobile/apps/photos/lib/ui/settings/ml/machine_learning_settings_page.dart
@@ -629,7 +629,11 @@ class _MLProcessingIssuesBlurb extends StatelessWidget {
         borderRadius: BorderRadius.circular(Radii.button),
       ),
       child: Padding(
-        padding: const EdgeInsets.all(Spacing.lg),
+        padding: const EdgeInsets.only(
+          left: Spacing.lg,
+          top: Spacing.lg,
+          right: Spacing.lg,
+        ),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -658,29 +662,49 @@ class _MLProcessingIssuesBlurb extends StatelessWidget {
                     context.strings.mlCouldNotProcessItems(count: itemCount),
                     style: TextStyles.bodyBold.copyWith(color: colors.textBase),
                   ),
-                  const SizedBox(height: Spacing.xs),
+                  const SizedBox(height: Spacing.sm),
                   Text(
                     context.strings.mlProcessingIssueReachOut,
                     style: TextStyles.mini.copyWith(color: colors.textLight),
                   ),
-                  const SizedBox(height: Spacing.xs),
-                  Transform.translate(
-                    offset: const Offset(-Spacing.sm, 0),
-                    child: SettingsLink(
-                      label: context.strings.contactUs,
-                      onTap: () {
-                        mlDecryptionRecordStore.logFileIDs();
-                        sendLogs(
-                          context,
-                          context.strings.contactUs,
-                          "support@ente.com",
-                          postShare: () {},
-                          subject: "Machine learning processing issue",
-                          body: context.strings.mlItemsCouldNotBeProcessed(
-                            count: itemCount,
+                  GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () {
+                      mlDecryptionRecordStore.logFileIDs();
+                      sendLogs(
+                        context,
+                        context.strings.contactUs,
+                        "support@ente.com",
+                        postShare: () {},
+                        subject: "Machine learning processing issue",
+                        body: context.strings.mlItemsCouldNotBeProcessed(
+                          count: itemCount,
+                        ),
+                      );
+                    },
+                    child: Padding(
+                      padding: const EdgeInsets.only(
+                        top: Spacing.sm,
+                        bottom: Spacing.lg,
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            context.strings.contactUs,
+                            style: TextStyles.bodyBold.copyWith(
+                              color: colors.primary,
+                            ),
                           ),
-                        );
-                      },
+                          const SizedBox(width: Spacing.xs),
+                          HugeIcon(
+                            icon: HugeIcons.strokeRoundedArrowRight01,
+                            color: colors.primary,
+                            size: 16,
+                            strokeWidth: 1.6,
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ],

--- a/mobile/apps/photos/lib/utils/ml_util.dart
+++ b/mobile/apps/photos/lib/utils/ml_util.dart
@@ -29,6 +29,7 @@ import "package:photos/services/filedata/model/response.dart";
 import "package:photos/services/machine_learning/face_ml/face_alignment/alignment_result.dart";
 import "package:photos/services/machine_learning/face_ml/face_detection/detection.dart";
 import "package:photos/services/machine_learning/ml_exceptions.dart";
+import "package:photos/services/machine_learning/ml_file_retrieval.dart";
 import "package:photos/services/machine_learning/ml_result.dart";
 import "package:photos/services/machine_learning/ml_run_control.dart";
 import "package:photos/services/search_service.dart";
@@ -739,7 +740,11 @@ Future<String> getImagePathForML(EnteFile enteFile) async {
           modificationTime: enteFile.modificationTime,
         );
       }
-      file = await getFile(enteFile, isOrigin: true);
+      file = await loadFileForMlWithDecryptionRetry(
+        () => getFile(enteFile, isOrigin: true, throwOnDecryptionFailure: true),
+      );
+    } on RepeatedFileDecryptionError {
+      rethrow;
     } catch (e, s) {
       _logger.severe("Could not get file for $enteFile", e, s);
     }
@@ -1020,6 +1025,9 @@ Future<MLResult> analyzeImageRust(Map args) async {
 }
 
 bool isExpectedMlSkipError(Object error) {
+  if (error is RepeatedFileDecryptionError) {
+    return true;
+  }
   final message = _normalizedErrorMessage(error);
   const acceptedIssueMarkers = <String>[
     "thumbnailretrievalexception",
@@ -1031,6 +1039,9 @@ bool isExpectedMlSkipError(Object error) {
 }
 
 String formatExpectedMlSkipReasonForLogs(Object error) {
+  if (error is RepeatedFileDecryptionError) {
+    return "origin decryption failed twice for identical ciphertext";
+  }
   final normalized = _normalizedErrorMessage(error);
   if (normalized.contains("invalidimageformatexception")) {
     return "image decode failed";

--- a/mobile/apps/photos/lib/utils/ml_util.dart
+++ b/mobile/apps/photos/lib/utils/ml_util.dart
@@ -740,7 +740,7 @@ Future<String> getImagePathForML(EnteFile enteFile) async {
           modificationTime: enteFile.modificationTime,
         );
       }
-      file = await loadFileForMlWithDecryptionRetry(
+      file = await downloadAndLoadFileForMlWithDecryptionRetry(
         () => getFile(enteFile, isOrigin: true, throwOnDecryptionFailure: true),
       );
     } on RepeatedFileDecryptionError {
@@ -1040,7 +1040,7 @@ bool isExpectedMlSkipError(Object error) {
 
 String formatExpectedMlSkipReasonForLogs(Object error) {
   if (error is RepeatedFileDecryptionError) {
-    return "origin decryption failed twice for identical ciphertext";
+    return "origin decryption failed after three retries with identical ciphertext";
   }
   final normalized = _normalizedErrorMessage(error);
   if (normalized.contains("invalidimageformatexception")) {

--- a/mobile/packages/strings/lib/l10n/arb/strings_en.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_en.arb
@@ -2543,7 +2543,7 @@
   "mlConsentConfirmation": "I understand, and wish to enable machine learning",
   "mlConsentDescription": "If you enable machine learning, Ente will extract information like face geometry from files, including those shared with you.\n\nThis will happen on your device, and any generated biometric information will be end-to-end encrypted.",
   "mlConsentPrivacy": "Please click here for more details about this feature in our privacy policy",
-  "mlCouldNotProcessItems": "{count, plural, one{Could not process {count} item.} other{Could not process {count} items.}}",
+  "mlCouldNotProcessItems": "{count, plural, one{Could not process {count} item} other{Could not process {count} items}}",
   "@mlCouldNotProcessItems": {
     "description": "Title shown when machine learning could not process one or more items",
     "placeholders": {
@@ -2561,6 +2561,10 @@
         "type": "int"
       }
     }
+  },
+  "mlProcessingIssueReachOut": "Please reach out to us so we can help.",
+  "@mlProcessingIssueReachOut": {
+    "description": "Support prompt shown when machine learning could not process one or more items"
   },
   "mlProgressBannerDescription": "Your photos are getting processed on device to detect faces, objects and more.",
   "mlProgressBannerStatus": "{indexed} out of {total} photos processed",

--- a/mobile/packages/strings/lib/l10n/arb/strings_en.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_en.arb
@@ -798,6 +798,10 @@
   "@contactSupport": {
     "description": "Contact support button label"
   },
+  "contactUs": "Contact us",
+  "@contactUs": {
+    "description": "Button label for contacting Ente support"
+  },
   "contactToManageSubscription": "Please contact us at support@ente.com to manage your {provider} subscription.",
   "@contactToManageSubscription": {
     "placeholders": {
@@ -2539,7 +2543,25 @@
   "mlConsentConfirmation": "I understand, and wish to enable machine learning",
   "mlConsentDescription": "If you enable machine learning, Ente will extract information like face geometry from files, including those shared with you.\n\nThis will happen on your device, and any generated biometric information will be end-to-end encrypted.",
   "mlConsentPrivacy": "Please click here for more details about this feature in our privacy policy",
+  "mlCouldNotProcessItems": "{count, plural, one{Could not process {count} item.} other{Could not process {count} items.}}",
+  "@mlCouldNotProcessItems": {
+    "description": "Title shown when machine learning could not process one or more items",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "mlIndexingDescription": "Please note that machine learning will result in higher bandwidth and battery usage until all items are processed. Consider using the desktop app for faster processing, and all results will be synced automatically.",
+  "mlItemsCouldNotBeProcessed": "{count, plural, one{{count} item could not be processed for machine learning. Please reach out to us so we can help.} other{{count} items could not be processed for machine learning. Please reach out to us so we can help.}}",
+  "@mlItemsCouldNotBeProcessed": {
+    "description": "Description shown when machine learning could not process one or more items",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "mlProgressBannerDescription": "Your photos are getting processed on device to detect faces, objects and more.",
   "mlProgressBannerStatus": "{indexed} out of {total} photos processed",
   "@mlProgressBannerStatus": {


### PR DESCRIPTION
## Description

- Retry ML origin download and decryption up to three times after the initial authentication failure, for four total attempts.
- Treat the fourth failure as an expected ML skip only when every attempt downloaded identical ciphertext; a different ciphertext hash is not accepted as a persistent issue.
- Store the existing empty ML results for accepted failures so later runs do not retry them indefinitely.
- Record repeatedly failing file IDs in a single local SharedPreferences list.
- Show the affected item count on the Machine Learning settings page with a contact-support action that includes app logs.
- Log the recorded file IDs when the Machine Learning settings page opens and before preparing the support logs.
- Clear failed temporary download artifacts before retrying while preserving existing gallery and public-download behavior.

## Testing

- `flutter analyze --no-pub`
- `flutter test test/ml_run_control_test.dart test/ml_process_lock_test.dart`
- Manually verified the warning, pluralized item count, recorded IDs, and contact-with-logs flow on an iOS simulator using the Ente test account.