### PR TITLE
[mobile][photos] align video stream button to left and constrain comment bubble width

### DIFF
--- a/mobile/apps/photos/changes/video-stream-button-alignment.md
+++ b/mobile/apps/photos/changes/video-stream-button-alignment.md
@@ -1,0 +1,1 @@
+- Align video stream button to left and constrain comment bubble. (@r4khul)

--- a/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
@@ -434,7 +434,9 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
               width: _latestCommentPillWidth(
                 context,
                 latestComment.data,
-                MediaQuery.sizeOf(context).width * 0.6,
+                (MediaQuery.sizeOf(context).width * 0.6) -
+                    _socialControlsSize -
+                    24,
               ),
               currentUserID: widget.currentUserID!,
               onTap: () =>

--- a/mobile/apps/photos/lib/ui/viewer/file/video_stream_change.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_stream_change.dart
@@ -102,13 +102,13 @@ class _VideoStreamChangeWidgetState extends State<VideoStreamChangeWidget> {
     return IgnorePointer(
       ignoring: !widget._showControls,
       child: Align(
-        alignment: Alignment.centerRight,
+        alignment: Alignment.centerLeft,
         child: AnimatedOpacity(
           duration: const Duration(milliseconds: 200),
           curve: Curves.easeInQuad,
           opacity: widget._showControls ? 1 : 0,
           child: Padding(
-            padding: const EdgeInsets.only(right: 10, bottom: 4),
+            padding: const EdgeInsets.only(left: 10, bottom: 4),
             child: GestureDetector(
               onTap: isCurrentlyProcessing ? null : widget.onStreamChange,
               child: Container(

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit_common.dart
@@ -257,7 +257,7 @@ class _VideoWidgetState extends State<VideoWidget> {
                           left: 0,
                           child: SafeArea(
                             top: false,
-                            left: false,
+                            left: true,
                             right: false,
                             child: VideoStreamChangeWidget(
                               showControls: value,

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -519,7 +519,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
                                   left: 0,
                                   child: SafeArea(
                                     top: false,
-                                    left: false,
+                                    left: true,
                                     right: false,
                                     child: ValueListenableBuilder(
                                       valueListenable: _showControls,


### PR DESCRIPTION
## Description
  
  On shared videos, the stream switch button ("Play stream" / "Play original") on the bottom right was colliding with the social controls (like and comment icons) and the latest comment bubble.          
  
  Fix:
  
  1. Moved the stream switch button to the bottom left and enabled left: true on its SafeArea so notches or camera cutouts in landscape do not block it.
  2. Capped the latest comment bubble max width so the entire social stack on the right occupies at most 60% of the screen width, keeping the left side clear.
  
`Pill width = (60% of screen width) - 48px icons - 24px margin`, which caps the entire right-side cluster at 60% of the screen and guarantees the left 40% stays free for the stream button.
  
<img width="1933" height="1428" alt="shapes at 26-09-05 03 06 31" src="https://github.com/user-attachments/assets/e4cc3939-aee3-4cbb-9e78-7d4e8017d010" />


## Verification
  
- Verified with physical device: realmeC67 5G & realme Pad 2