### PR TITLE
[mob][photos] Refine justified gallery row packing

### DIFF
--- a/mobile/apps/photos/lib/models/gallery/justified_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/justified_layout.dart
@@ -96,6 +96,9 @@ class JustifiedLayoutCalculator {
   static const double _minimumAspectRatio = 1 / 3;
   static const double _maximumAspectRatio = 4.0;
   static const double _maximumRowHeightFactor = 2.4;
+  static const double _minimumLandscapeTrioHeightFactor = 0.88;
+  // Keep rows visually scannable even when more items would remain tappable.
+  static const int _maximumItemsPerRow = 3;
   // Logical pixels map to density-independent tap extents on both platforms.
   static const double _minimumTappableExtent = 48.0;
 
@@ -128,6 +131,7 @@ class JustifiedLayoutCalculator {
     final rows = <JustifiedRowLayout>[];
     final pendingRatios = <double>[];
     final maximumRowHeight = targetRowHeight * _maximumRowHeightFactor;
+    final lastCommittedRatios = <double>[];
     var pendingRatioSum = 0.0;
     var pendingMinimumRatio = double.infinity;
     var pendingFirstIndex = 0;
@@ -136,7 +140,10 @@ class JustifiedLayoutCalculator {
     double widthWithoutGaps(int itemCount) =>
         math.max(1, availableWidth - spacing * (itemCount - 1));
 
-    void addPendingRow({required bool fillWidth}) {
+    void addPendingRow({
+      required bool fillWidth,
+      double raggedHeightFactor = 1,
+    }) {
       if (pendingRatios.isEmpty) return;
       final contentWidth = widthWithoutGaps(pendingRatios.length);
       final fittedHeight = contentWidth / pendingRatioSum;
@@ -148,7 +155,10 @@ class JustifiedLayoutCalculator {
           ? fittedHeight
           : math.min(
               fittedHeight,
-              math.max(targetRowHeight, minimumTappableHeight),
+              math.max(
+                targetRowHeight * raggedHeightFactor,
+                minimumTappableHeight,
+              ),
             );
       final widths = pendingRatios
           .map((ratio) => ratio * height)
@@ -170,11 +180,54 @@ class JustifiedLayoutCalculator {
           itemWidths: UnmodifiableListView(widths),
         ),
       );
+      lastCommittedRatios
+        ..clear()
+        ..addAll(pendingRatios);
       rowOffset += height + spacing;
       pendingFirstIndex += pendingRatios.length;
       pendingRatios.clear();
       pendingRatioSum = 0;
       pendingMinimumRatio = double.infinity;
+    }
+
+    bool canFillWidth(
+      List<double> ratios, {
+      bool applyLandscapeDensityRule = false,
+    }) {
+      final ratioSum = ratios.fold<double>(0, (sum, ratio) => sum + ratio);
+      final height = widthWithoutGaps(ratios.length) / ratioSum;
+      final minimumWidth =
+          height * ratios.reduce((left, right) => math.min(left, right));
+      final isTappableAndBounded =
+          height >= _minimumTappableExtent &&
+          height <= maximumRowHeight &&
+          minimumWidth >= _minimumTappableExtent;
+      if (!isTappableAndBounded) return false;
+
+      return !applyLandscapeDensityRule ||
+          ratios.length != _maximumItemsPerRow ||
+          ratios.any((ratio) => ratio < 1) ||
+          height >= targetRowHeight * _minimumLandscapeTrioHeightFactor;
+    }
+
+    void replacePendingRatios(Iterable<double> ratios) {
+      pendingRatios
+        ..clear()
+        ..addAll(ratios);
+      pendingRatioSum = pendingRatios.fold<double>(
+        0,
+        (sum, ratio) => sum + ratio,
+      );
+      pendingMinimumRatio = pendingRatios.fold<double>(
+        double.infinity,
+        (minimum, ratio) => math.min(minimum, ratio),
+      );
+    }
+
+    void rewindLastRow() {
+      final removedRow = rows.removeLast();
+      rowOffset = removedRow.minOffset;
+      pendingFirstIndex = removedRow.firstIndex;
     }
 
     for (final rawRatio in aspectRatios) {
@@ -190,18 +243,36 @@ class JustifiedLayoutCalculator {
             candidateHeight * math.min(pendingMinimumRatio, ratio);
         final currentHeight =
             widthWithoutGaps(pendingRatios.length) / pendingRatioSum;
-        final wouldOverCompress =
+        final violatesTapTarget =
             candidateHeight < _minimumTappableExtent ||
             candidateMinimumWidth < _minimumTappableExtent;
+        final violatesLandscapeDensity =
+            candidateCount == _maximumItemsPerRow &&
+            pendingMinimumRatio >= 1 &&
+            ratio >= 1 &&
+            candidateHeight <
+                targetRowHeight * _minimumLandscapeTrioHeightFactor;
 
-        if (wouldOverCompress) {
-          addPendingRow(fillWidth: currentHeight <= maximumRowHeight);
+        if (violatesTapTarget || violatesLandscapeDensity) {
+          final leaveSingletonRagged = pendingRatios.length == 1;
+          addPendingRow(
+            fillWidth:
+                !leaveSingletonRagged && currentHeight <= maximumRowHeight,
+          );
         }
       }
 
       pendingRatios.add(ratio);
       pendingRatioSum += ratio;
       pendingMinimumRatio = math.min(pendingMinimumRatio, ratio);
+
+      if (pendingRatios.length == _maximumItemsPerRow) {
+        // With a hard item cap and gap-free non-final rows, very narrow items
+        // can require a row taller than the normal soft height bound. Prefer
+        // the two product constraints when all three cannot be satisfied.
+        addPendingRow(fillWidth: true);
+        continue;
+      }
 
       final naturalWidth =
           pendingRatioSum * targetRowHeight +
@@ -211,7 +282,44 @@ class JustifiedLayoutCalculator {
       }
     }
 
-    addPendingRow(fillWidth: false);
+    // Avoid leaving a single item at the end of a group when the last few
+    // items can instead form full-width rows without creating a cramped row.
+    if (pendingRatios.length == 1 && rows.isNotEmpty) {
+      final tailRatios = <double>[...lastCommittedRatios, pendingRatios.single];
+      if (lastCommittedRatios.length < _maximumItemsPerRow &&
+          canFillWidth(tailRatios, applyLandscapeDensityRule: true)) {
+        rewindLastRow();
+        replacePendingRatios(tailRatios);
+        addPendingRow(fillWidth: true);
+      } else if (lastCommittedRatios.length == _maximumItemsPerRow) {
+        final firstPair = tailRatios.sublist(0, 2);
+        final secondPair = tailRatios.sublist(2);
+        if (canFillWidth(firstPair) && canFillWidth(secondPair)) {
+          rewindLastRow();
+          replacePendingRatios(firstPair);
+          addPendingRow(fillWidth: true);
+          replacePendingRatios(secondPair);
+          addPendingRow(fillWidth: true);
+        }
+      }
+    }
+
+    if (pendingRatios.isNotEmpty) {
+      final canJustifyFinalRow = canFillWidth(
+        pendingRatios,
+        applyLandscapeDensityRule: true,
+      );
+      final singletonHeightFactor =
+          pendingRatios.length == 1 && pendingRatios.single < 1
+          ? math.min(_maximumRowHeightFactor, 1 / pendingRatios.single)
+          : 1.0;
+      addPendingRow(
+        fillWidth: pendingRatios.length > 1 && canJustifyFinalRow,
+        // Give a lone portrait roughly one target-width column without
+        // making landscape singletons or forced non-final rows taller.
+        raggedHeightFactor: singletonHeightFactor,
+      );
+    }
     return UnmodifiableListView(rows);
   }
 }

--- a/mobile/apps/photos/lib/models/gallery/justified_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/justified_layout.dart
@@ -282,8 +282,8 @@ class JustifiedLayoutCalculator {
       }
     }
 
-    // Avoid leaving a single item at the end of a group when the last few
-    // items can instead form full-width rows without creating a cramped row.
+    // Product decision: avoid one-item group tails by rebalancing the preceding
+    // row when the replacement rows meet tap-target, height, and density limits.
     if (pendingRatios.length == 1 && rows.isNotEmpty) {
       final tailRatios = <double>[...lastCommittedRatios, pendingRatios.single];
       if (lastCommittedRatios.length < _maximumItemsPerRow &&

--- a/mobile/apps/photos/lib/models/gallery/justified_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/justified_layout.dart
@@ -97,7 +97,8 @@ class JustifiedLayoutCalculator {
   static const double _maximumAspectRatio = 4.0;
   static const double _maximumRowHeightFactor = 2.4;
   static const double _minimumLandscapeTrioHeightFactor = 0.88;
-  // Keep rows visually scannable even when more items would remain tappable.
+  // Product decision: cap visual density at three items per row,
+  // independently of tap-target sizing.
   static const int _maximumItemsPerRow = 3;
   // Logical pixels map to density-independent tap extents on both platforms.
   static const double _minimumTappableExtent = 48.0;
@@ -267,9 +268,8 @@ class JustifiedLayoutCalculator {
       pendingMinimumRatio = math.min(pendingMinimumRatio, ratio);
 
       if (pendingRatios.length == _maximumItemsPerRow) {
-        // With a hard item cap and gap-free non-final rows, very narrow items
-        // can require a row taller than the normal soft height bound. Prefer
-        // the two product constraints when all three cannot be satisfied.
+        // A three-item row may exceed maximumRowHeight: the three-item cap and
+        // fully justified non-final rows take precedence over that soft limit.
         addPendingRow(fillWidth: true);
         continue;
       }

--- a/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
+++ b/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
@@ -170,12 +170,16 @@ void main() {
       expect(rowAcrossLegacyBoundary.firstIndex, 39);
       expect(rowAcrossLegacyBoundary.lastIndex, 41);
 
-      for (final index in [75, fileCount - 1]) {
-        final fileOffset = groups.getOffsetOfFile(files[index]);
+      for (final row in section.rows) {
+        final firstFileInRow = files[row.firstIndex];
+        final fileOffset = groups.getOffsetOfFile(firstFileInRow);
         expect(fileOffset, isNotNull);
-        expect(groups.getFileAtScrollOffset(fileOffset!), same(files[index]));
+        expect(groups.getFileAtScrollOffset(fileOffset!), same(firstFileInRow));
       }
-      expect(groups.getFileAtScrollOffset(section.maxOffset), same(files.last));
+      expect(
+        groups.getFileAtScrollOffset(section.maxOffset),
+        same(files[section.rows.last.firstIndex]),
+      );
     },
   );
 

--- a/mobile/apps/photos/test/models/justified_layout_test.dart
+++ b/mobile/apps/photos/test/models/justified_layout_test.dart
@@ -22,7 +22,7 @@ void main() {
       const availableWidth = 400.0;
       const spacing = 2.0;
       final rows = JustifiedLayoutCalculator.computeRows(
-        aspectRatios: const [1, 1, 1, 1],
+        aspectRatios: const [1, 1, 1],
         availableWidth: availableWidth,
         targetRowHeight: 100,
         spacing: spacing,
@@ -30,49 +30,60 @@ void main() {
 
       expect(rows, hasLength(1));
       final row = rows.single;
-      final occupiedWidth =
-          row.itemWidths.fold<double>(0, (sum, width) => sum + width) +
-          spacing * (row.itemWidths.length - 1);
-      expect(occupiedWidth, closeTo(availableWidth, 1e-9));
-      expect(row.itemWidths, everyElement(closeTo(98.5, 1e-9)));
+      expect(row.itemWidths, hasLength(3));
+      expect(_occupiedWidth(row, spacing), closeTo(availableWidth, 1e-9));
     });
 
-    test("an already-tappable final row stays at the target height", () {
+    test("a two-item final row expands to the full available width", () {
       const availableWidth = 400.0;
-      const targetRowHeight = 100.0;
       const spacing = 2.0;
       final rows = JustifiedLayoutCalculator.computeRows(
         aspectRatios: const [1, 1],
         availableWidth: availableWidth,
-        targetRowHeight: targetRowHeight,
+        targetRowHeight: 100,
         spacing: spacing,
       );
 
       expect(rows, hasLength(1));
       final row = rows.single;
-      expect(row.height, targetRowHeight);
+      expect(row.itemWidths, hasLength(2));
       expect(row.itemWidths, everyElement(row.height));
-      final occupiedWidth =
-          row.itemWidths.fold<double>(0, (sum, width) => sum + width) + spacing;
-      expect(occupiedWidth, lessThanOrEqualTo(availableWidth));
+      expect(_occupiedWidth(row, spacing), closeTo(availableWidth, 1e-9));
     });
 
-    test("a sparse portrait final row remains ragged and tappable", () {
-      const availableWidth = 400.0;
-      const targetRowHeight = 100.0;
+    test("sizes final singletons by orientation and caps extremes", () {
+      const targetRowHeight = 200.0;
+      JustifiedRowLayout rowFor(double ratio) {
+        return JustifiedLayoutCalculator.computeRows(
+          aspectRatios: [ratio],
+          availableWidth: 402,
+          targetRowHeight: targetRowHeight,
+          spacing: 2,
+        ).single;
+      }
+
+      final portrait = rowFor(9 / 16);
+      final extremePortrait = rowFor(0.25);
+      final landscape = rowFor(3 / 2);
+
+      expect(portrait.itemWidths.single, targetRowHeight);
+      expect(extremePortrait.height, targetRowHeight * 2.4);
+      expect(
+        extremePortrait.itemWidths.single / extremePortrait.height,
+        closeTo(1 / 3, 1e-9),
+      );
+      expect(landscape.height, targetRowHeight);
+    });
+
+    test("rebalances a portrait orphan without disturbing earlier rows", () {
       final rows = JustifiedLayoutCalculator.computeRows(
-        aspectRatios: const [0.25],
-        availableWidth: availableWidth,
-        targetRowHeight: targetRowHeight,
+        aspectRatios: List.filled(7, 9 / 16),
+        availableWidth: 393,
+        targetRowHeight: (393 - 2) / 2,
         spacing: 2,
       );
 
-      expect(rows, hasLength(1));
-      final row = rows.single;
-      expect(row.height, 144);
-      expect(row.itemWidths.single / row.height, closeTo(1 / 3, 1e-9));
-      expect(row.itemWidths.single, closeTo(48, 1e-9));
-      expect(row.itemWidths.single, lessThan(availableWidth));
+      expect(rows.map((row) => row.lastIndex - row.firstIndex + 1), [3, 2, 2]);
     });
 
     test("keeps a tappable portrait with the following panorama", () {
@@ -92,9 +103,7 @@ void main() {
       expect(row.height, closeTo(391 / 4.85, 1e-9));
       expect(row.height, greaterThanOrEqualTo(48));
       expect(row.itemWidths, everyElement(greaterThanOrEqualTo(48)));
-      final occupiedWidth =
-          row.itemWidths.fold<double>(0, (sum, width) => sum + width) + spacing;
-      expect(occupiedWidth, closeTo(availableWidth, 1e-9));
+      expect(_occupiedWidth(row, spacing), closeTo(availableWidth, 1e-9));
     });
 
     test("does not squeeze an extreme item into a mixed row", () {
@@ -159,6 +168,56 @@ void main() {
       expect(rows.single.height, 48);
       expect(rows.single.itemWidths, [192]);
     });
+
+    test("caps rows at three items even when more would fit", () {
+      final rows = JustifiedLayoutCalculator.computeRows(
+        aspectRatios: const [0.4, 0.4, 1.0, 0.4],
+        availableWidth: 393,
+        targetRowHeight: 195.5,
+        spacing: 2,
+      );
+
+      expect(rows.expand((row) => row.itemWidths), hasLength(4));
+      expect(
+        rows.map((row) => row.itemWidths.length),
+        everyElement(lessThanOrEqualTo(3)),
+      );
+    });
+
+    test("keeps typical landscapes to pairs", () {
+      final rows = JustifiedLayoutCalculator.computeRows(
+        aspectRatios: const [4 / 3, 4 / 3, 4 / 3],
+        availableWidth: 393,
+        targetRowHeight: (393 - 4) / 3,
+        spacing: 2,
+      );
+
+      expect(rows.map((row) => row.itemWidths.length), [2, 1]);
+    });
+
+    test("merges a final portrait with a tappable two-item row", () {
+      final rows = JustifiedLayoutCalculator.computeRows(
+        aspectRatios: const [1.0, 1.0, 0.5],
+        availableWidth: 393,
+        targetRowHeight: (393 - 2) / 2,
+        spacing: 2,
+      );
+
+      expect(rows, hasLength(1));
+      expect(rows.single.itemWidths, hasLength(3));
+    });
+
+    test("forced non-final singleton uses the target row height", () {
+      final rows = JustifiedLayoutCalculator.computeRows(
+        aspectRatios: const [0.5, 4],
+        availableWidth: 393,
+        targetRowHeight: 130,
+        spacing: 2,
+      );
+
+      expect(rows, hasLength(2));
+      expect(rows.first.height, 130);
+    });
   });
 
   group("JustifiedSectionLayout", () {
@@ -215,4 +274,9 @@ void main() {
       expect(section.getMinChildIndexForScrollOffset(169), 13);
     });
   });
+}
+
+double _occupiedWidth(JustifiedRowLayout row, double spacing) {
+  return row.itemWidths.fold<double>(0, (sum, width) => sum + width) +
+      spacing * (row.itemWidths.length - 1);
 }


### PR DESCRIPTION
## Description

Refines the internal Justified gallery layout to keep rows visually scannable and reduce awkward group tails.

- Caps rows at three items and avoids overly compressed all-landscape trios.
- Rebalances portrait orphans while preserving tap-target constraints.
- Fills viable multi-item tails and sizes singleton portraits without enlarging landscape or forced non-final singletons.