### PR TITLE
[web][photos] Update signup flow to show planSelector before gallery

### DIFF
--- a/desktop/changes/choose-plan-after-signup.md
+++ b/desktop/changes/choose-plan-after-signup.md
@@ -1,0 +1,1 @@
+- New accounts now choose a storage plan before entering their gallery.

--- a/web/apps/photos/src/components/PlanSelector.tsx
+++ b/web/apps/photos/src/components/PlanSelector.tsx
@@ -88,20 +88,23 @@ export const PlanSelector: React.FC<PlanSelectorProps> = ({
                 backdrop: { sx: { backdropFilter: "blur(30px) opacity(95%)" } },
             }}
         >
-            <PlanSelectorCard {...{ onClose, setLoading, onManageFamily }} />
+            <PlanSelectorContents
+                {...{ onClose, setLoading, onManageFamily }}
+            />
         </Dialog>
     );
 };
 
-type PlanSelectorCardProps = Pick<
+export type PlanSelectorContentsProps = Pick<
     PlanSelectorProps,
     "onClose" | "setLoading" | "onManageFamily"
->;
+> & { onBeginCheckout?: () => void };
 
-const PlanSelectorCard: React.FC<PlanSelectorCardProps> = ({
+export const PlanSelectorContents: React.FC<PlanSelectorContentsProps> = ({
     onClose,
     setLoading,
     onManageFamily,
+    onBeginCheckout,
 }) => {
     const { showMiniDialog } = useBaseContext();
 
@@ -161,6 +164,7 @@ const PlanSelectorCard: React.FC<PlanSelectorCardProps> = ({
         switch (planSelectionOutcome(subscription)) {
             case "buyPlan":
                 try {
+                    onBeginCheckout?.();
                     setLoading(true);
                     await redirectToPaymentsApp(plan.stripeID!, "buy");
                 } catch (e) {

--- a/web/apps/photos/src/pages/gallery.tsx
+++ b/web/apps/photos/src/pages/gallery.tsx
@@ -62,7 +62,7 @@ import { IconButton, Link, Stack, Typography } from "@mui/material";
 import { sessionExpiredDialogAttributes } from "ente-accounts/components/utils/dialog";
 import {
     getAndClearIsFirstLogin,
-    getAndClearJustSignedUp,
+    savedJustSignedUp,
 } from "ente-accounts/services/accounts-db";
 import { stashRedirect } from "ente-accounts/services/redirect";
 import { isSessionInvalid } from "ente-accounts/services/session";
@@ -492,6 +492,11 @@ const Page: React.FC = () => {
                 return;
             }
 
+            if (savedJustSignedUp()) {
+                void router.replace("/plan");
+                return;
+            }
+
             if (!(await validateKey())) {
                 logout();
                 return;
@@ -504,10 +509,6 @@ const Page: React.FC = () => {
             dispatch({ type: "showAll" });
 
             setIsFirstLoad(getAndClearIsFirstLogin());
-
-            if (getAndClearJustSignedUp()) {
-                showPlanSelector();
-            }
 
             const user = ensureLocalUser();
             const masterKey = await masterKeyFromSession();

--- a/web/apps/photos/src/pages/generate.tsx
+++ b/web/apps/photos/src/pages/generate.tsx
@@ -4,6 +4,7 @@ import type { RecoveryKeyPresentationProps } from "ente-accounts/components/Reco
 import { RecoveryKeyForm } from "ente-accounts/components/auth/RecoveryKeyForm";
 import { SetPasswordForm } from "ente-accounts/components/auth/SetPasswordForm";
 import AccountsGeneratePage from "ente-accounts/pages/generate";
+import { useRouter } from "next/router";
 import type React from "react";
 
 function RecoveryKeyPresentation(
@@ -27,10 +28,17 @@ function SetPasswordPresentation(
 }
 
 function GeneratePage(): React.JSX.Element {
+    const router = useRouter();
+
+    function handleRecoveryKeyClose() {
+        void router.push("/plan");
+    }
+
     return (
         <AccountsGeneratePage
             passwordPresentation={SetPasswordPresentation}
             recoveryKeyPresentation={RecoveryKeyPresentation}
+            onRecoveryKeyClose={handleRecoveryKeyClose}
         />
     );
 }

--- a/web/apps/photos/src/pages/plan.tsx
+++ b/web/apps/photos/src/pages/plan.tsx
@@ -1,0 +1,59 @@
+import { PhotosAuthShell } from "@/components/PhotosAuthShell";
+import { PlanSelectorContents } from "@/components/PlanSelector";
+import {
+    getAndClearJustSignedUp,
+    savedJustSignedUp,
+} from "ente-accounts/services/accounts-db";
+import {
+    LoadingIndicator,
+    TranslucentLoadingOverlay,
+} from "ente-base/components/loaders";
+import { haveMasterKeyInSession } from "ente-base/session";
+import { savedAuthToken } from "ente-base/token";
+import { useRouter } from "next/router";
+import { useEffect, useState, type JSX } from "react";
+
+function PlanPage(): JSX.Element {
+    const router = useRouter();
+    const [isReady, setIsReady] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        void (async () => {
+            if (!haveMasterKeyInSession() || !(await savedAuthToken())) {
+                await router.replace("/");
+            } else if (!savedJustSignedUp()) {
+                await router.replace("/gallery");
+            } else {
+                setIsReady(true);
+            }
+        })();
+    }, [router]);
+
+    function handleContinue() {
+        getAndClearJustSignedUp();
+        void router.push("/gallery");
+    }
+
+    function handleBeginCheckout() {
+        getAndClearJustSignedUp();
+    }
+
+    if (!isReady) return <LoadingIndicator />;
+
+    return (
+        <>
+            <PhotosAuthShell contentWidth={420}>
+                <PlanSelectorContents
+                    onClose={handleContinue}
+                    setLoading={setIsLoading}
+                    onManageFamily={handleContinue}
+                    onBeginCheckout={handleBeginCheckout}
+                />
+            </PhotosAuthShell>
+            {isLoading && <TranslucentLoadingOverlay />}
+        </>
+    );
+}
+
+export default PlanPage;

--- a/web/packages/accounts/pages/generate.tsx
+++ b/web/packages/accounts/pages/generate.tsx
@@ -47,11 +47,13 @@ import {
 export interface GeneratePageProps {
     passwordPresentation?: ComponentType<NewPasswordPresentationProps>;
     recoveryKeyPresentation?: ComponentType<RecoveryKeyPresentationProps>;
+    onRecoveryKeyClose?: () => void;
 }
 
 const Page: React.FC<GeneratePageProps> = ({
     passwordPresentation,
     recoveryKeyPresentation,
+    onRecoveryKeyClose,
 }) => {
     const { logout, showMiniDialog } = useBaseContext();
 
@@ -106,7 +108,11 @@ const Page: React.FC<GeneratePageProps> = ({
     );
 
     function handleRecoveryKeyClose() {
-        void router.push(appHomeRoute);
+        if (onRecoveryKeyClose) {
+            onRecoveryKeyClose();
+        } else {
+            void router.push(appHomeRoute);
+        }
     }
 
     if (openRecoveryKey && recoveryKeyPresentation) {

--- a/web/packages/new/photos/services/user-details.ts
+++ b/web/packages/new/photos/services/user-details.ts
@@ -217,7 +217,8 @@ export const cancelStripeSubscription = async () => {
     return pullUserDetails();
 };
 
-const paymentsAppOrigin = "https://payments.ente.com";
+const paymentsAppOrigin =
+    process.env.NEXT_PUBLIC_PAYMENTS_APP_ORIGIN ?? "https://payments.ente.com";
 
 export const redirectToPaymentsApp = async (
     productID: string,

--- a/web/packages/new/photos/services/user-details.ts
+++ b/web/packages/new/photos/services/user-details.ts
@@ -217,8 +217,7 @@ export const cancelStripeSubscription = async () => {
     return pullUserDetails();
 };
 
-const paymentsAppOrigin =
-    process.env.NEXT_PUBLIC_PAYMENTS_APP_ORIGIN ?? "https://payments.ente.com";
+const paymentsAppOrigin = "https://payments.ente.com";
 
 export const redirectToPaymentsApp = async (
     productID: string,


### PR DESCRIPTION
## Description

Previously the PlanSelector was shown in the /gallery during the signup, now it's with the auth flow for the signup

<img width="709" height="500" alt="image" src="https://github.com/user-attachments/assets/02f7c56c-84ae-4d2c-ab0c-ed44629d8ecb" />


