### PR TITLE
[mobile][photos] show trash deletion copy for all users

### DIFF
--- a/mobile/apps/photos/lib/utils/delete_file_util.dart
+++ b/mobile/apps/photos/lib/utils/delete_file_util.dart
@@ -1137,7 +1137,6 @@ Future<bool?> showDeleteConfirmationSheet(
       files.every((file) => !file.isSharedMediaToAppSandbox) &&
       (Platform.isIOS ||
           (Platform.isAndroid &&
-              flagService.internalUser &&
               !await isAndroidSDKVersionLowerThan(android11SDKINT)));
   if (!context.mounted) return null;
   return showBottomSheetComponent<bool>(


### PR DESCRIPTION
## Description

Remove the internal-user gate from trash-aware deletion copy. Android 11+ users now see that files can be restored from trash, while the existing platform and shared-sandbox checks remain unchanged.

## Tests

- `fvm dart format lib/utils/delete_file_util.dart`
- `fvm flutter analyze lib/utils/delete_file_util.dart`
- `git diff --check`

The full pre-push analyzer is currently blocked by unrelated missing `muteAudio` and `unmuteAudio` localization getters in `full_screen_memory.dart`.
