### PR TITLE
[server] Bind scoped JWTs to sessions

### DIFF
--- a/server/ente/jwt/jwt.go
+++ b/server/ente/jwt/jwt.go
@@ -23,10 +23,12 @@ func (c ClaimScope) Ptr() *ClaimScope {
 }
 
 type WebCommonJWTClaim struct {
-	UserID     int64       `json:"userID,omitempty"`
-	ExpiryTime int64       `json:"expiryTime,omitempty"`
-	Email      string      `json:"email,omitempty"`
-	ClaimScope *ClaimScope `json:"claimScope,omitempty"`
+	UserID           int64       `json:"userID,omitempty"`
+	ExpiryTime       int64       `json:"expiryTime,omitempty"`
+	Email            string      `json:"email,omitempty"`
+	ClaimScope       *ClaimScope `json:"claimScope,omitempty"`
+	SessionTokenHash []byte      `json:"sessionTokenHash,omitempty"`
+	SessionApp       string      `json:"sessionApp,omitempty"`
 }
 
 func (w *WebCommonJWTClaim) GetScope() ClaimScope {

--- a/server/pkg/api/user.go
+++ b/server/pkg/api/user.go
@@ -445,7 +445,7 @@ func (h *UserHandler) ReportEvent(c *gin.Context) {
 
 func (h *UserHandler) GetPaymentToken(c *gin.Context) {
 	userID := auth.GetUserID(c.Request.Header)
-	token, err := h.UserController.GetJWTToken(userID, jwt.PAYMENT)
+	token, err := h.UserController.GetSessionJWTToken(userID, jwt.PAYMENT, auth.GetToken(c), auth.GetApp(c))
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
@@ -457,7 +457,7 @@ func (h *UserHandler) GetPaymentToken(c *gin.Context) {
 
 func (h *UserHandler) GetFamiliesToken(c *gin.Context) {
 	userID := auth.GetUserID(c.Request.Header)
-	token, err := h.UserController.GetJWTToken(userID, jwt.FAMILIES)
+	token, err := h.UserController.GetSessionJWTToken(userID, jwt.FAMILIES, auth.GetToken(c), auth.GetApp(c))
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return
@@ -470,7 +470,7 @@ func (h *UserHandler) GetFamiliesToken(c *gin.Context) {
 
 func (h *UserHandler) GetAccountsToken(c *gin.Context) {
 	userID := auth.GetUserID(c.Request.Header)
-	token, err := h.UserController.GetJWTToken(userID, jwt.ACCOUNTS)
+	token, err := h.UserController.GetSessionJWTToken(userID, jwt.ACCOUNTS, auth.GetToken(c), auth.GetApp(c))
 	if err != nil {
 		handler.Error(c, stacktrace.Propagate(err, ""))
 		return

--- a/server/pkg/controller/user/jwt.go
+++ b/server/pkg/controller/user/jwt.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ente/museum/ente"
 	enteJWT "github.com/ente/museum/ente/jwt"
+	"github.com/ente/museum/pkg/utils/auth"
 	"github.com/ente/museum/pkg/utils/time"
 	"github.com/ente/stacktrace"
 	"github.com/golang-jwt/jwt/v4"
@@ -21,14 +22,25 @@ var errJWTExpired = &ente.ApiError{
 }
 
 func (c *UserController) GetJWTToken(userID int64, scope enteJWT.ClaimScope) (string, error) {
+	return c.getJWTToken(userID, scope, nil, "")
+}
+
+func (c *UserController) GetSessionJWTToken(userID int64, scope enteJWT.ClaimScope, sessionToken string, sessionApp ente.App) (string, error) {
+	tokenHash := auth.HashToken(sessionToken)
+	return c.getJWTToken(userID, scope, tokenHash[:], sessionApp)
+}
+
+func (c *UserController) getJWTToken(userID int64, scope enteJWT.ClaimScope, sessionTokenHash []byte, sessionApp ente.App) (string, error) {
 	tokenExpiry := time.NDaysFromNow(1)
 	if scope == enteJWT.ACCOUNTS {
 		tokenExpiry = time.NMinFromNow(30)
 	}
 	claim := enteJWT.WebCommonJWTClaim{
-		UserID:     userID,
-		ExpiryTime: tokenExpiry,
-		ClaimScope: &scope,
+		UserID:           userID,
+		ExpiryTime:       tokenExpiry,
+		ClaimScope:       &scope,
+		SessionTokenHash: sessionTokenHash,
+		SessionApp:       string(sessionApp),
 	}
 	return c.GetJWTTokenForClaim(&claim)
 }

--- a/server/pkg/middleware/auth.go
+++ b/server/pkg/middleware/auth.go
@@ -1,9 +1,9 @@
 package middleware
 
 import (
+	"crypto/sha256"
 	"database/sql"
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -67,18 +67,29 @@ func (m *AuthMiddleware) TokenAuthMiddleware(jwtClaimScope *jwt.ClaimScope) gin.
 				}
 			}
 		} else {
-			cacheKey := fmt.Sprintf("%s:%s:%s", app, token, *jwtClaimScope)
-			cachedUserID, found := m.Cache.Get(cacheKey)
-			if found {
-				userID = cachedUserID.(int64)
-			} else {
-				claim, err := m.UserController.ValidateJWTToken(token, *jwtClaimScope)
-				if err != nil {
+			claim, err := m.UserController.ValidateJWTToken(token, *jwtClaimScope)
+			if err != nil {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+				return
+			}
+			userID = claim.UserID
+			// TODO: Reject missing session fields after the 24-hour rollout window.
+			if len(claim.SessionTokenHash) != 0 || claim.SessionApp != "" {
+				sessionApp := ente.App(claim.SessionApp)
+				if len(claim.SessionTokenHash) != sha256.Size || !sessionApp.IsValid() {
 					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
 					return
 				}
-				userID = claim.UserID
-				m.Cache.Set(cacheKey, userID, cache.DefaultExpiration)
+				sessionUserID, expired, _, err := authsession.Authenticate(m.UserAuthRepo, m.Cache, claim.SessionTokenHash, sessionApp)
+				if err != nil && !errors.Is(err, sql.ErrNoRows) {
+					logrus.Errorf("Failed to validate JWT session: %s", err)
+					c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to validate token"})
+					return
+				}
+				if err != nil || expired || sessionUserID != userID {
+					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+					return
+				}
 			}
 		}
 		c.Request.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))

--- a/server/pkg/middleware/auth_test.go
+++ b/server/pkg/middleware/auth_test.go
@@ -24,7 +24,7 @@ type authRouteTestTokens struct {
 }
 
 func TestRejectAuthAppKeepsAuthRoutesAndBlocksStorageRoutes(t *testing.T) {
-	router, tokens := setupAuthRouteTest(t)
+	router, tokens, _ := setupAuthRouteTest(t)
 
 	tests := []struct {
 		name       string
@@ -136,7 +136,26 @@ func TestRejectAuthAppKeepsAuthRoutesAndBlocksStorageRoutes(t *testing.T) {
 	}
 }
 
-func setupAuthRouteTest(t *testing.T) (*gin.Engine, authRouteTestTokens) {
+func TestSessionBoundJWTRejectsRevokedOriginSession(t *testing.T) {
+	router, tokens, userController := setupAuthRouteTest(t)
+
+	boundJWT, err := userController.GetSessionJWTToken(91001, jwt.FAMILIES, tokens.auth, ente.Auth)
+	if err != nil {
+		t.Fatalf("failed to create session-bound JWT: %v", err)
+	}
+	if recorder := performAuthRouteRequest(router, "/family/test", boundJWT, "io.ente.photos"); recorder.Code != http.StatusNoContent {
+		t.Fatalf("active session JWT status = %d, want %d; body=%s", recorder.Code, http.StatusNoContent, recorder.Body.String())
+	}
+
+	if err := userController.TerminateSession(91001, tokens.auth); err != nil {
+		t.Fatalf("terminate origin session: %v", err)
+	}
+	if recorder := performAuthRouteRequest(router, "/family/test", boundJWT, "io.ente.photos"); recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked session JWT status = %d, want %d; body=%s", recorder.Code, http.StatusUnauthorized, recorder.Body.String())
+	}
+}
+
+func setupAuthRouteTest(t *testing.T) (*gin.Engine, authRouteTestTokens, *usercontroller.UserController) {
 	t.Helper()
 
 	testutil.WithServerRoot(t)
@@ -157,7 +176,12 @@ func setupAuthRouteTest(t *testing.T) (*gin.Engine, authRouteTestTokens) {
 		photos: "auth-route-test-photos-token",
 		locker: "auth-route-test-locker-token",
 	}
-	userController := &usercontroller.UserController{JwtSecret: []byte("auth-route-test-jwt-secret")}
+	authCache := cache.New(time.Minute, time.Minute)
+	userController := &usercontroller.UserController{
+		UserAuthRepo: userAuthRepo,
+		Cache:        authCache,
+		JwtSecret:    []byte("auth-route-test-jwt-secret"),
+	}
 	var err error
 	tokens.family, err = userController.GetJWTToken(userID, jwt.FAMILIES)
 	if err != nil {
@@ -175,7 +199,7 @@ func setupAuthRouteTest(t *testing.T) (*gin.Engine, authRouteTestTokens) {
 	router := gin.New()
 	authMiddleware := &AuthMiddleware{
 		UserAuthRepo:   userAuthRepo,
-		Cache:          cache.New(time.Minute, time.Minute),
+		Cache:          authCache,
 		UserController: userController,
 	}
 	privateAPI := router.Group("/")
@@ -213,7 +237,7 @@ func setupAuthRouteTest(t *testing.T) (*gin.Engine, authRouteTestTokens) {
 		c.Status(http.StatusNoContent)
 	})
 
-	return router, tokens
+	return router, tokens, userController
 }
 
 func addTokenForTest(t *testing.T, userAuthRepo *repo.UserAuthRepository, userID int64, app ente.App, token string) {


### PR DESCRIPTION
Bind payment, families, and accounts JWTs to the account session that issued them. Validate the originating session on JWT-authenticated requests while accepting unbound JWTs during the rollout window.