### PR TITLE
[mobile][photos] set light overlay style for media viewer status bar

### DIFF
--- a/mobile/apps/photos/changes/media-viewer-status-bar-style.md
+++ b/mobile/apps/photos/changes/media-viewer-status-bar-style.md
@@ -1,0 +1,1 @@
+- Fixed image and video viewer status bar styles. (@r4khul)

--- a/mobile/apps/photos/changes/video-player-status-bar-style.md
+++ b/mobile/apps/photos/changes/video-player-status-bar-style.md
@@ -1,1 +1,0 @@
-- Fixed video player status bar style. (@r4khul)

--- a/mobile/apps/photos/changes/video-player-status-bar-style.md
+++ b/mobile/apps/photos/changes/video-player-status-bar-style.md
@@ -1,0 +1,1 @@
+- Fixed video player status bar style. (@r4khul)

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget.dart
@@ -5,6 +5,7 @@ import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_ui/components/loading_widget.dart";
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
+import "package:flutter/services.dart";
 import "package:fluttertoast/fluttertoast.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/event_bus.dart";
@@ -202,61 +203,65 @@ class _VideoWidgetState extends State<VideoWidget> {
         !widget.file.isDeviceTrash &&
         (!playPreview || Platform.isAndroid);
 
-    if (shouldUseNativeVideoPlayer) {
-      return VideoWidgetNative(
-        widget.file,
-        key: nativePlayerKey,
-        tagPrefix: widget.tagPrefix,
-        playbackCallback: widget.playbackCallback,
-        shouldDisableScroll: widget.shouldDisableScroll,
-        playlistData: playlistData,
-        selectedPreview: playPreview,
-        playbackSpeed: _playbackSpeed,
-        isFromMemories: widget.isFromMemories,
-        isActive: _isActive,
-        isAudioMutedOverride: widget.isAudioMutedOverride,
-        onStreamChange: () {
-          setState(() {
-            selectPreviewForPlay = !selectPreviewForPlay;
-            Bus.instance.fire(
-              StreamSwitchedEvent(
-                selectPreviewForPlay,
-                Platform.isAndroid && useNativeVideoPlayer
-                    ? PlayerType.nativeVideoPlayer
-                    : PlayerType.mediaKit,
-              ),
-            );
-          });
-        },
-        onFinalFileLoad: widget.onFinalFileLoad,
-      );
-    }
-    return VideoWidgetMediaKit(
-      widget.file,
-      key: mediaKitKey,
-      tagPrefix: widget.tagPrefix,
-      playbackCallback: widget.playbackCallback,
-      shouldDisableScroll: widget.shouldDisableScroll,
-      preview: playlistData?.preview,
-      selectedPreview: playPreview,
-      playbackSpeed: _playbackSpeed,
-      isFromMemories: widget.isFromMemories,
-      isActive: _isActive,
-      isAudioMutedOverride: widget.isAudioMutedOverride,
-      onStreamChange: () {
-        setState(() {
-          selectPreviewForPlay = !selectPreviewForPlay;
-          Bus.instance.fire(
-            StreamSwitchedEvent(
-              selectPreviewForPlay,
-              Platform.isAndroid
-                  ? PlayerType.nativeVideoPlayer
-                  : PlayerType.mediaKit,
-            ),
+    final Widget videoWidget = shouldUseNativeVideoPlayer
+        ? VideoWidgetNative(
+            widget.file,
+            key: nativePlayerKey,
+            tagPrefix: widget.tagPrefix,
+            playbackCallback: widget.playbackCallback,
+            shouldDisableScroll: widget.shouldDisableScroll,
+            playlistData: playlistData,
+            selectedPreview: playPreview,
+            playbackSpeed: _playbackSpeed,
+            isFromMemories: widget.isFromMemories,
+            isActive: _isActive,
+            isAudioMutedOverride: widget.isAudioMutedOverride,
+            onStreamChange: () {
+              setState(() {
+                selectPreviewForPlay = !selectPreviewForPlay;
+                Bus.instance.fire(
+                  StreamSwitchedEvent(
+                    selectPreviewForPlay,
+                    Platform.isAndroid && useNativeVideoPlayer
+                        ? PlayerType.nativeVideoPlayer
+                        : PlayerType.mediaKit,
+                  ),
+                );
+              });
+            },
+            onFinalFileLoad: widget.onFinalFileLoad,
+          )
+        : VideoWidgetMediaKit(
+            widget.file,
+            key: mediaKitKey,
+            tagPrefix: widget.tagPrefix,
+            playbackCallback: widget.playbackCallback,
+            shouldDisableScroll: widget.shouldDisableScroll,
+            preview: playlistData?.preview,
+            selectedPreview: playPreview,
+            playbackSpeed: _playbackSpeed,
+            isFromMemories: widget.isFromMemories,
+            isActive: _isActive,
+            isAudioMutedOverride: widget.isAudioMutedOverride,
+            onStreamChange: () {
+              setState(() {
+                selectPreviewForPlay = !selectPreviewForPlay;
+                Bus.instance.fire(
+                  StreamSwitchedEvent(
+                    selectPreviewForPlay,
+                    Platform.isAndroid
+                        ? PlayerType.nativeVideoPlayer
+                        : PlayerType.mediaKit,
+                  ),
+                );
+              });
+            },
+            onFinalFileLoad: widget.onFinalFileLoad,
           );
-        });
-      },
-      onFinalFileLoad: widget.onFinalFileLoad,
+
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: SystemUiOverlayStyle.light,
+      child: videoWidget,
     );
   }
 

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget.dart
@@ -178,8 +178,9 @@ class _VideoWidgetState extends State<VideoWidget> {
   @override
   Widget build(BuildContext context) {
     final playPreview = isPreviewLoadable && selectPreviewForPlay;
+    final Widget child;
     if (playPreview && playlistData == null) {
-      return Center(
+      child = Center(
         child: Container(
           width: 48,
           height: 48,
@@ -196,72 +197,72 @@ class _VideoWidgetState extends State<VideoWidget> {
           ),
         ),
       );
+    } else {
+      final shouldUseNativeVideoPlayer =
+          useNativeVideoPlayer &&
+          !widget.file.isDeviceTrash &&
+          (!playPreview || Platform.isAndroid);
+
+      child = shouldUseNativeVideoPlayer
+          ? VideoWidgetNative(
+              widget.file,
+              key: nativePlayerKey,
+              tagPrefix: widget.tagPrefix,
+              playbackCallback: widget.playbackCallback,
+              shouldDisableScroll: widget.shouldDisableScroll,
+              playlistData: playlistData,
+              selectedPreview: playPreview,
+              playbackSpeed: _playbackSpeed,
+              isFromMemories: widget.isFromMemories,
+              isActive: _isActive,
+              isAudioMutedOverride: widget.isAudioMutedOverride,
+              onStreamChange: () {
+                setState(() {
+                  selectPreviewForPlay = !selectPreviewForPlay;
+                  Bus.instance.fire(
+                    StreamSwitchedEvent(
+                      selectPreviewForPlay,
+                      Platform.isAndroid && useNativeVideoPlayer
+                          ? PlayerType.nativeVideoPlayer
+                          : PlayerType.mediaKit,
+                    ),
+                  );
+                });
+              },
+              onFinalFileLoad: widget.onFinalFileLoad,
+            )
+          : VideoWidgetMediaKit(
+              widget.file,
+              key: mediaKitKey,
+              tagPrefix: widget.tagPrefix,
+              playbackCallback: widget.playbackCallback,
+              shouldDisableScroll: widget.shouldDisableScroll,
+              preview: playlistData?.preview,
+              selectedPreview: playPreview,
+              playbackSpeed: _playbackSpeed,
+              isFromMemories: widget.isFromMemories,
+              isActive: _isActive,
+              isAudioMutedOverride: widget.isAudioMutedOverride,
+              onStreamChange: () {
+                setState(() {
+                  selectPreviewForPlay = !selectPreviewForPlay;
+                  Bus.instance.fire(
+                    StreamSwitchedEvent(
+                      selectPreviewForPlay,
+                      Platform.isAndroid
+                          ? PlayerType.nativeVideoPlayer
+                          : PlayerType.mediaKit,
+                    ),
+                  );
+                });
+              },
+              onFinalFileLoad: widget.onFinalFileLoad,
+            );
     }
-
-    final shouldUseNativeVideoPlayer =
-        useNativeVideoPlayer &&
-        !widget.file.isDeviceTrash &&
-        (!playPreview || Platform.isAndroid);
-
-    final Widget videoWidget = shouldUseNativeVideoPlayer
-        ? VideoWidgetNative(
-            widget.file,
-            key: nativePlayerKey,
-            tagPrefix: widget.tagPrefix,
-            playbackCallback: widget.playbackCallback,
-            shouldDisableScroll: widget.shouldDisableScroll,
-            playlistData: playlistData,
-            selectedPreview: playPreview,
-            playbackSpeed: _playbackSpeed,
-            isFromMemories: widget.isFromMemories,
-            isActive: _isActive,
-            isAudioMutedOverride: widget.isAudioMutedOverride,
-            onStreamChange: () {
-              setState(() {
-                selectPreviewForPlay = !selectPreviewForPlay;
-                Bus.instance.fire(
-                  StreamSwitchedEvent(
-                    selectPreviewForPlay,
-                    Platform.isAndroid && useNativeVideoPlayer
-                        ? PlayerType.nativeVideoPlayer
-                        : PlayerType.mediaKit,
-                  ),
-                );
-              });
-            },
-            onFinalFileLoad: widget.onFinalFileLoad,
-          )
-        : VideoWidgetMediaKit(
-            widget.file,
-            key: mediaKitKey,
-            tagPrefix: widget.tagPrefix,
-            playbackCallback: widget.playbackCallback,
-            shouldDisableScroll: widget.shouldDisableScroll,
-            preview: playlistData?.preview,
-            selectedPreview: playPreview,
-            playbackSpeed: _playbackSpeed,
-            isFromMemories: widget.isFromMemories,
-            isActive: _isActive,
-            isAudioMutedOverride: widget.isAudioMutedOverride,
-            onStreamChange: () {
-              setState(() {
-                selectPreviewForPlay = !selectPreviewForPlay;
-                Bus.instance.fire(
-                  StreamSwitchedEvent(
-                    selectPreviewForPlay,
-                    Platform.isAndroid
-                        ? PlayerType.nativeVideoPlayer
-                        : PlayerType.mediaKit,
-                  ),
-                );
-              });
-            },
-            onFinalFileLoad: widget.onFinalFileLoad,
-          );
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.light,
-      child: videoWidget,
+      child: child,
     );
   }
 

--- a/mobile/apps/photos/lib/ui/viewer/file/zoomable_live_image_new.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/zoomable_live_image_new.dart
@@ -3,6 +3,7 @@ import "dart:io";
 
 import "package:ente_strings/ente_strings.dart";
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
 import "package:media_kit/media_kit.dart";
 import "package:media_kit_video/media_kit_video.dart";
@@ -221,14 +222,18 @@ class _ZoomableLiveImageNewState extends State<ZoomableLiveImageNew>
       ],
     );
 
-    if (!widget.isFromMemories) {
-      return GestureDetector(
-        onLongPressStart: _onLongPressStart,
-        onLongPressEnd: (_) => _setPlaybackPressed(false),
-        child: content,
-      );
-    }
-    return content;
+    final Widget child = widget.isFromMemories
+        ? content
+        : GestureDetector(
+            onLongPressStart: _onLongPressStart,
+            onLongPressEnd: (_) => _setPlaybackPressed(false),
+            child: content,
+          );
+
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: SystemUiOverlayStyle.light,
+      child: child,
+    );
   }
 
   @override


### PR DESCRIPTION
  ## Description

 When using light mode, opening an image or video viewer can make the status bar icons and text black. Because the media viewer background is black, the clock, battery, and notification icons become invisible.

  This PR wraps the image and video viewer widgets in an `AnnotatedRegion<SystemUiOverlayStyle>` set to `SystemUiOverlayStyle.light`. This keeps status bar icons white while viewing media, regardless of the app theme.

  Same pattern as:

  - `lib/ui/viewer/album_slideshow/album_slideshow_page.dart`
  - `lib/ui/home/memories/full_screen_memory.dart`

<img width="3924" height="2226" alt="image" src="https://github.com/user-attachments/assets/6f3fdea0-2372-4058-a542-cbf4b341e666" />


## Verification

* Verified on a physical Android device: status bar icons and text render in white over the video player in light mode.