### PR TITLE
[docs] Document iOS Backup mode and upload cache cleanup

### DIFF
--- a/docs/docs/photos/faq/backup-and-sync.md
+++ b/docs/docs/photos/faq/backup-and-sync.md
@@ -79,9 +79,9 @@ The initial backup can take time depending on:
 
 **On iOS:**
 
-- Keep the app open in foreground for large initial uploads
-- Disable automatic screen lock temporarily (`Settings > Backup > Backup settings > Disable auto lock`)
-- Videos won't backup in background - keep the app open for them
+- Open [Backup mode](/photos/features/backup-and-sync/#backup-mode-ios) under `Settings > Backup > Backup settings` and tap **Start backup mode**
+- Keep Ente open on screen. Switching apps pauses Backup mode
+- Keep your phone connected to power and stable WiFi until the backup finishes
 
 **On Android:**
 
@@ -97,6 +97,19 @@ The initial backup can take time depending on:
 ### What happens if my backup is interrupted? {#backup-interrupted}
 
 If your backup is interrupted (due to network issues, closing the app, or other reasons), Ente will automatically resume from where it left off the next time you have connectivity. You don't need to restart the entire backup process.
+
+### Why is Ente using more device storage during backup? {#backup-device-storage}
+
+Ente needs temporary space while preparing and uploading your photos and videos. On iPhone, Ente may first download the full-resolution original from iCloud. Ente also creates an encrypted copy for upload. Encryption protects the file before it leaves your phone.
+
+Large videos and interrupted uploads can increase this storage. Ente removes the temporary data after an upload finishes. If an upload is interrupted, Ente keeps the data so it can continue instead of starting over.
+
+Try these steps:
+
+1. Open `Settings > Free up space > Manage device cache` and tap **Clear caches**. This removes thumbnails and previews that Ente can recreate. It does not remove files shown under **Pending sync** because Ente still needs them to finish your backup.
+2. If your phone has enough space, let the backup finish. For large uploads on iPhone, open [Backup mode](/photos/features/backup-and-sync/#backup-mode-ios) under `Settings > Backup > Backup settings` and tap **Start backup mode**. Connect your phone to power and stable WiFi. Keep Ente open on screen until the backup finishes.
+3. If your phone does not have enough space, turn off **Backup videos** under `Settings > Backup > Backup settings` for two days. You can continue using Ente during this time. After two days, close and reopen Ente once. Ente will remove old upload data when it starts. Then turn **Backup videos** back on and use Backup mode to finish the backup.
+4. If **Pending sync** is still large, [share your logs with support](/photos/faq/troubleshooting#sharing-logs). Include a screenshot of the **Manage device cache** screen.
 
 ### Do deleted photos on my device also delete from Ente? {#deletion-sync}
 
@@ -148,7 +161,7 @@ Yes! Once photos are safely backed up to Ente, you can delete them from your dev
 
 **On mobile:**
 
-Use Ente's "Free up space" feature at `Settings > Backup > Free up space`. Ente will show photos that are backed up and can be safely deleted. Review and confirm deletion.
+Use Ente's "Free up space" feature at `Settings > Free up space`. Ente will show photos that are backed up and can be safely deleted. Review and confirm deletion.
 
 This feature only deletes photos that have been successfully uploaded to Ente. Photos remain in Ente and can be re-downloaded anytime.
 
@@ -443,17 +456,17 @@ If you're using the web version, you'll need to keep the browser tab open for up
 
 ### How does background sync work on iOS? {#ios-background-sync}
 
-On iOS, background sync works through silent push notifications:
+On iOS, background sync uses silent notifications:
 
-- Our servers "tickle" your device periodically
-- This wakes up the app and gives it 30 seconds to sync
+- Ente asks iOS to start a short backup from time to time
+- iOS briefly wakes Ente to upload new photos
 - Videos may not upload in background due to size limitations
 
 > [!IMPORTANT]
 >
-> If you force-kill the app from recents, iOS won't deliver push notifications and background sync will stop working.
+> Do not swipe Ente away from the app switcher. iOS cannot wake Ente for background backups after the app has been closed this way.
 
-For large initial backups, keep the app open in foreground on iOS.
+For large initial backups and videos, use [Backup mode](/photos/features/backup-and-sync/#backup-mode-ios) and keep Ente open on screen.
 
 ### How does background sync work on Android? {#android-background-sync}
 

--- a/docs/docs/photos/faq/backup-and-sync.md
+++ b/docs/docs/photos/faq/backup-and-sync.md
@@ -106,10 +106,9 @@ Large videos and interrupted uploads can increase this storage. Ente removes the
 
 Try these steps:
 
-1. Open `Settings > Free up space > Manage device cache` and tap **Clear caches**. This removes thumbnails and previews that Ente can recreate. It does not remove files shown under **Pending sync** because Ente still needs them to finish your backup.
-2. If your phone has enough space, let the backup finish. For large uploads on iPhone, open [Backup mode](/photos/features/backup-and-sync/#backup-mode-ios) under `Settings > Backup > Backup settings` and tap **Start backup mode**. Connect your phone to power and stable WiFi. Keep Ente open on screen until the backup finishes.
-3. If your phone does not have enough space, turn off **Backup videos** under `Settings > Backup > Backup settings` for two days. You can continue using Ente during this time. After two days, close and reopen Ente once. Ente will remove old upload data when it starts. Then turn **Backup videos** back on and use Backup mode to finish the backup.
-4. If **Pending sync** is still large, [share your logs with support](/photos/faq/troubleshooting#sharing-logs). Include a screenshot of the **Manage device cache** screen.
+1. If your phone has enough space, let the backup finish. For large uploads on iPhone, open [Backup mode](/photos/features/backup-and-sync/#backup-mode-ios) under `Settings > Backup > Backup settings` and tap **Start backup mode**. Connect your phone to power and stable WiFi. Keep Ente open on screen until the backup finishes.
+2. If your phone does not have enough space, turn off **Backup videos** under `Settings > Backup > Backup settings` for two days. You can continue using Ente during this time. After two days, close and reopen Ente once. Ente will remove old upload data when it starts. Then turn **Backup videos** back on and use Backup mode to finish the backup.
+3. If **Pending sync** is still large, [share your logs with support](/photos/faq/troubleshooting#sharing-logs). Include a screenshot of the **Manage device cache** screen.
 
 ### Do deleted photos on my device also delete from Ente? {#deletion-sync}
 

--- a/docs/docs/photos/faq/troubleshooting.md
+++ b/docs/docs/photos/faq/troubleshooting.md
@@ -612,15 +612,15 @@ Overheating usually happens when Ente works through a large historical backup at
 
 **Steps to take:**
 
-1. Plug in your iPhone, remove the case if you use one, connect to WiFi, and leave Ente open in the foreground.
-2. Disable auto-lock.
+1. Plug in your iPhone, remove the case if you use one, and connect to WiFi.
+2. Open [Backup mode](/photos/features/backup-and-sync/#backup-mode-ios) under `Settings > Backup > Backup settings`, tap **Start backup mode**, and leave Ente open on screen.
 3. Close all other apps before starting.
 4. If the phone still overheats, turn off ML and video streaming: `Settings > Machine learning` and `Settings > Video streaming`.
 5. Let it run overnight, then re-enable ML and video streaming once the upload completes.
 
 > [!NOTE]
 >
-> iOS can still throttle, suspend, or terminate apps under heat pressure even with auto-lock disabled - that setting only keeps the screen from sleeping while the app is active, not the app from being suspended by the system. This can slow uploads considerably.
+> iOS can still throttle, suspend, or close apps under heat pressure while Backup mode is running. This can slow uploads considerably.
 >
 > If iCloud Photos "Optimize iPhone Storage" is enabled, originals may need to download from iCloud first, which can also slow or stall uploads.
 >
@@ -638,20 +638,15 @@ If you're running into repeated crashes on a low-RAM device:
 
 ### How can I clear the cache from the Ente app? {#clear-cache}
 
-If you notice storage usage growing or temporary files not clearing automatically, you can safely remove the cache:
+If Ente uses more storage during backup, see [why backups need temporary space](/photos/faq/backup-and-sync#backup-device-storage).
 
 **Clear the cache manually:**
 
 1. Open Ente Photos.
-2. Go to `Settings → Backup → Free up space → Manage device cache`.
-3. Tap **Clear cache**.
+2. Go to `Settings > Free up space > Manage device cache`.
+3. Tap **Clear caches**.
 
-This deletes temporary files such as thumbnails and preloaded images that can be regenerated when needed.
-
-**Automatic cache cleanup:**
-
-- Ente clears upload-related temporary files and pending syncs every 6 hours.
-- If the cache or sync state still hasn't cleared after 6 hours, force-close (kill) and reopen Ente Photos to trigger the manual cleanup.
+This removes thumbnails and previews that Ente can recreate. It does not remove files shown under **Pending sync** because Ente still needs them to finish your backup. Ente removes this data after the upload finishes. Old upload data is removed after it is no longer needed for another attempt.
 
 ## Getting Help
 

--- a/docs/docs/photos/features/albums-and-organization/storage-optimization.md
+++ b/docs/docs/photos/features/albums-and-organization/storage-optimization.md
@@ -45,14 +45,6 @@ The app will delete all photos and videos that have been successfully backed up 
 - All photos remain in Ente's cloud
 - Any photos in albums you haven't selected for backup
 
-## Manage device cache
-
-Ente saves thumbnails and previews on your device so photos and videos open faster. You can review this storage under `Settings > Free up space > Manage device cache`.
-
-Tap **Clear caches** to remove files that Ente can recreate. This does not remove files shown under **Pending sync** because Ente still needs them to finish your backup.
-
-Storage may grow during a large or interrupted backup. Learn [why backups need temporary space and how to reduce it](/photos/faq/backup-and-sync#backup-device-storage).
-
 ### Re-downloading photos
 
 When you free up space, photos are removed from your device but stay in Ente. To view a photo:
@@ -62,6 +54,14 @@ When you free up space, photos are removed from your device but stay in Ente. To
 - To download and view the photo in any other gallery
     - Long press the thumbnail and choose download option
     - Open the photo, choose the three dots at top right and choose download option.
+
+## Manage device cache
+
+Ente saves thumbnails and previews on your device so photos and videos open faster. You can review this storage under `Settings > Free up space > Manage device cache`.
+
+Tap **Clear caches** to remove files that Ente can recreate. This does not remove files shown under **Pending sync** because Ente still needs them to finish your backup.
+
+Storage may grow during a large or interrupted backup. Learn [why backups need temporary space and how to reduce it](/photos/faq/backup-and-sync#backup-device-storage).
 
 ## Remove exact duplicates
 

--- a/docs/docs/photos/features/albums-and-organization/storage-optimization.md
+++ b/docs/docs/photos/features/albums-and-organization/storage-optimization.md
@@ -15,7 +15,7 @@ Once your photos are safely backed up to Ente, you can free up storage space on 
 
 **On mobile (iOS and Android):**
 
-Open `Settings > Backup > Free up space > Free up device space`, review how much space will be freed, and confirm to delete backed-up photos from your device.
+Open `Settings > Free up space > Free up device space`, review how much space will be freed, and confirm to delete backed-up photos from your device.
 
 <div align="center">
 
@@ -45,6 +45,14 @@ The app will delete all photos and videos that have been successfully backed up 
 - All photos remain in Ente's cloud
 - Any photos in albums you haven't selected for backup
 
+## Manage device cache
+
+Ente saves thumbnails and previews on your device so photos and videos open faster. You can review this storage under `Settings > Free up space > Manage device cache`.
+
+Tap **Clear caches** to remove files that Ente can recreate. This does not remove files shown under **Pending sync** because Ente still needs them to finish your backup.
+
+Storage may grow during a large or interrupted backup. Learn [why backups need temporary space and how to reduce it](/photos/faq/backup-and-sync#backup-device-storage).
+
 ### Re-downloading photos
 
 When you free up space, photos are removed from your device but stay in Ente. To view a photo:
@@ -73,7 +81,7 @@ The deduplication tool:
 
 **On mobile:**
 
-Open `Settings > Backup > Free up space > Remove duplicates`, review the duplicates found, and confirm to remove them.
+Open `Settings > Free up space > Remove duplicates`, review the duplicates found, and confirm to remove them.
 
 **On desktop:**
 
@@ -109,7 +117,7 @@ The similar images feature:
 
 **On mobile:**
 
-Open `Settings > Backup > Free up space > Similar images`, review each group of similar photos, choose which to keep and which to delete, and confirm your selections.
+Open `Settings > Free up space > Similar images`, review each group of similar photos, choose which to keep and which to delete, and confirm your selections.
 
 **On desktop:**
 
@@ -151,7 +159,7 @@ The large files feature:
 
 **On mobile:**
 
-Open `Settings > Backup > Free up space > Large files` to see your largest files sorted by size.
+Open `Settings > Free up space > Large files` to see your largest files sorted by size.
 
 **On desktop:**
 
@@ -192,7 +200,7 @@ When a suggestion is made:
 
 **On mobile:**
 
-Open `Settings > Backup > Free up space > Delete suggestions` to see photos that have been suggested for deletion.
+Open `Settings > Free up space > Delete suggestions` to see photos that have been suggested for deletion.
 
 For each suggestion, you can:
 

--- a/docs/docs/photos/features/backup-and-sync/index.md
+++ b/docs/docs/photos/features/backup-and-sync/index.md
@@ -46,13 +46,25 @@ Day to day sync will work automatically. However, there are some platform specif
 
 ### iOS
 
-On iOS, if you have a very large number of photos and videos, then you might need to keep Ente running in the foreground for the first backup to happen (since we get only a limited amount of background execution time). To help with this, under `Settings > Backup` there is an option to disable the automatic device screen lock. But once your initial backup has completed, subsequent backups will work fine in the background and don't need disabling the screen lock.
+Day-to-day backups run automatically on iOS. However, iOS gives Ente limited time to work when the app is not open. Your initial backup and large videos may need more time.
 
-On iOS, Ente will not backup videos in the background (since videos are usually much larger and need more time to upload than what we get). However, they will get backed up the next time the Ente app is opened.
+#### Backup mode {#backup-mode-ios}
 
-Note that the Ente app will not be able to backup in the background if you force kill the app.
+Backup mode helps large backups finish by keeping Ente open and the screen awake. The screen dims to save battery.
 
-> If you're curious, the way this works is, our servers "tickle" your device every once in a while by sending a silent push notification, which wakes up our app and gives it 30 seconds to execute a background sync. However, if you have killed the app from recents, iOS will not deliver the push to the app, breaking the background sync.
+To use Backup mode:
+
+1. Connect your iPhone to power and stable WiFi.
+2. Open `Settings > Backup > Backup settings > Backup mode`.
+3. Tap **Start backup mode** and keep Ente open on screen. Switching apps pauses Backup mode.
+
+You only need Backup mode for large uploads. New photos will continue to back up in the background afterwards.
+
+Large videos may not finish during the short time iOS gives Ente in the background. Ente will continue the upload when iOS gives it more time or when you open the app.
+
+Do not swipe Ente away from the app switcher. iOS cannot wake Ente for a background backup after the app has been closed this way.
+
+> Ente uses silent notifications to ask iOS to start a short background backup. iOS does not deliver these notifications after you swipe the app away.
 
 ### Android
 
@@ -66,7 +78,7 @@ In addition to our mobile apps, the background sync also works on our desktop ap
 
 ### Troubleshooting background sync
 
-- On iOS, make sure that you're not killing the Ente app.
+- On iOS, do not swipe Ente away from the app switcher.
 - On Android, make sure that "Optimize battery usage" is not turned on in system settings for the Ente app.
 
 ## Understanding backup behavior

--- a/docs/docs/photos/getting-started/daily-use.md
+++ b/docs/docs/photos/getting-started/daily-use.md
@@ -36,7 +36,7 @@ Once you've selected your albums, Ente will:
 **On mobile:**
 
 - **WiFi vs mobile data**: Open `Settings > Backup` and toggle "Backup over mobile data" if you want to back up without WiFi
-- **Background backup**: On iOS, videos won't backup in background - keep the app open for large video uploads
+- **Background backup**: On iOS, use [Backup mode](/photos/features/backup-and-sync/#backup-mode-ios) for large video uploads
 - **Battery optimization**: On Android, disable battery optimization for Ente to ensure reliable background backup
 
 The initial backup of your existing photos may take some time depending on how many photos you have. Subsequent backups of new photos happen quickly in the background.

--- a/docs/docs/photos/migration/from-apple-photos/index.md
+++ b/docs/docs/photos/migration/from-apple-photos/index.md
@@ -11,7 +11,9 @@ If you are using Apple Photos on your phone, then the most seamless way is to in
 
 > [!TIP]
 >
-> For large libraries, this process may take a bit of time, so you can speed it up by keeping the app running in the foreground while the initial import is in progress. You can do this by going to `Settings > Backup > Backup settings` and turning on "Disable auto lock" (Note: this is only needed during the initial import, subsequently the app will automatically backup photos in the background as you take them).
+> Large libraries may take some time to back up. Open [Backup mode](/photos/features/backup-and-sync/#backup-mode-ios) under `Settings > Backup > Backup settings` and tap **Start backup mode**. Keep Ente open on screen. Backup mode keeps the screen awake and dims it to save battery.
+>
+> You only need Backup mode for the initial backup. Ente will automatically back up new photos in the background afterwards.
 
 ## Importing iCloud shared albums
 


### PR DESCRIPTION
- Document iOS Backup mode across backup and migration guidance.
- Explain temporary storage growth and cleanup during interrupted uploads.
- Correct cache settings paths and iOS background-upload guidance.