### PR TITLE
[server] Require session-bound scoped JWTs

### DIFF
--- a/server/pkg/middleware/auth.go
+++ b/server/pkg/middleware/auth.go
@@ -73,23 +73,20 @@ func (m *AuthMiddleware) TokenAuthMiddleware(jwtClaimScope *jwt.ClaimScope) gin.
 				return
 			}
 			userID = claim.UserID
-			// TODO: Reject missing session fields after the 24-hour rollout window.
-			if len(claim.SessionTokenHash) != 0 || claim.SessionApp != "" {
-				sessionApp := ente.App(claim.SessionApp)
-				if len(claim.SessionTokenHash) != sha256.Size || !sessionApp.IsValid() {
-					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
-					return
-				}
-				sessionUserID, expired, _, err := authsession.Authenticate(m.UserAuthRepo, m.Cache, claim.SessionTokenHash, sessionApp)
-				if err != nil && !errors.Is(err, sql.ErrNoRows) {
-					logrus.Errorf("Failed to validate JWT session: %s", err)
-					c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to validate token"})
-					return
-				}
-				if err != nil || expired || sessionUserID != userID {
-					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
-					return
-				}
+			sessionApp := ente.App(claim.SessionApp)
+			if len(claim.SessionTokenHash) != sha256.Size || !sessionApp.IsValid() {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+				return
+			}
+			sessionUserID, expired, _, err := authsession.Authenticate(m.UserAuthRepo, m.Cache, claim.SessionTokenHash, sessionApp)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				logrus.Errorf("Failed to validate JWT session: %s", err)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to validate token"})
+				return
+			}
+			if err != nil || expired || sessionUserID != userID {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+				return
 			}
 		}
 		c.Request.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))

--- a/server/pkg/middleware/auth_test.go
+++ b/server/pkg/middleware/auth_test.go
@@ -136,8 +136,24 @@ func TestRejectAuthAppKeepsAuthRoutesAndBlocksStorageRoutes(t *testing.T) {
 	}
 }
 
-func TestSessionBoundJWTRejectsRevokedOriginSession(t *testing.T) {
+func TestSessionBoundJWTAuthentication(t *testing.T) {
 	router, tokens, userController := setupAuthRouteTest(t)
+
+	unboundJWT, err := userController.GetJWTToken(91001, jwt.FAMILIES)
+	if err != nil {
+		t.Fatalf("failed to create unbound JWT: %v", err)
+	}
+	if recorder := performAuthRouteRequest(router, "/family/test", unboundJWT, "io.ente.photos"); recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("unbound JWT status = %d, want %d; body=%s", recorder.Code, http.StatusUnauthorized, recorder.Body.String())
+	}
+
+	mismatchedJWT, err := userController.GetSessionJWTToken(91002, jwt.FAMILIES, tokens.auth, ente.Auth)
+	if err != nil {
+		t.Fatalf("failed to create mismatched session JWT: %v", err)
+	}
+	if recorder := performAuthRouteRequest(router, "/family/test", mismatchedJWT, "io.ente.photos"); recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("mismatched session JWT status = %d, want %d; body=%s", recorder.Code, http.StatusUnauthorized, recorder.Body.String())
+	}
 
 	boundJWT, err := userController.GetSessionJWTToken(91001, jwt.FAMILIES, tokens.auth, ente.Auth)
 	if err != nil {
@@ -182,18 +198,18 @@ func setupAuthRouteTest(t *testing.T) (*gin.Engine, authRouteTestTokens, *userco
 		Cache:        authCache,
 		JwtSecret:    []byte("auth-route-test-jwt-secret"),
 	}
-	var err error
-	tokens.family, err = userController.GetJWTToken(userID, jwt.FAMILIES)
-	if err != nil {
-		t.Fatalf("failed to create family JWT: %v", err)
-	}
-	tokens.payment, err = userController.GetJWTToken(userID, jwt.PAYMENT)
-	if err != nil {
-		t.Fatalf("failed to create payment JWT: %v", err)
-	}
 	addTokenForTest(t, userAuthRepo, userID, ente.Auth, tokens.auth)
 	addTokenForTest(t, userAuthRepo, userID, ente.Photos, tokens.photos)
 	addTokenForTest(t, userAuthRepo, userID, ente.Locker, tokens.locker)
+	var err error
+	tokens.family, err = userController.GetSessionJWTToken(userID, jwt.FAMILIES, tokens.auth, ente.Auth)
+	if err != nil {
+		t.Fatalf("failed to create family JWT: %v", err)
+	}
+	tokens.payment, err = userController.GetSessionJWTToken(userID, jwt.PAYMENT, tokens.auth, ente.Auth)
+	if err != nil {
+		t.Fatalf("failed to create payment JWT: %v", err)
+	}
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()


### PR DESCRIPTION
Require payment, families, and accounts JWTs to reference an active originating session.

Deployment gate: deploy only after every Museum instance includes #12536 and at least 24 hours have elapsed since the last legacy issuer stopped. Restart the window after any rollback to an older version.