### PR TITLE
[server] Verify GHCR publish source

### DIFF
--- a/.github/workflows/server-publish-ghcr.yml
+++ b/.github/workflows/server-publish-ghcr.yml
@@ -7,6 +7,7 @@ on:
     workflow_dispatch:
 
 permissions:
+    actions: read
     contents: read
     packages: write
 
@@ -15,9 +16,19 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Determine commit from prod museum
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   museum_commit="$(curl -s https://api.ente.com/ping | jq -r .id)"
                   [[ "${museum_commit}" =~ ^[0-9a-f]{40}$ ]]
+                  [[ "$(gh run list \
+                      --repo "${GITHUB_REPOSITORY}" \
+                      --workflow server-release.yml \
+                      --commit "${museum_commit}" \
+                      --status success \
+                      --limit 1 \
+                      --json databaseId \
+                      --jq length)" -gt 0 ]]
                   echo "museum_commit=${museum_commit}" >> $GITHUB_ENV
 
             - name: Checkout prod museum commit


### PR DESCRIPTION
Require the production-reported server commit to have a successful server release workflow run before publishing it to GHCR.