### PR TITLE
[mob][photos] Tune justified layout for wider screens

### DIFF
--- a/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
+++ b/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
@@ -1,4 +1,5 @@
 import "dart:core";
+import "dart:math" as math;
 
 import "package:flutter/material.dart";
 import "package:logging/logging.dart";
@@ -61,6 +62,9 @@ class GalleryGroups {
   }
 
   static const double spacing = 2.0;
+  // Product decision: limit how tall the preferred justified row can grow as
+  // the gallery widens.
+  static const double _maximumJustifiedTargetRowHeight = 320.0;
 
   late final int crossAxisCount;
   late final GalleryLayoutType layoutType;
@@ -440,8 +444,11 @@ class GalleryGroups {
 
   List<SectionLayout> _computeJustifiedGroupLayouts() {
     final stopwatch = Stopwatch()..start();
-    final targetRowHeight =
+    final gridTargetRowHeight =
         (widthAvailable - (crossAxisCount - 1) * spacing) / crossAxisCount;
+    final targetRowHeight = gridTargetRowHeight.isFinite
+        ? math.min(gridTargetRowHeight, _maximumJustifiedTargetRowHeight)
+        : gridTargetRowHeight;
     final groupLayouts = <SectionLayout>[];
     var currentIndex = 0;
     var currentOffset = 0.0;

--- a/mobile/apps/photos/lib/models/gallery/justified_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/justified_layout.dart
@@ -96,10 +96,16 @@ class JustifiedLayoutCalculator {
   static const double _minimumAspectRatio = 1 / 3;
   static const double _maximumAspectRatio = 4.0;
   static const double _maximumRowHeightFactor = 2.4;
-  static const double _minimumLandscapeTrioHeightFactor = 0.88;
-  // Product decision: cap visual density at three items per row,
+  static const double _maximumWideFinalRowHeightFactor = 1.25;
+  static const double _minimumLandscapeRowHeightFactor = 0.88;
+  static const double _mediumWidthBreakpoint = 600;
+  static const double _expandedWidthBreakpoint = 1008;
+  // Product decision: cap visual density based on the available gallery width,
   // independently of tap-target sizing.
-  static const int _maximumItemsPerRow = 3;
+  static const int _compactMaximumItemsPerRow = 3;
+  static const int _mediumMaximumItemsPerRow = 4;
+  static const int _expandedMaximumItemsPerRow = 5;
+  static const int _minimumLandscapeDensityItemCount = 3;
   // Logical pixels map to density-independent tap extents on both platforms.
   static const double _minimumTappableExtent = 48.0;
 
@@ -110,6 +116,16 @@ class JustifiedLayoutCalculator {
     return (width / height)
         .clamp(_minimumAspectRatio, _maximumAspectRatio)
         .toDouble();
+  }
+
+  static int _maximumItemsPerRowFor(double availableWidth) {
+    if (availableWidth < _mediumWidthBreakpoint) {
+      return _compactMaximumItemsPerRow;
+    }
+    if (availableWidth < _expandedWidthBreakpoint) {
+      return _mediumMaximumItemsPerRow;
+    }
+    return _expandedMaximumItemsPerRow;
   }
 
   static List<JustifiedRowLayout> computeRows({
@@ -132,6 +148,15 @@ class JustifiedLayoutCalculator {
     final rows = <JustifiedRowLayout>[];
     final pendingRatios = <double>[];
     final maximumRowHeight = targetRowHeight * _maximumRowHeightFactor;
+    final maximumItemsPerRow = _maximumItemsPerRowFor(availableWidth);
+    // Product decision: on wider galleries, prefer a partial final row over
+    // enlarging its items by more than 25%. Compact layouts retain their
+    // existing tail treatment.
+    final limitsFinalRowGrowth = availableWidth >= _mediumWidthBreakpoint;
+    final maximumFinalRowHeightFactor = limitsFinalRowGrowth
+        ? _maximumWideFinalRowHeightFactor
+        : _maximumRowHeightFactor;
+    final maximumFinalRowHeight = targetRowHeight * maximumFinalRowHeightFactor;
     final lastCommittedRatios = <double>[];
     var pendingRatioSum = 0.0;
     var pendingMinimumRatio = double.infinity;
@@ -191,24 +216,20 @@ class JustifiedLayoutCalculator {
       pendingMinimumRatio = double.infinity;
     }
 
-    bool canFillWidth(
-      List<double> ratios, {
-      bool applyLandscapeDensityRule = false,
-    }) {
+    bool canJustifyFinalRow(List<double> ratios) {
       final ratioSum = ratios.fold<double>(0, (sum, ratio) => sum + ratio);
       final height = widthWithoutGaps(ratios.length) / ratioSum;
       final minimumWidth =
           height * ratios.reduce((left, right) => math.min(left, right));
       final isTappableAndBounded =
           height >= _minimumTappableExtent &&
-          height <= maximumRowHeight &&
+          height <= maximumFinalRowHeight &&
           minimumWidth >= _minimumTappableExtent;
       if (!isTappableAndBounded) return false;
 
-      return !applyLandscapeDensityRule ||
-          ratios.length != _maximumItemsPerRow ||
+      return ratios.length < _minimumLandscapeDensityItemCount ||
           ratios.any((ratio) => ratio < 1) ||
-          height >= targetRowHeight * _minimumLandscapeTrioHeightFactor;
+          height >= targetRowHeight * _minimumLandscapeRowHeightFactor;
     }
 
     void replacePendingRatios(Iterable<double> ratios) {
@@ -232,6 +253,12 @@ class JustifiedLayoutCalculator {
     }
 
     for (final rawRatio in aspectRatios) {
+      // Reaching the item cap only proves that a row is non-final once another
+      // item arrives. An exact-cap group tail still uses the final-row policy.
+      if (pendingRatios.length == maximumItemsPerRow) {
+        addPendingRow(fillWidth: true);
+      }
+
       final ratio = rawRatio.isFinite && rawRatio > 0
           ? rawRatio.clamp(_minimumAspectRatio, _maximumAspectRatio).toDouble()
           : 1.0;
@@ -248,11 +275,11 @@ class JustifiedLayoutCalculator {
             candidateHeight < _minimumTappableExtent ||
             candidateMinimumWidth < _minimumTappableExtent;
         final violatesLandscapeDensity =
-            candidateCount == _maximumItemsPerRow &&
+            candidateCount >= _minimumLandscapeDensityItemCount &&
             pendingMinimumRatio >= 1 &&
             ratio >= 1 &&
             candidateHeight <
-                targetRowHeight * _minimumLandscapeTrioHeightFactor;
+                targetRowHeight * _minimumLandscapeRowHeightFactor;
 
         if (violatesTapTarget || violatesLandscapeDensity) {
           final leaveSingletonRagged = pendingRatios.length == 1;
@@ -267,13 +294,6 @@ class JustifiedLayoutCalculator {
       pendingRatioSum += ratio;
       pendingMinimumRatio = math.min(pendingMinimumRatio, ratio);
 
-      if (pendingRatios.length == _maximumItemsPerRow) {
-        // A three-item row may exceed maximumRowHeight: the three-item cap and
-        // fully justified non-final rows take precedence over that soft limit.
-        addPendingRow(fillWidth: true);
-        continue;
-      }
-
       final naturalWidth =
           pendingRatioSum * targetRowHeight +
           spacing * (pendingRatios.length - 1);
@@ -282,42 +302,52 @@ class JustifiedLayoutCalculator {
       }
     }
 
+    // Compact galleries retain the established behavior of filling a row that
+    // ends exactly at their item cap. Wider galleries defer it to the bounded
+    // final-row treatment below.
+    if (!limitsFinalRowGrowth && pendingRatios.length == maximumItemsPerRow) {
+      addPendingRow(fillWidth: true);
+    }
+
     // Product decision: avoid one-item group tails by rebalancing the preceding
     // row when the replacement rows meet tap-target, height, and density limits.
     if (pendingRatios.length == 1 && rows.isNotEmpty) {
       final tailRatios = <double>[...lastCommittedRatios, pendingRatios.single];
-      if (lastCommittedRatios.length < _maximumItemsPerRow &&
-          canFillWidth(tailRatios, applyLandscapeDensityRule: true)) {
+      if (lastCommittedRatios.length < maximumItemsPerRow &&
+          canJustifyFinalRow(tailRatios)) {
         rewindLastRow();
         replacePendingRatios(tailRatios);
         addPendingRow(fillWidth: true);
-      } else if (lastCommittedRatios.length == _maximumItemsPerRow) {
-        final firstPair = tailRatios.sublist(0, 2);
-        final secondPair = tailRatios.sublist(2);
-        if (canFillWidth(firstPair) && canFillWidth(secondPair)) {
+      } else if (tailRatios.length >= 4) {
+        final firstRowItemCount = (tailRatios.length + 1) ~/ 2;
+        final firstRow = tailRatios.sublist(0, firstRowItemCount);
+        final secondRow = tailRatios.sublist(firstRowItemCount);
+        if (canJustifyFinalRow(firstRow) && canJustifyFinalRow(secondRow)) {
           rewindLastRow();
-          replacePendingRatios(firstPair);
+          replacePendingRatios(firstRow);
           addPendingRow(fillWidth: true);
-          replacePendingRatios(secondPair);
+          replacePendingRatios(secondRow);
           addPendingRow(fillWidth: true);
         }
       }
     }
 
     if (pendingRatios.isNotEmpty) {
-      final canJustifyFinalRow = canFillWidth(
-        pendingRatios,
-        applyLandscapeDensityRule: true,
-      );
+      final shouldJustifyFinalRow = canJustifyFinalRow(pendingRatios);
       final singletonHeightFactor =
           pendingRatios.length == 1 && pendingRatios.single < 1
           ? math.min(_maximumRowHeightFactor, 1 / pendingRatios.single)
           : 1.0;
+      final finalRowHeightFactor = pendingRatios.length == 1
+          ? math.min(singletonHeightFactor, maximumFinalRowHeightFactor)
+          : limitsFinalRowGrowth
+          ? maximumFinalRowHeightFactor
+          : 1.0;
       addPendingRow(
-        fillWidth: pendingRatios.length > 1 && canJustifyFinalRow,
-        // Give a lone portrait roughly one target-width column without
-        // making landscape singletons or forced non-final rows taller.
-        raggedHeightFactor: singletonHeightFactor,
+        fillWidth: pendingRatios.length > 1 && shouldJustifyFinalRow,
+        // Give compact portrait singletons roughly one target-width column;
+        // wider tails also obey their 25% growth limit.
+        raggedHeightFactor: finalRowHeightFactor,
       );
     }
     return UnmodifiableListView(rows);

--- a/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
+++ b/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
@@ -183,6 +183,35 @@ void main() {
     },
   );
 
+  test(
+    "caps the target height only when the grid-derived target is taller",
+    () async {
+      final file = _file(
+        index: 0,
+        creationTime: DateTime(2026, 8, 19).microsecondsSinceEpoch,
+        width: 1,
+        height: 1,
+      );
+      double rowHeight() {
+        final section =
+            _galleryGroups(
+                  files: [file],
+                  groupType: GroupType.none,
+                  groupHeaderExtent: GalleryGroups.spacing,
+                  widthAvailable: 1024,
+                ).groupLayouts.single
+                as JustifiedSectionLayout;
+        return section.rows.single.height;
+      }
+
+      await localSettings.setPhotoGridSize(2);
+      expect(rowHeight(), 320);
+
+      await localSettings.setPhotoGridSize(4);
+      expect(rowHeight(), (1024 - 3 * GalleryGroups.spacing) / 4);
+    },
+  );
+
   testWidgets("justified rows request large thumbnails for every tile", (
     tester,
   ) async {
@@ -312,6 +341,7 @@ GalleryGroups _galleryGroups({
   required List<EnteFile> files,
   required GroupType groupType,
   required double groupHeaderExtent,
+  double widthAvailable = 430,
   bool sortOrderAsc = false,
   GalleryLayoutType? layoutTypeOverride,
 }) {
@@ -319,7 +349,7 @@ GalleryGroups _galleryGroups({
     allFiles: files,
     groupType: groupType,
     sortOrderAsc: sortOrderAsc,
-    widthAvailable: 430,
+    widthAvailable: widthAvailable,
     selectedFiles: null,
     tagPrefix: "test_",
     groupHeaderExtent: groupHeaderExtent,

--- a/mobile/apps/photos/test/models/justified_layout_test.dart
+++ b/mobile/apps/photos/test/models/justified_layout_test.dart
@@ -51,13 +51,37 @@ void main() {
       expect(_occupiedWidth(row, spacing), closeTo(availableWidth, 1e-9));
     });
 
+    test("caps wide final-row growth and leaves trailing space", () {
+      for (final testCase in const [
+        (width: 744.0, ratios: [0.75, 0.75]),
+        (width: 1024.0, ratios: [0.75, 0.75, 0.75]),
+      ]) {
+        final row = JustifiedLayoutCalculator.computeRows(
+          aspectRatios: testCase.ratios,
+          availableWidth: testCase.width,
+          targetRowHeight: 320,
+          spacing: 2,
+        ).single;
+
+        expect(row.height, 400, reason: "available width ${testCase.width}");
+        expect(
+          _occupiedWidth(row, 2),
+          lessThan(testCase.width),
+          reason: "available width ${testCase.width}",
+        );
+      }
+    });
+
     test("sizes final singletons by orientation and caps extremes", () {
-      const targetRowHeight = 200.0;
-      JustifiedRowLayout rowFor(double ratio) {
+      JustifiedRowLayout rowFor(
+        double ratio, {
+        double width = 402,
+        double targetHeight = 200,
+      }) {
         return JustifiedLayoutCalculator.computeRows(
           aspectRatios: [ratio],
-          availableWidth: 402,
-          targetRowHeight: targetRowHeight,
+          availableWidth: width,
+          targetRowHeight: targetHeight,
           spacing: 2,
         ).single;
       }
@@ -65,17 +89,27 @@ void main() {
       final portrait = rowFor(9 / 16);
       final extremePortrait = rowFor(0.25);
       final landscape = rowFor(3 / 2);
+      final mediumPortrait = rowFor(0.5, width: 744, targetHeight: 320);
+      final minimumTappablePortrait = rowFor(
+        0.25,
+        width: 600,
+        targetHeight: (600 - 10) / 6,
+      );
 
-      expect(portrait.itemWidths.single, targetRowHeight);
-      expect(extremePortrait.height, targetRowHeight * 2.4);
+      expect(portrait.itemWidths.single, 200);
+      expect(extremePortrait.height, 200 * 2.4);
       expect(
         extremePortrait.itemWidths.single / extremePortrait.height,
         closeTo(1 / 3, 1e-9),
       );
-      expect(landscape.height, targetRowHeight);
+      expect(landscape.height, 200);
+      expect(mediumPortrait.height, 400);
+      expect(mediumPortrait.itemWidths.single, 200);
+      expect(minimumTappablePortrait.height, 144);
+      expect(minimumTappablePortrait.itemWidths.single, 48);
     });
 
-    test("rebalances a portrait orphan without disturbing earlier rows", () {
+    test("rebalances a compact portrait orphan", () {
       final rows = JustifiedLayoutCalculator.computeRows(
         aspectRatios: List.filled(7, 9 / 16),
         availableWidth: 393,
@@ -83,7 +117,18 @@ void main() {
         spacing: 2,
       );
 
-      expect(rows.map((row) => row.lastIndex - row.firstIndex + 1), [3, 2, 2]);
+      expect(rows.map((row) => row.itemWidths.length), [3, 2, 2]);
+    });
+
+    test("does not create oversized tablet rows to avoid an orphan", () {
+      final rows = JustifiedLayoutCalculator.computeRows(
+        aspectRatios: List.filled(5, 0.5),
+        availableWidth: 744,
+        targetRowHeight: 320,
+        spacing: 2,
+      );
+
+      expect(rows.map((row) => row.itemWidths.length), [4, 1]);
     });
 
     test("keeps a tappable portrait with the following panorama", () {
@@ -169,30 +214,74 @@ void main() {
       expect(rows.single.itemWidths, [192]);
     });
 
-    test("caps rows at three items even when more would fit", () {
-      final rows = JustifiedLayoutCalculator.computeRows(
-        aspectRatios: const [0.4, 0.4, 1.0, 0.4],
-        availableWidth: 393,
-        targetRowHeight: 195.5,
-        spacing: 2,
-      );
+    test("caps row density based on available width", () {
+      for (final testCase in const [
+        (width: 393.0, maximumItems: 3),
+        (width: 599.9, maximumItems: 3),
+        (width: 600.0, maximumItems: 4),
+        (width: 1007.9, maximumItems: 4),
+        (width: 1008.0, maximumItems: 5),
+      ]) {
+        final targetHeight =
+            (testCase.width - 2 * (testCase.maximumItems - 1)) /
+            testCase.maximumItems;
+        final rows = JustifiedLayoutCalculator.computeRows(
+          aspectRatios: List.filled(testCase.maximumItems * 2, 1 / 3),
+          availableWidth: testCase.width,
+          targetRowHeight: targetHeight,
+          spacing: 2,
+        );
 
-      expect(rows.expand((row) => row.itemWidths), hasLength(4));
-      expect(
-        rows.map((row) => row.itemWidths.length),
-        everyElement(lessThanOrEqualTo(3)),
-      );
+        expect(
+          rows.map((row) => row.itemWidths.length),
+          [testCase.maximumItems, testCase.maximumItems],
+          reason: "available width ${testCase.width}",
+        );
+        expect(
+          rows.first.height,
+          closeTo(3 * targetHeight, 1e-9),
+          reason: "non-final row at width ${testCase.width}",
+        );
+        final expectedFinalHeight = testCase.width < 600
+            ? 3 * targetHeight
+            : 1.25 * targetHeight;
+        expect(
+          rows.last.height,
+          closeTo(expectedFinalHeight, 1e-9),
+          reason: "final row at width ${testCase.width}",
+        );
+      }
     });
 
-    test("keeps typical landscapes to pairs", () {
-      final rows = JustifiedLayoutCalculator.computeRows(
-        aspectRatios: const [4 / 3, 4 / 3, 4 / 3],
-        availableWidth: 393,
-        targetRowHeight: (393 - 4) / 3,
-        spacing: 2,
-      );
+    test("keeps cramped landscape rows independent of responsive cap", () {
+      for (final testCase in const [
+        (
+          ratios: [4 / 3, 4 / 3, 4 / 3],
+          width: 393.0,
+          targetHeight: (393 - 4) / 3,
+          rowCounts: [2, 1],
+        ),
+        (
+          ratios: [1.0, 1.0, 1.0, 1.0],
+          width: 1024.0,
+          targetHeight: 320.0,
+          rowCounts: [3, 1],
+        ),
+      ]) {
+        final rows = JustifiedLayoutCalculator.computeRows(
+          aspectRatios: testCase.ratios,
+          availableWidth: testCase.width,
+          targetRowHeight: testCase.targetHeight,
+          spacing: 2,
+        );
 
-      expect(rows.map((row) => row.itemWidths.length), [2, 1]);
+        expect(
+          rows.map((row) => row.itemWidths.length),
+          testCase.rowCounts,
+          reason: "available width ${testCase.width}",
+        );
+        expect(rows.last.height, testCase.targetHeight);
+      }
     });
 
     test("merges a final portrait with a tappable two-item row", () {
@@ -205,6 +294,21 @@ void main() {
 
       expect(rows, hasLength(1));
       expect(rows.single.itemWidths, hasLength(3));
+    });
+
+    test("rebalances a wide orphan when replacement rows stay bounded", () {
+      final rows = JustifiedLayoutCalculator.computeRows(
+        aspectRatios: const [0.8, 0.8, 0.8, 0.4, 2.0],
+        availableWidth: 600,
+        targetRowHeight: 200,
+        spacing: 2,
+      );
+
+      expect(rows.map((row) => row.itemWidths.length), [3, 2]);
+      for (final row in rows) {
+        expect(row.height, lessThanOrEqualTo(250));
+        expect(_occupiedWidth(row, 2), closeTo(600, 1e-9));
+      }
     });
 
     test("forced non-final singleton uses the target row height", () {


### PR DESCRIPTION
## Description

Refines the internal Justified gallery layout for wider screens.

- Increase the row item cap responsively from three to four and five as gallery width grows.
- Cap the preferred row height at 320 logical pixels.
- Limit final-row and orphan-rebalance enlargement on wider galleries, leaving trailing space when filling the row would make thumbnails too large.
- Preserve the existing compact-phone layout behavior.