### PR TITLE
Fix reviewed mobile translations

### DIFF
--- a/mobile/packages/strings/lib/l10n/arb/strings_et.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_et.arb
@@ -182,7 +182,7 @@
     "description": "Placeholder text for comment input field"
   },
   "comments": "Kommentaarid",
-  "commentsCount": "{count, plural, =0{Kommentare pole} one{{count} kommentar} other{{count} kommentari}}",
+  "commentsCount": "{count, plural, =0{Kommentaare pole} one{{count} kommentaar} other{{count} kommentari}}",
   "@commentsCount": {
     "description": "Number of comments with pluralization",
     "placeholders": {

--- a/mobile/packages/strings/lib/l10n/arb/strings_sv.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_sv.arb
@@ -639,7 +639,7 @@
   "@deletedComment": {
     "description": "Label for deleted comments"
   },
-  "deletedFromEnte": "Radera från Ente",
+  "deletedFromEnte": "Raderad från Ente",
   "deletedItemsStayHereForThirtyDays": "Raderade objekt stannar här i 30 dagar",
   "deleteDuplicates": "Radera dubbletter",
   "deleteEmptyAlbums": "Ta bort tomma album",

--- a/mobile/packages/strings/lib/l10n/arb/strings_vi.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_vi.arb
@@ -2084,7 +2084,7 @@
   "librarySharingShareWith": "Chia sẻ với",
   "librarySharingSharingWith": "Đang chia sẻ với",
   "librarySharingStopSharing": "Ngừng chia sẻ",
-  "librarySharingStopSharingDescription": "{count, plural, other{Họ sẽ mất những album này và mọi ảnh họ đã thêm sẽ được giữ lại. Bạn có thể chia sẻ lại sau.}}",
+  "librarySharingStopSharingDescription": "{count, plural, other{Họ sẽ mất những album này và mọi ảnh họ đã thêm cũng sẽ bị xóa khỏi album. Bạn có thể chia sẻ lại sau.}}",
   "@librarySharingStopSharingDescription": {
     "placeholders": {
       "count": {


### PR DESCRIPTION
Fixes all translation issues raised in the automated review of #12381:

- correct the Vietnamese library-sharing removal warning
- change the Swedish ignored-upload reason from an action to a status
- correct the Estonian zero- and one-comment forms

Validation:
- parsed all three ARB files with `jq`
- ran `flutter gen-l10n` successfully
- ran `git diff --check`