### PR TITLE
[rust] Add photo metadata reader

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2554,6 +2554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ente-exif"
+version = "0.0.0"
+dependencies = [
+ "brotli-decompressor",
+ "miniz_oxide",
+ "quick-xml",
+ "serde_json",
+]
+
+[[package]]
 name = "ente-frb-lib"
 version = "0.0.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/core",
     "crates/ensu",
     "crates/ensu-crypto",
+    "crates/exif",
     "crates/image",
     "crates/legacy",
     "crates/location",
@@ -49,6 +50,7 @@ ente-contacts = { path = "crates/contacts" }
 ente-core = { path = "crates/core" }
 ente-ensu = { path = "crates/ensu" }
 ente-ensu-crypto = { path = "crates/ensu-crypto" }
+ente-exif = { path = "crates/exif" }
 ente-frb-lib = { path = "bindings/frb/lib" }
 ente-frb-log = { path = "bindings/frb/log" }
 ente-image = { path = "crates/image" }
@@ -77,6 +79,7 @@ md-5 = "0.11.0"
 mockito = "1.7.2"
 ort = { version = "=2.0.0-rc.13", default-features = false }
 ort-sys = { version = "=2.0.0-rc.13", default-features = false }
+quick-xml = "0.41.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.28", default-features = false }
 rusqlite = { version = "0.38.0", default-features = false, features = ["bundled"] }

--- a/rust/crates/exif/Cargo.toml
+++ b/rust/crates/exif/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ente-exif"
+edition = "2024"
+
+[dependencies]
+brotli-decompressor = "5.0.0"
+miniz_oxide = "0.8.9"
+quick-xml.workspace = true
+serde_json.workspace = true

--- a/rust/crates/exif/README.md
+++ b/rust/crates/exif/README.md
@@ -46,6 +46,50 @@ nested XMP annotations need parent/list relationships.
   vendor trailer bytes and does not establish playback support. Pairing separate
   live-photo files belongs to the caller.
 
+## API contracts
+
+Dates retain local components: offsets are minutes east of UTC, capture output
+normalizes them to `±HH:MM`, and epoch timestamps use microseconds. Local text
+retains nanoseconds. Unknown offsets stay unknown. Partial dates normalize to
+period-start midnight UTC without inventing an embedded offset; source-specific
+`date_time()` preserves precision without this normalization. Epoch zero is valid.
+
+Capture selection uses the first parseable candidate, in this order:
+
+| Family | Sources |
+| --- | --- |
+| Original | XMP `exif:DateTimeOriginal`, IPTC 2:55/60, EXIF Original, XMP `photoshop:DateCreated` |
+| Digitized | XMP `exif:DateTimeDigitized`, IPTC 2:62/63, EXIF Digitized, XMP `xmp:CreateDate` |
+| Metadata change | XMP `xmp:MetadataDate` |
+| Modified | XMP `tiff:DateTime`, EXIF Modified, XMP `xmp:ModifyDate` |
+
+EXIF families use their own subsecond/offset tags; inline values win. Blank
+auxiliary fields mean unknown; malformed values used for conversion fail.
+`capture_date_time_with()` can resolve the epoch using host timezone/DST rules or
+reject a candidate with `false`. An assumed offset must not replace `offset_time`.
+
+Display size prefers container/EXIF dimensions, then a complete XMP pair.
+Native transforms apply in order. Nonzero HEIF rotation or any mirror suppresses
+EXIF/XMP orientation; otherwise valid EXIF wins over XMP. XMP-only sizes use XMP
+orientation. JPEG XL orientation always wins. Crops must be positive, integral,
+pixel-aligned and in bounds; otherwise size is `None`. Display resampling and
+pixel aspect ratio are excluded. Rotations are counterclockwise quarter turns;
+mirror axes are 0 = vertical, 1 = horizontal; EXIF orientations 5–8 swap axes.
+
+GPS helpers preserve `(0, 0)` and reject invalid/incomplete coordinates. EXIF
+signed D/M/S values supply the sign only when both hemisphere references are
+absent; XMP requires a suffix or reference for each axis. Camera text is trimmed;
+exposure is exact rational seconds, focal length is millimetres, and legacy ISO
+ratings preserve the 65535 sentinel. Text decoding requires an explicit encoding;
+IPTC's declared UTF-8 overrides the fallback. Raw collections retain duplicates;
+`tag()`/`property()` return the first. XMP descriptions prefer the requested
+language, then `x-default`, then the first value. Structured XMP parent indices
+align with properties; node parents identify enclosing structures/list items.
+
+Motion extraction chooses the largest candidate, ending at the next video or
+EOF. Explicit `MotionPhoto` values other than `1` disable detection. Panorama
+means GPano cylindrical/equirectangular projection or EXIF `CustomRendered = 6`.
+
 ## Limits
 
 `Limits::default()` bounds logical reads to 8 MiB, individual values to 64 KiB,

--- a/rust/crates/exif/README.md
+++ b/rust/crates/exif/README.md
@@ -1,0 +1,77 @@
+# ente-exif
+
+Reads EXIF, XMP and IPTC with bounded reads and owned results, without decoding
+image pixels. Supports JPEG, TIFF, HEIF/AVIF, PNG, WebP, GIF, JPEG XL and explicitly
+supplied XMP sidecars. It does not discover adjacent files or write metadata.
+
+```rust,no_run
+use ente_exif::{Limits, Mode};
+use std::{fs::File, io::BufReader};
+
+let mut file = BufReader::with_capacity(16 * 1024, File::open("photo.heic")?);
+let metadata = ente_exif::read(&mut file, Mode::Summary, Limits::default())?;
+if let Some(size) = metadata.display_dimensions() {
+    println!("display size: {} × {}", size.width, size.height);
+}
+println!("camera: {:?} {:?}", metadata.camera_make(), metadata.camera_model());
+println!("location: {:?}", metadata.exif_location());
+if let Some(date) = metadata.capture_date_time() {
+    println!("photo time: {}; offset: {:?}; epoch µs: {:?}; source: {:?}",
+             date.date_time, date.offset_time, date.timestamp_micros, date.source);
+}
+println!("panorama: {}", metadata.is_panorama());
+if let Some(video) = metadata.motion_video {
+    println!("motion video: [{}..{})", video.start, video.end);
+}
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Use `Cursor<&[u8]>` for bytes already in memory. `Summary` retains common photo
+fields; `Details` adds general tags and properties. Use `read_structured()` when
+nested XMP annotations need parent/list relationships.
+
+## Photo metadata
+
+- `display_dimensions()` applies container crops and orientation. `width()` and
+  `height()` return stored dimensions. Use decoder output dimensions directly
+  when available; do not orient them again.
+- `capture_date_time()` selects a date across XMP/IPTC/EXIF and keeps local time,
+  embedded offset and epoch microseconds separate. Full timestamps without an
+  offset remain unresolved. `capture_date_time_with()` accepts application
+  timezone/rejection policy; `date_time(source)` reads a single source.
+- Camera, lens, exposure, GPS and description helpers derive values on demand.
+  Location/caption source precedence and upload storage mapping belong to callers.
+- `is_panorama()` recognizes GPano projections or EXIF panorama metadata.
+  `motion_video` gives an appended video's half-open byte range. It may include
+  vendor trailer bytes and does not establish playback support. Pairing separate
+  live-photo files belongs to the caller.
+
+## Limits
+
+`Limits::default()` bounds logical reads to 8 MiB, individual values to 64 KiB,
+retained metadata accounting to 512 KiB, entries to 16,384, TIFF directories to
+64 per block and nesting to 32. Expanded text has a separate cumulative budget
+equal to the read limit. These account for parser work, not exact process memory.
+
+I/O errors and exhausted budgets stop parsing. Recoverable malformed metadata
+appears in `issues`; inspect it before treating a result as complete.
+
+BigTIFF, manufacturer MakerNotes, non-TIFF RAW adapters and metadata writing are
+unsupported. JPEG scanning ends at the first image scan. PNG CRCs and extended-XMP
+GUID digests are not authenticated. Structured XMP is not a complete RDF graph
+or a typed face-region API.
+
+## Development
+
+From `rust/`:
+
+```sh
+cargo test --locked -p ente-exif
+cargo test --locked -p ente-exif --test integration jxl::
+cargo run --release --locked -p ente-exif --example inspect -- photo.heic
+cargo run --release --locked -p ente-exif --example extract_motion -- photo.jpg motion.mp4
+```
+
+Tests generate metadata containers in memory; no downloads or external fixtures
+are needed. See [fixture rules and references](tests/README.md). Shared lint and
+build commands are in the [workspace README](../../README.md).

--- a/rust/crates/exif/examples/extract_motion.rs
+++ b/rust/crates/exif/examples/extract_motion.rs
@@ -1,0 +1,21 @@
+use ente_exif::{Limits, Mode};
+use std::fs::File;
+use std::io::{self, BufReader, Read, Seek, SeekFrom};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let (Some(input), Some(output), None) = (args.next(), args.next(), args.next()) else {
+        return Err("usage: extract_motion INPUT OUTPUT.mp4".into());
+    };
+    let mut source = BufReader::with_capacity(16 * 1024, File::open(input)?);
+    let metadata = ente_exif::read(&mut source, Mode::Summary, Limits::default())?;
+    let video = metadata.motion_video.ok_or("no motion video detected")?;
+    source.seek(SeekFrom::Start(video.start))?;
+    let mut output = File::create_new(output)?;
+    let copied = io::copy(&mut source.take(video.end - video.start), &mut output)?;
+    println!(
+        "copied {copied} bytes from [{}..{})",
+        video.start, video.end
+    );
+    Ok(())
+}

--- a/rust/crates/exif/examples/inspect.rs
+++ b/rust/crates/exif/examples/inspect.rs
@@ -1,0 +1,91 @@
+use ente_exif::{DateTimeKind, Ifd, Limits, Mode, TextEncoding};
+use std::fs::File;
+use std::io::BufReader;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1).peekable();
+    let mode = if args.peek().is_some_and(|arg| arg == "--details") {
+        args.next();
+        Mode::Details
+    } else {
+        Mode::Summary
+    };
+    for path in args {
+        let mut file = BufReader::with_capacity(16 * 1024, File::open(&path)?);
+        let metadata = ente_exif::read(&mut file, mode, Limits::default())?;
+        println!("{path}");
+        println!("display dimensions: {:?}", metadata.display_dimensions());
+        println!("capture date/time: {:?}", metadata.capture_date_time());
+        println!(
+            "stored dimensions: {:?} × {:?}",
+            metadata.width(),
+            metadata.height()
+        );
+        println!(
+            "EXIF orientation: {:?}; native transforms: {:?}",
+            metadata.orientation(),
+            metadata.transforms
+        );
+        println!(
+            "camera: {:?} {:?}; lens: {:?}",
+            metadata.camera_make(),
+            metadata.camera_model(),
+            metadata.lens_model()
+        );
+        println!(
+            "exposure seconds: {:?}; f-number: {:?}; focal length mm: {:?}; sensitivity: {:?}",
+            metadata.exposure_time(),
+            metadata.f_number(),
+            metadata.focal_length(),
+            metadata.iso_speed_ratings()
+        );
+        for kind in [
+            DateTimeKind::Original,
+            DateTimeKind::Digitized,
+            DateTimeKind::Modified,
+        ] {
+            if let Some(date) = metadata.exif_date_time(kind) {
+                println!(
+                    "EXIF {kind:?}: {date}; epoch microseconds: {:?}",
+                    date.unix_micros()
+                );
+            }
+        }
+        println!(
+            "EXIF location: {:?}; XMP location: {:?}",
+            metadata.exif_location(),
+            metadata.xmp_location()
+        );
+        println!(
+            "EXIF description: {:?}; XMP description: {:?}",
+            metadata.exif_description(),
+            metadata.xmp_description(None)
+        );
+        println!(
+            "EXIF description as Latin-1: {:?}; IPTC caption (Windows-1252 fallback): {:?}",
+            metadata
+                .tag(Ifd::Image(0), 0x10e)
+                .and_then(|t| t.value.text_with(TextEncoding::Latin1)),
+            metadata.iptc_caption(TextEncoding::Windows1252)
+        );
+        println!("panorama: {}", metadata.is_panorama());
+        if let Some(video) = metadata.motion_video {
+            println!(
+                "motion video: [{}..{}), {} bytes",
+                video.start,
+                video.end,
+                video.end - video.start
+            );
+        } else {
+            println!("motion video: none detected");
+        }
+        println!(
+            "issues: {:?}; reads: {:?}",
+            metadata.issues, metadata.statistics
+        );
+        if mode == Mode::Details {
+            println!("{metadata:#?}");
+        }
+    }
+    Ok(())
+}

--- a/rust/crates/exif/src/boxes.rs
+++ b/rust/crates/exif/src/boxes.rs
@@ -1,0 +1,40 @@
+use crate::read::{Error, Reader, be32, range};
+use std::io::{Read, Seek};
+
+pub(crate) struct BoxRange {
+    pub kind: [u8; 4],
+    pub start: u64,
+    pub len: u64,
+}
+impl BoxRange {
+    pub fn end(&self) -> u64 {
+        self.start + self.len
+    }
+}
+
+pub(crate) fn box_at<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    offset: u64,
+    end: u64,
+) -> Result<BoxRange, Error> {
+    range(0, end, offset, 8)?;
+    let header = reader.array::<8>(offset)?;
+    let mut size = u64::from(be32(&header));
+    let mut header_size = 8;
+    if size == 1 {
+        range(0, end, offset, 16)?;
+        size = u64::from_be_bytes(reader.array::<8>(offset + 8)?);
+        header_size = 16;
+    } else if size == 0 {
+        size = end - offset;
+    }
+    if size < header_size {
+        return Err(Error::Malformed("box size"));
+    }
+    range(0, end, offset, size)?;
+    Ok(BoxRange {
+        kind: header[4..8].try_into().unwrap(),
+        start: offset + header_size,
+        len: size - header_size,
+    })
+}

--- a/rust/crates/exif/src/datetime.rs
+++ b/rust/crates/exif/src/datetime.rs
@@ -1,0 +1,350 @@
+use crate::{Ifd, Metadata};
+use std::fmt;
+
+/// An EXIF date and its matching subsecond/UTC-offset tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateTimeKind {
+    Original,
+    Digitized,
+    Modified,
+}
+
+/// The metadata field(s) containing one date/time value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateTimeSource {
+    Exif(DateTimeKind),
+    /// Namespace URI and local property name.
+    Xmp(&'static str, &'static str),
+    /// Date and time dataset IDs in IPTC record 2.
+    Iptc(u8, u8),
+}
+
+/// Parsed date components and the smallest calendar unit present in the source.
+/// Omitted components use the start of that period (month/day 1, clock 0).
+/// Precision keeps those defaults distinguishable from explicitly supplied values.
+/// No UTC offset is inferred and parsing allocates no strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DateTimeValue {
+    pub date_time: DateTime,
+    pub precision: DateTimePrecision,
+}
+
+/// Smallest supplied calendar unit. Fractional digits remain in the raw field;
+/// DateTime retains their value up to nanoseconds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateTimePrecision {
+    Year,
+    Month,
+    Day,
+    Minute,
+    Second,
+}
+
+/// A complete photo-local date/time. A missing UTC offset is unknown, not UTC.
+/// Original text and precision remain available through the raw metadata tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DateTime {
+    pub year: u16,
+    pub month: u8,
+    pub day: u8,
+    pub hour: u8,
+    pub minute: u8,
+    pub second: u8,
+    /// Fractional seconds, truncated to nine digits.
+    pub nanosecond: u32,
+    /// Signed minutes east of UTC, including negative sub-hour offsets.
+    pub offset_minutes: Option<i16>,
+}
+
+impl Metadata {
+    /// Parse a specific EXIF, XMP or IPTC date without fallback or timezone policy.
+    /// Returns None when that field is absent or malformed. XMP fields must be
+    /// retained by the chosen read mode; arbitrary properties require Details.
+    #[inline]
+    pub fn date_time(&self, source: DateTimeSource) -> Option<DateTimeValue> {
+        match source {
+            DateTimeSource::Exif(kind) => Some(DateTimeValue {
+                date_time: self.exif_date_time(kind)?,
+                precision: DateTimePrecision::Second,
+            }),
+            DateTimeSource::Xmp(ns, name) => xmp_date(self.property(ns, name)?),
+            DateTimeSource::Iptc(date, time) => {
+                iptc_date(self.iptc_value(date)?, self.iptc_value(time))
+            }
+        }
+    }
+
+    /// Parse one EXIF date family without selecting a creation-time fallback.
+    /// Inline fractions/offsets take precedence over matching auxiliary tags.
+    /// Blank auxiliary fields mean unknown; malformed fields used for conversion are rejected.
+    ///
+    /// ```rust,no_run
+    /// # use ente_exif::{DateTime, DateTimeKind, DateTimeSource, Limits, Mode, namespace};
+    /// # let mut file = std::fs::File::open("photo.jpg")?;
+    /// # let metadata = ente_exif::read(&mut file, Mode::Summary, Limits::default())?;
+    /// let original = metadata.exif_date_time(DateTimeKind::Original);
+    /// let digitized = metadata.exif_date_time(DateTimeKind::Digitized);
+    /// let modified = metadata.exif_date_time(DateTimeKind::Modified);
+    /// // Choose the fallback order appropriate to the application.
+    /// let capture = original.or(modified);
+    /// if let Some(date) = capture {
+    ///     println!("local: {}-{}-{} {}:{}:{}", date.year, date.month, date.day,
+    ///              date.hour, date.minute, date.second);
+    ///     println!("offset minutes: {:?}; epoch µs: {:?}", date.offset_minutes, date.unix_micros());
+    /// }
+    /// let xmp_created = metadata.date_time(DateTimeSource::Xmp(namespace::XMP, "CreateDate"));
+    /// let iptc_created = metadata.date_time(DateTimeSource::Iptc(55, 60));
+    /// let strict = DateTime::parse("2024-02-29T12:34:56+05:30");
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn exif_date_time(&self, kind: DateTimeKind) -> Option<DateTime> {
+        let (ifd, date, subsecond, offset) = match kind {
+            DateTimeKind::Original => (Ifd::Exif(0), 0x9003, 0x9291, 0x9011),
+            DateTimeKind::Digitized => (Ifd::Exif(0), 0x9004, 0x9292, 0x9012),
+            DateTimeKind::Modified => (Ifd::Image(0), 0x132, 0x9290, 0x9010),
+        };
+        let auxiliary = |id| match self.tag(Ifd::Exif(0), id) {
+            Some(tag) => Some(tag.value.text()?.trim()),
+            None => Some(""),
+        };
+        parse(
+            self.text(ifd, date)?,
+            auxiliary(subsecond),
+            auxiliary(offset),
+        )
+    }
+
+    fn iptc_value(&self, dataset: u8) -> Option<&[u8]> {
+        self.iptc
+            .iter()
+            .find(|v| v.record == 2 && v.dataset == dataset)
+            .map(|v| v.value.as_slice())
+    }
+}
+
+impl DateTime {
+    /// Parse a complete EXIF or ISO-style timestamp with optional fraction and offset.
+    /// Accepts YYYY:MM:DD HH:MM:SS and YYYY-MM-DD[T or space]HH:MM:SS,
+    /// dot/colon fractions, and Z or `±HH[:]?MM` offsets. Partial dates, leap seconds,
+    /// impossible calendar dates and named timezones return None.
+    pub fn parse(value: &str) -> Option<Self> {
+        parse(value.trim(), Some(""), Some(""))
+    }
+
+    /// Epoch microseconds only when the offset and calendar components are valid.
+    /// No device timezone, DST rule, sentinel-date policy or fallback is applied.
+    pub fn unix_micros(self) -> Option<i64> {
+        if !self.valid() {
+            return None;
+        }
+        let offset = i64::from(self.offset_minutes?);
+        let year = i64::from(self.year) - 1;
+        let before_year = 365 * year + year / 4 - year / 100 + year / 400;
+        let before_month: i64 = (1..self.month)
+            .map(|m| i64::from(days_in_month(self.year, m)))
+            .sum();
+        let days = before_year + before_month + i64::from(self.day) - 1 - 719_162;
+        let seconds = days * 86_400
+            + i64::from(self.hour) * 3600
+            + i64::from(self.minute) * 60
+            + i64::from(self.second)
+            - offset * 60;
+        Some(seconds * 1_000_000 + i64::from(self.nanosecond / 1000))
+    }
+
+    fn valid(self) -> bool {
+        (1..=9999).contains(&self.year)
+            && self.day != 0
+            && self.day <= days_in_month(self.year, self.month)
+            && self.hour < 24
+            && self.minute < 60
+            && self.second < 60
+            && self.nanosecond < 1_000_000_000
+            && self
+                .offset_minutes
+                .is_none_or(|v| (-1439..=1439).contains(&v))
+    }
+}
+
+impl fmt::Display for DateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+            self.year, self.month, self.day, self.hour, self.minute, self.second
+        )?;
+        if self.nanosecond != 0 {
+            write!(f, ".{:09}", self.nanosecond)?;
+        }
+        if let Some(offset) = self.offset_minutes {
+            let minutes = offset.unsigned_abs();
+            write!(
+                f,
+                "{}{:02}:{:02}",
+                if offset < 0 { '-' } else { '+' },
+                minutes / 60,
+                minutes % 60
+            )?;
+        }
+        Ok(())
+    }
+}
+
+fn xmp_date(value: &str) -> Option<DateTimeValue> {
+    let bytes = value.trim().as_bytes();
+    let precision = match bytes.len() {
+        4 => DateTimePrecision::Year,
+        7 => DateTimePrecision::Month,
+        10 => DateTimePrecision::Day,
+        _ => DateTimePrecision::Second,
+    };
+    if precision != DateTimePrecision::Second {
+        let mut complete = *b"0000-01-01T00:00:00";
+        complete[..bytes.len()].copy_from_slice(bytes);
+        return DateTime::parse(std::str::from_utf8(&complete).ok()?).map(|date_time| {
+            DateTimeValue {
+                date_time,
+                precision,
+            }
+        });
+    }
+    if bytes.len() >= 16 && matches!(bytes.get(16), None | Some(b'Z' | b'z' | b'+' | b'-')) {
+        let suffix = &bytes[16..];
+        let mut complete = *b"0000-00-00T00:00:00      ";
+        complete[..16].copy_from_slice(&bytes[..16]);
+        complete
+            .get_mut(19..19 + suffix.len())?
+            .copy_from_slice(suffix);
+        return DateTime::parse(std::str::from_utf8(&complete[..19 + suffix.len()]).ok()?).map(
+            |date_time| DateTimeValue {
+                date_time,
+                precision: DateTimePrecision::Minute,
+            },
+        );
+    }
+    DateTime::parse(value).map(|date_time| DateTimeValue {
+        date_time,
+        precision: DateTimePrecision::Second,
+    })
+}
+
+fn iptc_date(date: &[u8], time: Option<&[u8]>) -> Option<DateTimeValue> {
+    if date.len() != 8 {
+        return None;
+    }
+    let mut complete = *b"0000-00-00T00:00:00+0000";
+    complete[..4].copy_from_slice(&date[..4]);
+    complete[5..7].copy_from_slice(&date[4..6]);
+    complete[8..10].copy_from_slice(&date[6..]);
+    let mut len = 19;
+    if let Some(time) = time {
+        if !matches!(time.len(), 6 | 11) {
+            return None;
+        }
+        complete[11..13].copy_from_slice(&time[..2]);
+        complete[14..16].copy_from_slice(&time[2..4]);
+        complete[17..19].copy_from_slice(&time[4..6]);
+        if time.len() == 11 {
+            complete[19..].copy_from_slice(&time[6..]);
+            len = 24;
+        }
+    }
+    DateTime::parse(std::str::from_utf8(&complete[..len]).ok()?).map(|date_time| DateTimeValue {
+        date_time,
+        precision: if time.is_none() {
+            DateTimePrecision::Day
+        } else {
+            DateTimePrecision::Second
+        },
+    })
+}
+
+fn parse(value: &str, subsecond: Option<&str>, offset: Option<&str>) -> Option<DateTime> {
+    let b = value.as_bytes();
+    if b.len() < 19
+        || !matches!(b[4], b':' | b'-')
+        || b[7] != b[4]
+        || !matches!(b[10], b' ' | b'T' | b't')
+        || b[13] != b':'
+        || b[16] != b':'
+    {
+        return None;
+    }
+    let mut date = DateTime {
+        year: number(&b[..4])? as u16,
+        month: number(&b[5..7])? as u8,
+        day: number(&b[8..10])? as u8,
+        hour: number(&b[11..13])? as u8,
+        minute: number(&b[14..16])? as u8,
+        second: number(&b[17..19])? as u8,
+        nanosecond: 0,
+        offset_minutes: None,
+    };
+    let mut suffix = value.get(19..)?;
+    if suffix.starts_with(['.', ':']) {
+        let digits = &suffix[1..];
+        let end = digits.bytes().take_while(u8::is_ascii_digit).count();
+        date.nanosecond = fraction(&digits[..end])?;
+        suffix = &digits[end..];
+    } else {
+        let subsecond = subsecond?;
+        if !subsecond.is_empty() {
+            date.nanosecond = fraction(subsecond)?;
+        }
+    }
+    if !suffix.is_empty() {
+        date.offset_minutes = Some(utc_offset(suffix)?);
+    } else {
+        let offset = offset?;
+        if !offset.bytes().all(|b| matches!(b, b' ' | b':')) {
+            date.offset_minutes = Some(utc_offset(offset)?);
+        }
+    }
+    date.valid().then_some(date)
+}
+
+fn number(bytes: &[u8]) -> Option<u32> {
+    bytes.iter().try_fold(0, |n, b| {
+        b.is_ascii_digit().then(|| n * 10 + u32::from(b - b'0'))
+    })
+}
+
+fn fraction(value: &str) -> Option<u32> {
+    if value.is_empty() || !value.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let digits = value.len().min(9);
+    Some(number(&value.as_bytes()[..digits])? * 10u32.pow(9 - digits as u32))
+}
+
+fn utc_offset(value: &str) -> Option<i16> {
+    if matches!(value, "Z" | "z") {
+        return Some(0);
+    }
+    let b = value.as_bytes();
+    let minutes = match b {
+        [b'+' | b'-', _, _, b':', _, _] => number(&b[4..])?,
+        [b'+' | b'-', _, _, _, _] => number(&b[3..])?,
+        _ => return None,
+    };
+    let hours = number(&b[1..3])?;
+    if hours > 23 || minutes > 59 {
+        return None;
+    }
+    Some((hours * 60 + minutes) as i16 * if b[0] == b'-' { -1 } else { 1 })
+}
+
+fn days_in_month(year: u16, month: u8) -> u8 {
+    match month {
+        2 => {
+            if year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400)) {
+                29
+            } else {
+                28
+            }
+        }
+        4 | 6 | 9 | 11 => 30,
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        _ => 0,
+    }
+}

--- a/rust/crates/exif/src/datetime.rs
+++ b/rust/crates/exif/src/datetime.rs
@@ -1,7 +1,6 @@
 use crate::{Ifd, Metadata};
 use std::fmt;
 
-/// An EXIF date and its matching subsecond/UTC-offset tags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DateTimeKind {
     Original,
@@ -9,28 +8,17 @@ pub enum DateTimeKind {
     Modified,
 }
 
-/// The metadata field(s) containing one date/time value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DateTimeSource {
     Exif(DateTimeKind),
-    /// Namespace URI and local property name.
     Xmp(&'static str, &'static str),
-    /// Date and time dataset IDs in IPTC record 2.
     Iptc(u8, u8),
 }
-
-/// Parsed date components and the smallest calendar unit present in the source.
-/// Omitted components use the start of that period (month/day 1, clock 0).
-/// Precision keeps those defaults distinguishable from explicitly supplied values.
-/// No UTC offset is inferred and parsing allocates no strings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DateTimeValue {
     pub date_time: DateTime,
     pub precision: DateTimePrecision,
 }
-
-/// Smallest supplied calendar unit. Fractional digits remain in the raw field;
-/// DateTime retains their value up to nanoseconds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DateTimePrecision {
     Year,
@@ -39,9 +27,6 @@ pub enum DateTimePrecision {
     Minute,
     Second,
 }
-
-/// A complete photo-local date/time. A missing UTC offset is unknown, not UTC.
-/// Original text and precision remain available through the raw metadata tags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DateTime {
     pub year: u16,
@@ -50,16 +35,11 @@ pub struct DateTime {
     pub hour: u8,
     pub minute: u8,
     pub second: u8,
-    /// Fractional seconds, truncated to nine digits.
     pub nanosecond: u32,
-    /// Signed minutes east of UTC, including negative sub-hour offsets.
     pub offset_minutes: Option<i16>,
 }
 
 impl Metadata {
-    /// Parse a specific EXIF, XMP or IPTC date without fallback or timezone policy.
-    /// Returns None when that field is absent or malformed. XMP fields must be
-    /// retained by the chosen read mode; arbitrary properties require Details.
     #[inline]
     pub fn date_time(&self, source: DateTimeSource) -> Option<DateTimeValue> {
         match source {
@@ -73,30 +53,6 @@ impl Metadata {
             }
         }
     }
-
-    /// Parse one EXIF date family without selecting a creation-time fallback.
-    /// Inline fractions/offsets take precedence over matching auxiliary tags.
-    /// Blank auxiliary fields mean unknown; malformed fields used for conversion are rejected.
-    ///
-    /// ```rust,no_run
-    /// # use ente_exif::{DateTime, DateTimeKind, DateTimeSource, Limits, Mode, namespace};
-    /// # let mut file = std::fs::File::open("photo.jpg")?;
-    /// # let metadata = ente_exif::read(&mut file, Mode::Summary, Limits::default())?;
-    /// let original = metadata.exif_date_time(DateTimeKind::Original);
-    /// let digitized = metadata.exif_date_time(DateTimeKind::Digitized);
-    /// let modified = metadata.exif_date_time(DateTimeKind::Modified);
-    /// // Choose the fallback order appropriate to the application.
-    /// let capture = original.or(modified);
-    /// if let Some(date) = capture {
-    ///     println!("local: {}-{}-{} {}:{}:{}", date.year, date.month, date.day,
-    ///              date.hour, date.minute, date.second);
-    ///     println!("offset minutes: {:?}; epoch µs: {:?}", date.offset_minutes, date.unix_micros());
-    /// }
-    /// let xmp_created = metadata.date_time(DateTimeSource::Xmp(namespace::XMP, "CreateDate"));
-    /// let iptc_created = metadata.date_time(DateTimeSource::Iptc(55, 60));
-    /// let strict = DateTime::parse("2024-02-29T12:34:56+05:30");
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn exif_date_time(&self, kind: DateTimeKind) -> Option<DateTime> {
         let (ifd, date, subsecond, offset) = match kind {
             DateTimeKind::Original => (Ifd::Exif(0), 0x9003, 0x9291, 0x9011),
@@ -123,16 +79,9 @@ impl Metadata {
 }
 
 impl DateTime {
-    /// Parse a complete EXIF or ISO-style timestamp with optional fraction and offset.
-    /// Accepts YYYY:MM:DD HH:MM:SS and YYYY-MM-DD[T or space]HH:MM:SS,
-    /// dot/colon fractions, and Z or `±HH[:]?MM` offsets. Partial dates, leap seconds,
-    /// impossible calendar dates and named timezones return None.
     pub fn parse(value: &str) -> Option<Self> {
         parse(value.trim(), Some(""), Some(""))
     }
-
-    /// Epoch microseconds only when the offset and calendar components are valid.
-    /// No device timezone, DST rule, sentinel-date policy or fallback is applied.
     pub fn unix_micros(self) -> Option<i64> {
         if !self.valid() {
             return None;

--- a/rust/crates/exif/src/dimensions.rs
+++ b/rust/crates/exif/src/dimensions.rs
@@ -13,16 +13,10 @@ pub struct CleanAperture {
     pub horizontal_offset: Rational,
     pub vertical_offset: Rational,
 }
-
-/// A primary-image transform. Crops use coordinates after preceding transforms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Transform {
-    /// Authoritative orientation using EXIF's 1–8 convention (JPEG XL).
-    /// Even 1 (normal) overrides EXIF/XMP orientation.
     Orientation(u8),
-    /// Quarter turns counterclockwise (0–3).
     Rotate(u8),
-    /// Mirror axis: 0 = vertical axis, 1 = horizontal axis.
     Mirror(u8),
     Crop(CleanAperture),
 }
@@ -31,10 +25,6 @@ impl Dimensions {
     pub(crate) fn new(width: u32, height: u32) -> Option<Self> {
         (width != 0 && height != 0).then_some(Self { width, height })
     }
-
-    /// Apply EXIF's width/height swap to stored dimensions, including OS-provided ones.
-    /// Orientations 5–8 swap axes. Unknown values leave the pair unchanged.
-    /// Do not apply this again to dimensions already oriented by a decoder.
     pub fn with_exif_orientation(mut self, orientation: u32) -> Self {
         if (5..=8).contains(&orientation) {
             std::mem::swap(&mut self.width, &mut self.height);
@@ -44,8 +34,6 @@ impl Dimensions {
 }
 
 impl CleanAperture {
-    /// Apply an exact pixel crop to dimensions after any preceding transforms.
-    /// Returns None unless the crop is positive, integral, aligned and in bounds.
     pub fn cropped_dimensions(self, input: Dimensions) -> Option<Dimensions> {
         Some(Dimensions {
             width: crop_axis(input.width, self.width, self.horizontal_offset)?,
@@ -63,7 +51,6 @@ fn crop_axis(input: u32, size: Rational, offset: Rational) -> Option<u32> {
     }
     let size = u32::try_from(size.numerator / size.denominator).ok()?;
     let spare = i128::from(input.checked_sub(size)?);
-    // https://developer.apple.com/documentation/quicktime-file-format/clean_aperture
     let denominator = 2 * i128::from(offset.denominator);
     let origin = spare * i128::from(offset.denominator) + 2 * i128::from(offset.numerator);
     (origin >= 0 && origin <= spare * denominator && origin % denominator == 0).then_some(size)

--- a/rust/crates/exif/src/dimensions.rs
+++ b/rust/crates/exif/src/dimensions.rs
@@ -1,0 +1,70 @@
+use crate::Rational;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Dimensions {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CleanAperture {
+    pub width: Rational,
+    pub height: Rational,
+    pub horizontal_offset: Rational,
+    pub vertical_offset: Rational,
+}
+
+/// A primary-image transform. Crops use coordinates after preceding transforms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transform {
+    /// Authoritative orientation using EXIF's 1–8 convention (JPEG XL).
+    /// Even 1 (normal) overrides EXIF/XMP orientation.
+    Orientation(u8),
+    /// Quarter turns counterclockwise (0–3).
+    Rotate(u8),
+    /// Mirror axis: 0 = vertical axis, 1 = horizontal axis.
+    Mirror(u8),
+    Crop(CleanAperture),
+}
+
+impl Dimensions {
+    pub(crate) fn new(width: u32, height: u32) -> Option<Self> {
+        (width != 0 && height != 0).then_some(Self { width, height })
+    }
+
+    /// Apply EXIF's width/height swap to stored dimensions, including OS-provided ones.
+    /// Orientations 5–8 swap axes. Unknown values leave the pair unchanged.
+    /// Do not apply this again to dimensions already oriented by a decoder.
+    pub fn with_exif_orientation(mut self, orientation: u32) -> Self {
+        if (5..=8).contains(&orientation) {
+            std::mem::swap(&mut self.width, &mut self.height);
+        }
+        self
+    }
+}
+
+impl CleanAperture {
+    /// Apply an exact pixel crop to dimensions after any preceding transforms.
+    /// Returns None unless the crop is positive, integral, aligned and in bounds.
+    pub fn cropped_dimensions(self, input: Dimensions) -> Option<Dimensions> {
+        Some(Dimensions {
+            width: crop_axis(input.width, self.width, self.horizontal_offset)?,
+            height: crop_axis(input.height, self.height, self.vertical_offset)?,
+        })
+    }
+}
+
+fn crop_axis(input: u32, size: Rational, offset: Rational) -> Option<u32> {
+    if size.numerator <= 0 || size.denominator <= 0 || offset.denominator <= 0 {
+        return None;
+    }
+    if size.numerator % size.denominator != 0 {
+        return None;
+    }
+    let size = u32::try_from(size.numerator / size.denominator).ok()?;
+    let spare = i128::from(input.checked_sub(size)?);
+    // https://developer.apple.com/documentation/quicktime-file-format/clean_aperture
+    let denominator = 2 * i128::from(offset.denominator);
+    let origin = spare * i128::from(offset.denominator) + 2 * i128::from(offset.numerator);
+    (origin >= 0 && origin <= spare * denominator && origin % denominator == 0).then_some(size)
+}

--- a/rust/crates/exif/src/gif.rs
+++ b/rust/crates/exif/src/gif.rs
@@ -1,0 +1,93 @@
+use crate::read::{Error, Reader, State, range};
+use crate::{Dimensions, xmp};
+use std::io::{Read, Seek};
+
+pub(crate) fn read<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+) -> Result<(), Error> {
+    let data = reader.array::<7>(6)?;
+    state.metadata.dimensions = Dimensions::new(
+        u32::from(u16::from_le_bytes([data[0], data[1]])),
+        u32::from(u16::from_le_bytes([data[2], data[3]])),
+    );
+    let table_size = |flags: u8| {
+        if flags & 0x80 != 0 {
+            3u64 << ((flags & 7) + 1)
+        } else {
+            0
+        }
+    };
+    let mut offset = 13 + table_size(data[4]);
+    while offset < reader.len {
+        state.entries(1)?;
+        let marker = reader.array::<1>(offset)?[0];
+        offset += 1;
+        match marker {
+            0x3b => return Ok(()),
+            0x2c => {
+                let image = reader.array::<9>(offset)?;
+                offset += 10 + table_size(image[8]);
+                skip_subblocks(reader, state, &mut offset)?;
+            }
+            0x21 => {
+                let label = reader.array::<1>(offset)?[0];
+                offset += 1;
+                if label == 0xff {
+                    let size = reader.array::<1>(offset)?[0] as usize;
+                    offset += 1;
+                    let app = reader.bytes(offset, size)?;
+                    offset += size as u64;
+                    if app == b"XMP DataXMP" {
+                        // https://github.com/adobe/XMP-Toolkit-SDK/blob/main/docs/XMPSpecificationPart3.pdf
+                        let start = offset;
+                        let mut packet = Vec::new();
+                        loop {
+                            let scan = packet.len().saturating_sub(257);
+                            let count = (reader.len - offset).min(4096) as usize;
+                            if count == 0 {
+                                return Err(Error::Malformed("GIF XMP trailer"));
+                            }
+                            packet.extend(reader.bytes(offset, count)?);
+                            offset += count as u64;
+                            if let Some(end) = packet[scan..].windows(258).position(|w| {
+                                w[0] == 1
+                                    && w[257] == 0
+                                    && w[1..257].iter().copied().eq((0..=255).rev())
+                            }) {
+                                let end = scan + end;
+                                offset = start + end as u64 + 258;
+                                packet.truncate(end);
+                                let result = xmp::read(&packet, state);
+                                state.recover(offset, result)?;
+                                break;
+                            }
+                        }
+                    } else {
+                        skip_subblocks(reader, state, &mut offset)?;
+                    }
+                } else {
+                    skip_subblocks(reader, state, &mut offset)?;
+                }
+            }
+            _ => return Err(Error::Malformed("GIF block")),
+        }
+    }
+    Err(Error::Malformed("missing GIF trailer"))
+}
+
+fn skip_subblocks<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    offset: &mut u64,
+) -> Result<(), Error> {
+    loop {
+        state.entries(1)?;
+        let size = u64::from(reader.array::<1>(*offset)?[0]);
+        range(0, reader.len, *offset, size + 1)?;
+        *offset += size + 1;
+        if size == 0 {
+            return Ok(());
+        }
+    }
+}

--- a/rust/crates/exif/src/gif.rs
+++ b/rust/crates/exif/src/gif.rs
@@ -39,7 +39,6 @@ pub(crate) fn read<R: Read + Seek>(
                     let app = reader.bytes(offset, size)?;
                     offset += size as u64;
                     if app == b"XMP DataXMP" {
-                        // https://github.com/adobe/XMP-Toolkit-SDK/blob/main/docs/XMPSpecificationPart3.pdf
                         let start = offset;
                         let mut packet = Vec::new();
                         loop {

--- a/rust/crates/exif/src/iptc.rs
+++ b/rust/crates/exif/src/iptc.rs
@@ -1,0 +1,85 @@
+use crate::read::{Cursor, Error, State};
+use crate::{Metadata, Mode, TextEncoding, text};
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Iptc {
+    pub record: u8,
+    pub dataset: u8,
+    pub value: Vec<u8>,
+}
+
+impl Metadata {
+    /// IPTC caption (2:120), respecting its character-set announcement.
+    pub fn iptc_caption(&self, fallback: TextEncoding) -> Option<Cow<'_, str>> {
+        self.iptc_text(2, 120, fallback)
+    }
+
+    /// Decode the first matching IPTC text dataset without trimming it.
+    /// Record 1 uses ASCII. Records 2–6 and 8 support the UTF-8 announcement
+    /// (ESC % G); other announcements return `None`. The caller's encoding is
+    /// used only when no announcement exists. Invalid UTF-8 is not repaired.
+    /// Raw datasets, including repeats and unsupported encodings, remain available.
+    pub fn iptc_text(
+        &self,
+        record: u8,
+        dataset: u8,
+        fallback: TextEncoding,
+    ) -> Option<Cow<'_, str>> {
+        let encoding = match record {
+            1 => TextEncoding::Ascii,
+            2..=6 | 8 => match self.iptc.iter().find(|v| v.record == 1 && v.dataset == 90) {
+                Some(v) if v.value == b"\x1b%G" => TextEncoding::Utf8,
+                Some(_) => return None,
+                None => fallback,
+            },
+            _ => return None,
+        };
+        let value = &self
+            .iptc
+            .iter()
+            .find(|v| v.record == record && v.dataset == dataset)?
+            .value;
+        text::decode(value, encoding)
+    }
+}
+
+pub(crate) fn read(data: &[u8], state: &mut State) -> Result<(), Error> {
+    let mut cursor = Cursor::new(data);
+    while cursor.pos < data.len() {
+        state.entries(1)?;
+        if data[cursor.pos] == 0 && data[cursor.pos..].iter().all(|b| *b == 0) {
+            break;
+        }
+        if cursor.number(1)? != 0x1c {
+            return Err(Error::Malformed("IPTC dataset"));
+        }
+        let record = cursor.number(1)? as u8;
+        let dataset = cursor.number(1)? as u8;
+        let size = cursor.number(2)? as usize;
+        let size = if size & 0x8000 != 0 {
+            let width = size & 0x7fff;
+            if width == 0 || width > 4 {
+                return Err(Error::Malformed("IPTC extended size"));
+            }
+            cursor.number(width)? as usize
+        } else {
+            size
+        };
+        let value = cursor.take(size)?;
+        if state.mode == Mode::Details
+            || matches!((record, dataset), (1, 90) | (2, 55 | 60 | 62 | 63 | 120))
+        {
+            if size > state.limits.value_bytes {
+                return Err(Error::Limit("IPTC value"));
+            }
+            state.retain(std::mem::size_of::<Iptc>() + size)?;
+            state.metadata.iptc.push(Iptc {
+                record,
+                dataset,
+                value: value.to_vec(),
+            });
+        }
+    }
+    Ok(())
+}

--- a/rust/crates/exif/src/iptc.rs
+++ b/rust/crates/exif/src/iptc.rs
@@ -10,16 +10,9 @@ pub struct Iptc {
 }
 
 impl Metadata {
-    /// IPTC caption (2:120), respecting its character-set announcement.
     pub fn iptc_caption(&self, fallback: TextEncoding) -> Option<Cow<'_, str>> {
         self.iptc_text(2, 120, fallback)
     }
-
-    /// Decode the first matching IPTC text dataset without trimming it.
-    /// Record 1 uses ASCII. Records 2–6 and 8 support the UTF-8 announcement
-    /// (ESC % G); other announcements return `None`. The caller's encoding is
-    /// used only when no announcement exists. Invalid UTF-8 is not repaired.
-    /// Raw datasets, including repeats and unsupported encodings, remain available.
     pub fn iptc_text(
         &self,
         record: u8,

--- a/rust/crates/exif/src/isobmff.rs
+++ b/rust/crates/exif/src/isobmff.rs
@@ -40,6 +40,7 @@ pub(crate) fn read<R: Read + Seek>(
 struct Item {
     kind: [u8; 4],
     mime: String,
+    protected: bool,
     location: Option<Location>,
     describes: Vec<u32>,
 }
@@ -191,6 +192,9 @@ fn read_item<R: Read + Seek>(
     idat: Option<&BoxRange>,
     is_exif: bool,
 ) -> Result<(), Error> {
+    if item.protected {
+        return Err(Error::Unsupported("protected metadata"));
+    }
     let location = item
         .location
         .as_ref()
@@ -283,15 +287,13 @@ fn item_info<R: Read + Seek>(
         } else {
             String::new()
         };
-        if protection != 0 && (&kind == b"Exif" || mime == "application/rdf+xml") {
-            return Err(Error::Unsupported("protected metadata"));
-        }
         let item = meta.items.entry(id).or_default();
         if item.kind != [0; 4] {
             return Err(Error::Malformed("duplicate item info"));
         }
         item.kind = kind;
         item.mime = mime;
+        item.protected = protection != 0;
     }
     Ok(())
 }

--- a/rust/crates/exif/src/isobmff.rs
+++ b/rust/crates/exif/src/isobmff.rs
@@ -1,0 +1,433 @@
+use crate::boxes::{BoxRange, box_at};
+use crate::read::{Cursor, Error, Reader, State, be32, range};
+use crate::{CleanAperture, Dimensions, Rational, Transform, tiff, xmp};
+use std::collections::BTreeMap;
+use std::io::{Read, Seek};
+
+pub(crate) fn read<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+) -> Result<(), Error> {
+    let first = box_at(reader, 0, reader.len)?;
+    let brands = reader.bytes(
+        first.start,
+        usize::try_from(first.len).map_err(|_| Error::Limit("brands"))?,
+    )?;
+    if brands.len() < 8
+        || !brands.as_chunks::<4>().0.iter().enumerate().any(|(i, b)| {
+            i != 1
+                && matches!(
+                    b,
+                    b"heic" | b"heix" | b"hevc" | b"hevx" | b"mif1" | b"msf1" | b"avif" | b"avis"
+                )
+        })
+    {
+        return Err(Error::Unsupported("ISOBMFF image brand"));
+    }
+    let mut offset = first.end();
+    while offset < reader.len {
+        state.entries(1)?;
+        let b = box_at(reader, offset, reader.len)?;
+        if &b.kind == b"meta" {
+            return metadata(reader, state, b);
+        }
+        offset = b.end();
+    }
+    Err(Error::Malformed("missing HEIF metadata"))
+}
+
+#[derive(Default)]
+struct Item {
+    kind: [u8; 4],
+    mime: String,
+    location: Option<Location>,
+    describes: Vec<u32>,
+}
+struct Location {
+    method: u64,
+    reference: u64,
+    base: u64,
+    extents: Vec<(u64, u64)>,
+}
+#[derive(Default)]
+struct Meta {
+    primary: Option<u32>,
+    items: BTreeMap<u32, Item>,
+    properties: Vec<BoxRange>,
+    associations: Vec<(u32, Vec<(usize, bool)>)>,
+    idat: Option<BoxRange>,
+}
+
+fn metadata<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    b: BoxRange,
+) -> Result<(), Error> {
+    range(b.start, b.len, 0, 4)?;
+    let mut meta = Meta::default();
+    let mut offset = b.start + 4;
+    while offset < b.end() {
+        state.entries(1)?;
+        let child = box_at(reader, offset, b.end())?;
+        offset = child.end();
+        match &child.kind {
+            b"pitm" => {
+                let bytes = payload(reader, &child)?;
+                let mut c = Cursor::new(&bytes);
+                let version = c.number(1)?;
+                c.take(3)?;
+                if version > 1 {
+                    return Err(Error::Unsupported("pitm version"));
+                }
+                meta.primary = Some(c.number(if version == 0 { 2 } else { 4 })? as u32);
+            }
+            b"iinf" => item_info(reader, state, &child, &mut meta)?,
+            b"iloc" => locations(&payload(reader, &child)?, state, &mut meta)?,
+            b"iref" => references(reader, state, &child, &mut meta)?,
+            b"iprp" => properties(reader, state, &child, &mut meta)?,
+            b"idat" => meta.idat = Some(child),
+            _ => {}
+        }
+    }
+    let primary = meta.primary.ok_or(Error::Malformed("primary image"))?;
+    for (_, props) in meta.associations.iter().filter(|(id, _)| *id == primary) {
+        for &(index, _) in props {
+            if index == 0 {
+                continue;
+            }
+            let p = meta
+                .properties
+                .get(index - 1)
+                .ok_or(Error::Malformed("property index"))?;
+            match &p.kind {
+                b"ispe" => {
+                    if p.len != 12 {
+                        return Err(Error::Malformed("ispe size"));
+                    }
+                    let bytes = reader.array::<8>(p.start + 4)?;
+                    state.metadata.dimensions = Dimensions::new(be32(&bytes), be32(&bytes[4..]));
+                }
+                b"irot" | b"imir" => {
+                    if p.len != 1 {
+                        return Err(Error::Malformed("transform size"));
+                    }
+                    let value = reader.array::<1>(p.start)?[0];
+                    let transform = if &p.kind == b"irot" && value <= 3 {
+                        Transform::Rotate(value)
+                    } else if &p.kind == b"imir" && value <= 1 {
+                        Transform::Mirror(value)
+                    } else {
+                        return Err(Error::Malformed("transform value"));
+                    };
+                    state.retain(std::mem::size_of::<Transform>())?;
+                    state.metadata.transforms.push(transform);
+                }
+                b"clap" => {
+                    if p.len != 32 {
+                        return Err(Error::Malformed("clap size"));
+                    }
+                    let bytes = reader.array::<32>(p.start)?;
+                    let rational = |offset, signed| -> Result<Rational, Error> {
+                        let n = be32(&bytes[offset..]);
+                        let d = be32(&bytes[offset + 4..]);
+                        if d == 0 {
+                            return Err(Error::Malformed("clap denominator"));
+                        }
+                        Ok(Rational {
+                            numerator: if signed {
+                                i64::from(n as i32)
+                            } else {
+                                i64::from(n)
+                            },
+                            denominator: i64::from(d),
+                        })
+                    };
+                    let crop = CleanAperture {
+                        width: rational(0, false)?,
+                        height: rational(8, false)?,
+                        horizontal_offset: rational(16, true)?,
+                        vertical_offset: rational(24, true)?,
+                    };
+                    state.retain(std::mem::size_of::<Transform>())?;
+                    state.metadata.transforms.push(Transform::Crop(crop));
+                }
+                _ => {}
+            }
+        }
+    }
+    for is_exif in [true, false] {
+        let mut candidates = meta.items.values().filter(|item| {
+            (item.describes.is_empty() || item.describes.contains(&primary))
+                && if is_exif {
+                    &item.kind == b"Exif"
+                } else {
+                    &item.kind == b"mime"
+                        && matches!(
+                            item.mime.as_str(),
+                            "application/rdf+xml" | "application/xml" | "text/xml"
+                        )
+                }
+        });
+        let Some(item) = candidates.next() else {
+            continue;
+        };
+        if candidates.next().is_some() {
+            state.recover(
+                b.start,
+                Err(Error::Unsupported("ambiguous primary metadata")),
+            )?;
+            continue;
+        }
+        let result = read_item(reader, state, item, meta.idat.as_ref(), is_exif);
+        state.recover(b.start, result)?;
+    }
+    Ok(())
+}
+
+fn read_item<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    item: &Item,
+    idat: Option<&BoxRange>,
+    is_exif: bool,
+) -> Result<(), Error> {
+    let location = item
+        .location
+        .as_ref()
+        .ok_or(Error::Malformed("missing item location"))?;
+    if location.reference != 0 {
+        return Err(Error::Unsupported("external item reference"));
+    }
+    let (origin, len) = match location.method {
+        0 => (0, reader.len),
+        1 => {
+            let b = idat.ok_or(Error::Malformed("missing idat"))?;
+            (b.start, b.len)
+        }
+        _ => return Err(Error::Unsupported("item construction method")),
+    };
+    if location.extents.is_empty() {
+        return Err(Error::Malformed("missing item extents"));
+    }
+    let extent = |(offset, size)| {
+        if size == 0 {
+            return Err(Error::Unsupported("unbounded item extent"));
+        }
+        let offset = location
+            .base
+            .checked_add(offset)
+            .ok_or(Error::Malformed("extent offset overflow"))?;
+        Ok((range(origin, len, offset, size)?, size))
+    };
+    if is_exif && let [single] = location.extents.as_slice() {
+        let (start, len) = extent(*single)?;
+        return tiff::exif_block(reader, state, start, len);
+    }
+    let total = location.extents.iter().try_fold(0u64, |sum, (_, size)| {
+        sum.checked_add(*size)
+            .ok_or(Error::Malformed("extent length overflow"))
+    })?;
+    if total > state.limits.read_bytes as u64 {
+        return Err(Error::Limit("item bytes"));
+    }
+    let mut bytes = Vec::with_capacity(total as usize);
+    for &item in &location.extents {
+        let (absolute, size) = extent(item)?;
+        let previous = bytes.len();
+        bytes.resize(previous + size as usize, 0);
+        reader.fill(absolute, &mut bytes[previous..])?;
+    }
+    if is_exif {
+        let mut cursor = std::io::Cursor::new(&bytes);
+        let mut buffer = Reader::new(&mut cursor, state.limits)?;
+        tiff::exif_block(&mut buffer, state, 0, total)
+    } else {
+        xmp::read(&bytes, state)
+    }
+}
+
+fn item_info<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    b: &BoxRange,
+    meta: &mut Meta,
+) -> Result<(), Error> {
+    if b.len < 6 {
+        return Err(Error::Malformed("iinf header"));
+    }
+    let version = reader.array::<1>(b.start)?[0];
+    let width = if version == 0 { 2 } else { 4 };
+    let bytes = reader.bytes(b.start + 4, width)?;
+    let count = Cursor::new(&bytes).number(width)? as usize;
+    state.entries(count)?;
+    let mut offset = b.start + 4 + width as u64;
+    for _ in 0..count {
+        let child = box_at(reader, offset, b.end())?;
+        offset = child.end();
+        if &child.kind != b"infe" {
+            return Err(Error::Malformed("item info box"));
+        }
+        let bytes = payload(reader, &child)?;
+        let mut c = Cursor::new(&bytes);
+        let version = c.number(1)?;
+        c.take(3)?;
+        if !matches!(version, 2 | 3) {
+            return Err(Error::Unsupported("infe version"));
+        }
+        let id = c.number(if version == 2 { 2 } else { 4 })? as u32;
+        let protection = c.number(2)?;
+        let kind: [u8; 4] = c.take(4)?.try_into().unwrap();
+        c.string()?;
+        let mime = if &kind == b"mime" {
+            c.string()?.to_owned()
+        } else {
+            String::new()
+        };
+        if protection != 0 && (&kind == b"Exif" || mime == "application/rdf+xml") {
+            return Err(Error::Unsupported("protected metadata"));
+        }
+        let item = meta.items.entry(id).or_default();
+        if item.kind != [0; 4] {
+            return Err(Error::Malformed("duplicate item info"));
+        }
+        item.kind = kind;
+        item.mime = mime;
+    }
+    Ok(())
+}
+
+fn locations(bytes: &[u8], state: &mut State, meta: &mut Meta) -> Result<(), Error> {
+    let mut c = Cursor::new(bytes);
+    let version = c.number(1)?;
+    if version > 2 {
+        return Err(Error::Unsupported("iloc version"));
+    }
+    c.take(3)?;
+    let sizes = c.number(1)? as usize;
+    let more = c.number(1)? as usize;
+    let (offset_size, length_size, base_size, index_size) = (
+        sizes >> 4,
+        sizes & 15,
+        more >> 4,
+        if version == 0 { 0 } else { more & 15 },
+    );
+    let count = c.number(if version < 2 { 2 } else { 4 })? as usize;
+    state.entries(count)?;
+    for _ in 0..count {
+        let id = c.number(if version < 2 { 2 } else { 4 })? as u32;
+        let method = if version == 0 { 0 } else { c.number(2)? & 15 };
+        let reference = c.number(2)?;
+        let base = c.number(base_size)?;
+        let count = c.number(2)? as usize;
+        state.entries(count)?;
+        let mut extents = Vec::new();
+        for _ in 0..count {
+            c.number(index_size)?;
+            extents.push((c.number(offset_size)?, c.number(length_size)?));
+        }
+        let item = meta.items.entry(id).or_default();
+        if item.location.is_some() {
+            return Err(Error::Malformed("duplicate item location"));
+        }
+        item.location = Some(Location {
+            method,
+            reference,
+            base,
+            extents,
+        });
+    }
+    Ok(())
+}
+
+fn references<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    b: &BoxRange,
+    meta: &mut Meta,
+) -> Result<(), Error> {
+    if b.len < 4 {
+        return Err(Error::Malformed("iref header"));
+    }
+    let version = reader.array::<1>(b.start)?[0];
+    if version > 1 {
+        return Err(Error::Unsupported("iref version"));
+    }
+    let width = if version == 0 { 2 } else { 4 };
+    let mut offset = b.start + 4;
+    while offset < b.end() {
+        state.entries(1)?;
+        let child = box_at(reader, offset, b.end())?;
+        offset = child.end();
+        if &child.kind != b"cdsc" {
+            continue;
+        }
+        let bytes = payload(reader, &child)?;
+        let mut c = Cursor::new(&bytes);
+        let id = c.number(width)? as u32;
+        let count = c.number(2)? as usize;
+        state.entries(count)?;
+        let item = meta.items.entry(id).or_default();
+        for _ in 0..count {
+            item.describes.push(c.number(width)? as u32);
+        }
+    }
+    Ok(())
+}
+
+fn properties<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    b: &BoxRange,
+    meta: &mut Meta,
+) -> Result<(), Error> {
+    let mut offset = b.start;
+    while offset < b.end() {
+        state.entries(1)?;
+        let child = box_at(reader, offset, b.end())?;
+        offset = child.end();
+        match &child.kind {
+            b"ipco" => {
+                let mut offset = child.start;
+                while offset < child.end() {
+                    state.entries(1)?;
+                    let property = box_at(reader, offset, child.end())?;
+                    offset = property.end();
+                    meta.properties.push(property);
+                }
+            }
+            b"ipma" => {
+                let bytes = payload(reader, &child)?;
+                let mut c = Cursor::new(&bytes);
+                let version = c.number(1)?;
+                if version > 1 {
+                    return Err(Error::Unsupported("ipma version"));
+                }
+                let flags = c.number(3)?;
+                let count = c.number(4)? as usize;
+                state.entries(count)?;
+                for _ in 0..count {
+                    let id = c.number(if version == 0 { 2 } else { 4 })? as u32;
+                    let count = c.number(1)? as usize;
+                    state.entries(count)?;
+                    let mut properties = Vec::new();
+                    for _ in 0..count {
+                        let width = if flags & 1 == 0 { 1 } else { 2 };
+                        let value = c.number(width)? as usize;
+                        let mask = 1 << (width * 8 - 1);
+                        properties.push((value & (mask - 1), value & mask != 0));
+                    }
+                    meta.associations.push((id, properties));
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn payload<R: Read + Seek>(reader: &mut Reader<'_, R>, b: &BoxRange) -> Result<Vec<u8>, Error> {
+    reader.bytes(
+        b.start,
+        usize::try_from(b.len).map_err(|_| Error::Limit("box payload"))?,
+    )
+}

--- a/rust/crates/exif/src/isobmff.rs
+++ b/rust/crates/exif/src/isobmff.rs
@@ -157,17 +157,26 @@ fn metadata<R: Read + Seek>(
         }
     }
     for is_exif in [true, false] {
-        let mut candidates = meta.items.values().filter(|item| {
-            (item.describes.is_empty() || item.describes.contains(&primary))
-                && if is_exif {
-                    &item.kind == b"Exif"
-                } else {
-                    &item.kind == b"mime"
-                        && matches!(
-                            item.mime.as_str(),
-                            "application/rdf+xml" | "application/xml" | "text/xml"
-                        )
-                }
+        let candidates = meta.items.values().filter(|item| {
+            if is_exif {
+                &item.kind == b"Exif"
+            } else {
+                &item.kind == b"mime"
+                    && matches!(
+                        item.mime.as_str(),
+                        "application/rdf+xml" | "application/xml" | "text/xml"
+                    )
+            }
+        });
+        let has_primary = candidates
+            .clone()
+            .any(|item| item.describes.contains(&primary));
+        let mut candidates = candidates.filter(|item| {
+            if has_primary {
+                item.describes.contains(&primary)
+            } else {
+                item.describes.is_empty()
+            }
         });
         let Some(item) = candidates.next() else {
             continue;

--- a/rust/crates/exif/src/jpeg.rs
+++ b/rust/crates/exif/src/jpeg.rs
@@ -1,0 +1,117 @@
+use crate::read::{Error, Reader, State, be16, be32, range};
+use crate::{Dimensions, photoshop, tiff, xmp};
+use std::io::{Read, Seek};
+
+const XMP: &[u8] = b"http://ns.adobe.com/xap/1.0/\0";
+const EXTENDED: &[u8] = b"http://ns.adobe.com/xmp/extension/\0";
+
+pub(crate) fn read<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+) -> Result<(), Error> {
+    let mut offset = 2;
+    let mut fragments = Vec::new();
+    while offset < reader.len {
+        state.entries(1)?;
+        if reader.array::<1>(offset)?[0] != 0xff {
+            return Err(Error::Malformed("JPEG marker"));
+        }
+        offset += 1;
+        let mut marker = reader.array::<1>(offset)?[0];
+        while marker == 0xff {
+            offset += 1;
+            marker = reader.array::<1>(offset)?[0];
+        }
+        offset += 1;
+        if matches!(marker, 0xda | 0xd9) {
+            break;
+        }
+        if matches!(marker, 0x01 | 0xd0..=0xd8) {
+            continue;
+        }
+        let size = u64::from(be16(&reader.array::<2>(offset)?));
+        if size < 2 {
+            return Err(Error::Malformed("JPEG segment length"));
+        }
+        range(0, reader.len, offset, size)?;
+        let start = offset + 2;
+        let len = size - 2;
+        match marker {
+            0xe1 => {
+                let header = reader.bytes(start, len.min(35) as usize)?;
+                let result = if header.starts_with(b"Exif\0\0") {
+                    tiff::read(reader, state, start + 6, len - 6)
+                } else if header.starts_with(XMP) {
+                    let bytes = reader.bytes(start + XMP.len() as u64, len as usize - XMP.len())?;
+                    xmp::read(&bytes, state)
+                } else if header.starts_with(EXTENDED) {
+                    let bytes = reader
+                        .bytes(start + EXTENDED.len() as u64, len as usize - EXTENDED.len())?;
+                    if bytes.len() < 40 {
+                        Err(Error::Malformed("extended XMP header"))
+                    } else {
+                        fragments.push(bytes);
+                        Ok(())
+                    }
+                } else {
+                    Ok(())
+                };
+                state.recover(start, result)?;
+            }
+            0xed => {
+                let data = reader.bytes(start, len as usize)?;
+                let result = photoshop::read(&data, state);
+                state.recover(start, result)?;
+            }
+            0xc0..=0xc3 | 0xc5..=0xc7 | 0xc9..=0xcb | 0xcd..=0xcf => {
+                if len < 6 {
+                    return Err(Error::Malformed("JPEG frame"));
+                }
+                let frame = reader.array::<5>(start)?;
+                if state.metadata.dimensions.is_none() {
+                    state.metadata.dimensions =
+                        Dimensions::new(u32::from(be16(&frame[3..])), u32::from(be16(&frame[1..])));
+                }
+            }
+            _ => {}
+        }
+        offset += size;
+    }
+    if !fragments.is_empty() {
+        let result = extended_xmp(fragments, state);
+        state.recover(offset, result)?;
+    }
+    Ok(())
+}
+
+fn extended_xmp(mut fragments: Vec<Vec<u8>>, state: &mut State) -> Result<(), Error> {
+    let Some(id) = state
+        .metadata
+        .property(xmp::namespace::NOTE, "HasExtendedXMP")
+    else {
+        return Err(Error::Malformed("unreferenced extended XMP"));
+    };
+    fragments.retain(|f| f.get(..32) == Some(id.as_bytes()));
+    if fragments.is_empty() {
+        return Err(Error::Malformed("missing extended XMP"));
+    }
+    fragments.sort_by_key(|f| be32(&f[36..]));
+    let total = be32(&fragments[0][32..]) as usize;
+    if total > state.limits.read_bytes {
+        return Err(Error::Limit("extended XMP"));
+    }
+    let mut joined = Vec::new();
+    for fragment in fragments {
+        if be32(&fragment[32..]) as usize != total
+            || be32(&fragment[36..]) as usize != joined.len()
+            || fragment.len() - 40 > total - joined.len()
+        {
+            return Err(Error::Malformed("extended XMP extents"));
+        }
+        joined.extend_from_slice(&fragment[40..]);
+    }
+    if joined.len() != total {
+        return Err(Error::Malformed("incomplete extended XMP"));
+    }
+    xmp::read(&joined, state)
+}

--- a/rust/crates/exif/src/jxl.rs
+++ b/rust/crates/exif/src/jxl.rs
@@ -1,0 +1,216 @@
+use crate::boxes::box_at;
+use crate::read::{Error, Reader, State, be32, range};
+use crate::{Dimensions, Transform, tiff, xmp};
+use brotli_decompressor::{BrotliDecompressStream, BrotliResult, BrotliState, StandardAlloc};
+use std::io::{Read, Seek};
+
+pub(crate) const SIGNATURE: &[u8] = b"\0\0\0\x0cJXL \r\n\x87\n";
+
+pub(crate) fn read<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    bare: bool,
+) -> Result<(), Error> {
+    let mut prefix = [0; 12];
+    if bare {
+        let count = reader.len.min(prefix.len() as u64) as usize;
+        reader.fill(0, &mut prefix[..count])?;
+        return codestream(&prefix[..count], state);
+    }
+    if reader.array::<20>(12)? != *b"\0\0\0\x14ftypjxl \0\0\0\0jxl " {
+        return Err(Error::Malformed("JPEG XL file type"));
+    }
+    let mut offset = 32;
+    let mut count = 0;
+    let mut next_part = 0;
+    let mut complete = false;
+    while offset < reader.len {
+        state.entries(1)?;
+        let b = box_at(reader, offset, reader.len)?;
+        let start = b.start;
+        let len = b.len;
+        let kind = &b.kind;
+        let result = match kind {
+            b"jxlc" | b"jxlp" => {
+                if complete || (kind == b"jxlc" && next_part != 0) {
+                    return Err(Error::Malformed("JPEG XL codestream sequence"));
+                }
+                let skip = if kind == b"jxlp" {
+                    let index = be32(&reader.array::<4>(range(start, len, 0, 4)?)?);
+                    if index & 0x7fff_ffff != next_part {
+                        return Err(Error::Malformed("JPEG XL part index"));
+                    }
+                    next_part += 1;
+                    complete = index & 0x8000_0000 != 0;
+                    4
+                } else {
+                    complete = true;
+                    0
+                };
+                let take = (len - skip).min((prefix.len() - count) as u64) as usize;
+                if take != 0 {
+                    reader.fill(start + skip, &mut prefix[count..count + take])?;
+                    count += take;
+                }
+                Ok(())
+            }
+            b"Exif" => tiff::exif_block(reader, state, start, len),
+            b"xml " => xmp::read(&reader.bytes(start, length(len)?)?, state),
+            b"brob" => compressed(reader, state, start, len),
+            b"JXL " | b"ftyp" => Err(Error::Malformed("duplicate JPEG XL header")),
+            _ => Ok(()),
+        };
+        state.recover(offset, result)?;
+        offset = b.end();
+    }
+    if !complete {
+        return Err(Error::Malformed("incomplete JPEG XL codestream"));
+    }
+    codestream(&prefix[..count], state)
+}
+
+fn codestream(bytes: &[u8], state: &mut State) -> Result<(), Error> {
+    let mut bits = Bits { bytes, position: 0 };
+    if bits.take(16)? != 0x0aff {
+        return Err(Error::Malformed("JPEG XL signature"));
+    }
+    // https://www.iso.org/standard/85066.html — Annex D.2–D.3.
+    let div8 = bits.take(1)? != 0;
+    let height = bits.dimension(div8)?;
+    let ratio = bits.take(3)?;
+    let width = if ratio == 0 {
+        bits.dimension(div8)?
+    } else {
+        let (numerator, denominator) =
+            [(1, 1), (6, 5), (4, 3), (3, 2), (16, 9), (5, 4), (2, 1)][(ratio - 1) as usize];
+        (u64::from(height) * numerator / denominator) as u32
+    };
+    let all_default = bits.take(1)? != 0;
+    let orientation = if !all_default && bits.take(1)? != 0 {
+        bits.take(3)? as u8 + 1
+    } else {
+        1
+    };
+    state.retain(std::mem::size_of::<Transform>())?;
+    state.metadata.dimensions = Dimensions::new(width, height);
+    state
+        .metadata
+        .transforms
+        .push(Transform::Orientation(orientation));
+    Ok(())
+}
+
+fn compressed<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    start: u64,
+    len: u64,
+) -> Result<(), Error> {
+    let kind = reader.array::<4>(range(start, len, 0, 4)?)?;
+    if &kind == b"brob" || kind.starts_with(b"jxl") {
+        return Err(Error::Malformed("JPEG XL compressed box type"));
+    }
+    if !matches!(&kind, b"Exif" | b"xml ") {
+        return Ok(());
+    }
+    let input = reader.bytes(start + 4, length(len - 4)?)?;
+    let bytes = decompress(&input, state)?;
+    if &kind == b"Exif" {
+        let mut source = std::io::Cursor::new(&bytes);
+        let mut buffer = Reader::new(&mut source, state.limits)?;
+        tiff::exif_block(&mut buffer, state, 0, bytes.len() as u64)
+    } else {
+        xmp::read(&bytes, state)
+    }
+}
+
+fn decompress(input: &[u8], state: &mut State) -> Result<Vec<u8>, Error> {
+    // https://www.rfc-editor.org/rfc/rfc7932.html#section-9.1
+    let first = *input.first().ok_or(Error::Malformed("Brotli header"))?;
+    let window_bits = if first & 1 == 0 {
+        16
+    } else if first & 0x0f != 1 {
+        17 + ((first >> 1) & 7)
+    } else {
+        match (first >> 4) & 7 {
+            0 => 17,
+            1 => return Err(Error::Malformed("Brotli window")),
+            value => 8 + value,
+        }
+    };
+    if (1u64 << window_bits) > state.limits.read_bytes as u64 {
+        return Err(Error::Limit("Brotli window"));
+    }
+    let limit = state.expansion_limit();
+    let mut output = vec![0; limit.min(4096)];
+    let mut decoder = BrotliState::new_strict(
+        StandardAlloc::default(),
+        StandardAlloc::default(),
+        StandardAlloc::default(),
+    );
+    let mut available_in = input.len();
+    let mut input_offset = 0;
+    let mut output_offset = 0;
+    let mut total = 0;
+    loop {
+        let before = output_offset;
+        let mut available_out = output.len() - output_offset;
+        let result = BrotliDecompressStream(
+            &mut available_in,
+            &mut input_offset,
+            input,
+            &mut available_out,
+            &mut output_offset,
+            &mut output,
+            &mut total,
+            &mut decoder,
+        );
+        state.expanded(output_offset - before)?;
+        match result {
+            BrotliResult::ResultSuccess if input_offset == input.len() => {
+                output.truncate(output_offset);
+                return Ok(output);
+            }
+            BrotliResult::NeedsMoreOutput => {
+                if output.len() == limit {
+                    return Err(Error::Limit("Brotli output"));
+                }
+                output.resize(output.len().saturating_mul(2).min(limit), 0);
+            }
+            _ => return Err(Error::Malformed("Brotli stream")),
+        }
+    }
+}
+
+fn length(value: u64) -> Result<usize, Error> {
+    usize::try_from(value).map_err(|_| Error::Limit("JPEG XL box bytes"))
+}
+
+struct Bits<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl Bits<'_> {
+    fn take(&mut self, count: usize) -> Result<u32, Error> {
+        let mut value = 0;
+        for shift in 0..count {
+            let byte = self
+                .bytes
+                .get(self.position / 8)
+                .ok_or(Error::Malformed("JPEG XL header"))?;
+            value |= u32::from((byte >> (self.position % 8)) & 1) << shift;
+            self.position += 1;
+        }
+        Ok(value)
+    }
+
+    fn dimension(&mut self, div8: bool) -> Result<u32, Error> {
+        if div8 {
+            Ok(8 * (1 + self.take(5)?))
+        } else {
+            let count = [9, 13, 18, 30][self.take(2)? as usize];
+            Ok(1 + self.take(count)?)
+        }
+    }
+}

--- a/rust/crates/exif/src/jxl.rs
+++ b/rust/crates/exif/src/jxl.rs
@@ -74,7 +74,6 @@ fn codestream(bytes: &[u8], state: &mut State) -> Result<(), Error> {
     if bits.take(16)? != 0x0aff {
         return Err(Error::Malformed("JPEG XL signature"));
     }
-    // https://www.iso.org/standard/85066.html — Annex D.2–D.3.
     let div8 = bits.take(1)? != 0;
     let height = bits.dimension(div8)?;
     let ratio = bits.take(3)?;
@@ -125,7 +124,6 @@ fn compressed<R: Read + Seek>(
 }
 
 fn decompress(input: &[u8], state: &mut State) -> Result<Vec<u8>, Error> {
-    // https://www.rfc-editor.org/rfc/rfc7932.html#section-9.1
     let first = *input.first().ok_or(Error::Malformed("Brotli header"))?;
     let window_bits = if first & 1 == 0 {
         16

--- a/rust/crates/exif/src/lib.rs
+++ b/rust/crates/exif/src/lib.rs
@@ -1,0 +1,155 @@
+//! Photo metadata without reading or decoding image pixels.
+#![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
+
+mod boxes;
+mod datetime;
+mod dimensions;
+mod gif;
+mod iptc;
+mod isobmff;
+mod jpeg;
+mod jxl;
+mod metadata;
+mod motion;
+pub mod photo;
+mod photoshop;
+mod png;
+mod read;
+mod tags;
+mod text;
+mod tiff;
+mod webp;
+mod xmp;
+
+pub use datetime::{DateTime, DateTimeKind, DateTimePrecision, DateTimeSource, DateTimeValue};
+pub use dimensions::{CleanAperture, Dimensions, Transform};
+pub use iptc::Iptc;
+pub use metadata::{Location, Metadata, StructuredMetadata};
+pub use motion::VideoRange;
+pub use photo::CaptureDateTime;
+pub use read::{Error, Issue, Limits, Statistics};
+pub use tags::{Ifd, Rational, Tag, Value};
+pub use text::TextEncoding;
+pub use xmp::{Property, XmpNode, XmpStructure, namespace};
+
+use std::io::{Read, Seek};
+
+/// Reads from byte zero, leaving the source positioned at the last accessed range.
+/// Metadata errors in a bounded block are reported in `issues`; I/O and resource
+/// limits stop the operation. No-metadata images return an empty successful result.
+pub fn read<R: Read + Seek>(source: &mut R, mode: Mode, limits: Limits) -> Result<Metadata, Error> {
+    read_with_structure(source, mode, limits, None)
+}
+
+/// Details plus XMP ancestor/list relationships, for consumers of structured annotations.
+///
+/// ```rust,no_run
+/// # use ente_exif::Limits;
+/// # let mut file = std::fs::File::open("photo.xmp")?;
+/// let structured = ente_exif::read_structured(&mut file, Limits::default())?;
+/// // Includes Details metadata; parents[i] belongs to metadata.xmp[i].
+/// for (property, parent) in structured.metadata.xmp.iter().zip(&structured.xmp.parents) {
+///     println!("{}: {} (parent {parent:?})", property.name, property.value);
+/// }
+/// // Follow XmpNode::parent through structured.xmp.nodes to find region/list owners.
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn read_structured<R: Read + Seek>(
+    source: &mut R,
+    limits: Limits,
+) -> Result<StructuredMetadata, Error> {
+    let mut xmp = XmpStructure::default();
+    let metadata = read_with_structure(source, Mode::Details, limits, Some(&mut xmp))?;
+    Ok(StructuredMetadata { metadata, xmp })
+}
+
+fn read_with_structure<R: Read + Seek>(
+    source: &mut R,
+    mode: Mode,
+    limits: Limits,
+    structure: Option<&mut XmpStructure>,
+) -> Result<Metadata, Error> {
+    let mut reader = read::Reader::new(source, limits)?;
+    let mut state = read::State::new(mode, limits);
+    state.structure = structure;
+    let header = reader.bytes(0, reader.len.min(16) as usize)?;
+    state.metadata.format = if header.starts_with(b"\xff\xd8") {
+        jpeg::read(&mut reader, &mut state)?;
+        Format::Jpeg
+    } else if header.starts_with(b"II") || header.starts_with(b"MM") {
+        let len = reader.len;
+        tiff::read(&mut reader, &mut state, 0, len)?;
+        Format::Tiff
+    } else if header.starts_with(b"\x89PNG\r\n\x1a\n") {
+        png::read(&mut reader, &mut state)?;
+        Format::Png
+    } else if header.starts_with(b"RIFF") && header.get(8..12) == Some(b"WEBP") {
+        webp::read(&mut reader, &mut state)?;
+        Format::Webp
+    } else if header.starts_with(b"GIF87a") || header.starts_with(b"GIF89a") {
+        gif::read(&mut reader, &mut state)?;
+        Format::Gif
+    } else if header.starts_with(b"\xff\x0a") || header.starts_with(jxl::SIGNATURE) {
+        jxl::read(&mut reader, &mut state, header.starts_with(b"\xff\x0a"))?;
+        Format::Jxl
+    } else if header.get(4..8) == Some(b"ftyp") {
+        isobmff::read(&mut reader, &mut state)?;
+        Format::Heif
+    } else {
+        let utf16 = header.starts_with(b"\xff\xfe") || header.starts_with(b"\xfe\xff");
+        let prefix = header.strip_prefix(b"\xef\xbb\xbf").unwrap_or(&header);
+        if !utf16
+            && prefix
+                .iter()
+                .find(|b| !b.is_ascii_whitespace())
+                .is_some_and(|b| *b != b'<')
+        {
+            return Err(Error::Unsupported("format"));
+        }
+        let bytes = reader.bytes(
+            0,
+            usize::try_from(reader.len).map_err(|_| Error::Limit("input"))?,
+        )?;
+        if !utf16
+            && !std::str::from_utf8(&bytes)
+                .map_err(|_| Error::Unsupported("format"))?
+                .trim_start_matches('\u{feff}')
+                .trim_start()
+                .starts_with('<')
+        {
+            return Err(Error::Unsupported("format"));
+        }
+        xmp::read(&bytes, &mut state)?;
+        Format::Xmp
+    };
+    if state.metadata.dimensions.is_none() {
+        state.metadata.dimensions = state.metadata.tiff_dimensions();
+    }
+    motion::read(&mut reader, &mut state)?;
+    state.metadata.statistics = reader.statistics;
+    Ok(state.metadata)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Common capture, camera, location, description, panorama and motion fields.
+    Summary,
+    /// Named standard TIFF tags, secondary IFDs, general XMP/IPTC and PNG text.
+    /// Unknown TIFF tags, MakerNotes and pixel/thumbnail references are omitted
+    /// with their byte counts. Opaque XMP HDRPlusMakernote is skipped in both modes.
+    Details,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    #[default]
+    Jpeg,
+    Tiff,
+    Heif,
+    Png,
+    Webp,
+    Gif,
+    Jxl,
+    Xmp,
+}

--- a/rust/crates/exif/src/lib.rs
+++ b/rust/crates/exif/src/lib.rs
@@ -1,4 +1,3 @@
-//! Photo metadata without reading or decoding image pixels.
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 
@@ -34,27 +33,9 @@ pub use text::TextEncoding;
 pub use xmp::{Property, XmpNode, XmpStructure, namespace};
 
 use std::io::{Read, Seek};
-
-/// Reads from byte zero, leaving the source positioned at the last accessed range.
-/// Metadata errors in a bounded block are reported in `issues`; I/O and resource
-/// limits stop the operation. No-metadata images return an empty successful result.
 pub fn read<R: Read + Seek>(source: &mut R, mode: Mode, limits: Limits) -> Result<Metadata, Error> {
     read_with_structure(source, mode, limits, None)
 }
-
-/// Details plus XMP ancestor/list relationships, for consumers of structured annotations.
-///
-/// ```rust,no_run
-/// # use ente_exif::Limits;
-/// # let mut file = std::fs::File::open("photo.xmp")?;
-/// let structured = ente_exif::read_structured(&mut file, Limits::default())?;
-/// // Includes Details metadata; parents[i] belongs to metadata.xmp[i].
-/// for (property, parent) in structured.metadata.xmp.iter().zip(&structured.xmp.parents) {
-///     println!("{}: {} (parent {parent:?})", property.name, property.value);
-/// }
-/// // Follow XmpNode::parent through structured.xmp.nodes to find region/list owners.
-/// # Ok::<(), Box<dyn std::error::Error>>(())
-/// ```
 pub fn read_structured<R: Read + Seek>(
     source: &mut R,
     limits: Limits,
@@ -133,11 +114,7 @@ fn read_with_structure<R: Read + Seek>(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
-    /// Common capture, camera, location, description, panorama and motion fields.
     Summary,
-    /// Named standard TIFF tags, secondary IFDs, general XMP/IPTC and PNG text.
-    /// Unknown TIFF tags, MakerNotes and pixel/thumbnail references are omitted
-    /// with their byte counts. Opaque XMP HDRPlusMakernote is skipped in both modes.
     Details,
 }
 

--- a/rust/crates/exif/src/metadata.rs
+++ b/rust/crates/exif/src/metadata.rs
@@ -1,0 +1,320 @@
+use crate::{
+    CaptureDateTime, Dimensions, Format, Ifd, Iptc, Issue, Property, Rational, Statistics, Tag,
+    Transform, Value, VideoRange, XmpStructure, namespace, photo,
+};
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Metadata {
+    pub format: Format,
+    /// Stored primary-image dimensions, before applying any transforms.
+    pub dimensions: Option<Dimensions>,
+    /// Primary-image transforms in application order, independent of EXIF/XMP.
+    pub transforms: Vec<Transform>,
+    pub tags: Vec<Tag>,
+    pub xmp: Vec<Property>,
+    pub iptc: Vec<Iptc>,
+    pub motion_video: Option<VideoRange>,
+    pub issues: Vec<Issue>,
+    pub statistics: Statistics,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StructuredMetadata {
+    pub metadata: Metadata,
+    pub xmp: XmpStructure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Location {
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+impl Metadata {
+    /// Default capture-date selection. See [`photo::capture_date_time`].
+    pub fn capture_date_time(&self) -> Option<CaptureDateTime> {
+        photo::capture_date_time(self)
+    }
+
+    /// Default date selection with caller resolution/rejection. See [`photo::capture_date_time_with`].
+    pub fn capture_date_time_with(
+        &self,
+        accept: impl FnMut(&mut CaptureDateTime) -> bool,
+    ) -> Option<CaptureDateTime> {
+        photo::capture_date_time_with(self, accept)
+    }
+
+    /// Default display-size selection. See [`photo::display_dimensions`].
+    pub fn display_dimensions(&self) -> Option<Dimensions> {
+        photo::display_dimensions(self)
+    }
+
+    /// First matching tag. The raw collection preserves duplicates.
+    pub fn tag(&self, ifd: Ifd, id: u16) -> Option<&Tag> {
+        self.tags.iter().find(|tag| tag.ifd == ifd && tag.id == id)
+    }
+
+    /// First matching namespace URI/local name. Raw properties preserve duplicates.
+    pub fn property(&self, namespace: &str, name: &str) -> Option<&str> {
+        self.xmp
+            .iter()
+            .find(|p| p.namespace == namespace && p.name == name)
+            .map(|p| p.value.as_str())
+    }
+
+    pub fn properties<'a>(
+        &'a self,
+        namespace: &'a str,
+        name: &'a str,
+    ) -> impl Iterator<Item = &'a Property> {
+        self.xmp
+            .iter()
+            .filter(move |p| p.namespace == namespace && p.name == name)
+    }
+
+    /// Raw EXIF orientation. Native container/codestream transforms are separate.
+    pub fn orientation(&self) -> Option<u32> {
+        self.tag(Ifd::Image(0), 0x112)?.value.unsigned()
+    }
+
+    /// GPano cylindrical/equirectangular projection or EXIF CustomRendered = 6.
+    /// Does not infer panoramas from aspect ratio.
+    pub fn is_panorama(&self) -> bool {
+        matches!(
+            self.property(namespace::GPANO, "ProjectionType"),
+            Some("cylindrical" | "equirectangular")
+        ) || self
+            .tag(Ifd::Exif(0), 0xa401)
+            .and_then(|t| t.value.unsigned())
+            == Some(6)
+    }
+
+    /// Stored primary-image width, before orientation or cropping.
+    pub fn width(&self) -> Option<u32> {
+        self.dimensions.map(|d| d.width)
+    }
+
+    /// Stored primary-image height, before orientation or cropping.
+    pub fn height(&self) -> Option<u32> {
+        self.dimensions.map(|d| d.height)
+    }
+
+    /// Dimensions from one XMP namespace/pair, without orientation or source fallback.
+    pub fn xmp_dimensions(&self) -> Option<Dimensions> {
+        [
+            (namespace::TIFF, "ImageWidth", "ImageLength"),
+            (namespace::EXIF, "PixelXDimension", "PixelYDimension"),
+        ]
+        .into_iter()
+        .find_map(|(ns, width, height)| {
+            Dimensions::new(
+                self.property(ns, width)?.trim().parse().ok()?,
+                self.property(ns, height)?.trim().parse().ok()?,
+            )
+        })
+    }
+
+    /// EXIF camera make; trimmed and borrowed. Empty values are absent.
+    pub fn camera_make(&self) -> Option<&str> {
+        self.text(Ifd::Image(0), 0x10f)
+    }
+
+    /// EXIF camera model; trimmed and borrowed.
+    pub fn camera_model(&self) -> Option<&str> {
+        self.text(Ifd::Image(0), 0x110)
+    }
+
+    /// EXIF lens model; trimmed and borrowed.
+    pub fn lens_model(&self) -> Option<&str> {
+        self.text(Ifd::Exif(0), 0xa434)
+    }
+
+    /// Exact positive EXIF exposure time in seconds, without display rounding.
+    pub fn exposure_time(&self) -> Option<Rational> {
+        let Value::Rational(values) = &self.tag(Ifd::Exif(0), 0x829a)?.value else {
+            return None;
+        };
+        let [value] = values.as_slice() else {
+            return None;
+        };
+        (value.as_f64()? > 0.0).then_some(*value)
+    }
+
+    /// Positive EXIF f-number (for example, 2.8).
+    pub fn f_number(&self) -> Option<f64> {
+        self.positive_number(0x829d)
+    }
+
+    /// Positive EXIF focal length in millimetres.
+    pub fn focal_length(&self) -> Option<f64> {
+        self.positive_number(0x920a)
+    }
+
+    /// Legacy EXIF sensitivity values (0x8827), including any 65535 sentinel.
+    /// Does not infer ISO speed from the newer sensitivity-type/extended tags.
+    pub fn iso_speed_ratings(&self) -> Option<&[u32]> {
+        match &self.tag(Ifd::Exif(0), 0x8827)?.value {
+            Value::Unsigned(values) => Some(values),
+            _ => None,
+        }
+    }
+
+    /// EXIF ImageDescription only; no XMP/IPTC precedence or character-set guess.
+    pub fn exif_description(&self) -> Option<&str> {
+        self.text(Ifd::Image(0), 0x10e)
+    }
+
+    /// EXIF coordinates only. Preserves (0, 0); source precedence belongs to the caller.
+    /// Signed D/M/S components supply the sign only when both references are absent.
+    /// Rejects incomplete/out-of-range coordinates, malformed references, non-finite
+    /// values and minute/second magnitudes of 60 or more.
+    pub fn exif_location(&self) -> Option<Location> {
+        let latitude_ref = self.tag(Ifd::Gps(0), 1);
+        let longitude_ref = self.tag(Ifd::Gps(0), 3);
+        if latitude_ref.is_some() != longitude_ref.is_some() {
+            return None;
+        }
+        let coordinate = |id, reference: Option<&Tag>, positive, negative| {
+            let tag = self.tag(Ifd::Gps(0), id)?;
+            if tag.count != 3 {
+                return None;
+            }
+            let parts = [
+                tag.value.number(0)?,
+                tag.value.number(1)?,
+                tag.value.number(2)?,
+            ];
+            if parts[1].abs() >= 60.0 || parts[2].abs() >= 60.0 {
+                return None;
+            }
+            let sign = match reference {
+                Some(r) => hemisphere(r.value.text()?, positive, negative)?,
+                None => {
+                    if parts.iter().any(|v| *v < 0.0) {
+                        -1.0
+                    } else {
+                        1.0
+                    }
+                }
+            };
+            Some(sign * (parts[0].abs() + parts[1].abs() / 60.0 + parts[2].abs() / 3600.0))
+        };
+        location(
+            coordinate(2, latitude_ref, b'N', b'S')?,
+            coordinate(4, longitude_ref, b'E', b'W')?,
+        )
+    }
+
+    /// XMP decimal or comma-separated degree/minute/second coordinates.
+    /// A suffix or separate hemisphere reference is required for each axis.
+    ///
+    /// ```rust,no_run
+    /// # use ente_exif::{Limits, Mode, namespace};
+    /// # let mut file = std::fs::File::open("photo.jpg")?;
+    /// let metadata = ente_exif::read(&mut file, Mode::Details, Limits::default())?;
+    /// let exif_location = metadata.exif_location();
+    /// let xmp_location = metadata.xmp_location();
+    /// let description = metadata.xmp_description(Some("en"));
+    /// for keyword in metadata.properties(namespace::DC, "subject") {
+    ///     println!("{}", keyword.value);
+    /// }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn xmp_location(&self) -> Option<Location> {
+        location(
+            xmp_coordinate(
+                self.property(namespace::EXIF, "GPSLatitude")?,
+                self.property(namespace::EXIF, "GPSLatitudeRef"),
+                b'N',
+                b'S',
+            )?,
+            xmp_coordinate(
+                self.property(namespace::EXIF, "GPSLongitude")?,
+                self.property(namespace::EXIF, "GPSLongitudeRef"),
+                b'E',
+                b'W',
+            )?,
+        )
+    }
+
+    /// Preferred language, then x-default, then the first XMP description.
+    /// IPTC encoding and cross-source caption precedence remain explicit in the caller.
+    pub fn xmp_description(&self, language: Option<&str>) -> Option<&str> {
+        let descriptions = || self.properties(namespace::DC, "description");
+        language
+            .and_then(|language| {
+                descriptions().find(|p| {
+                    p.language
+                        .as_deref()
+                        .is_some_and(|l| l.eq_ignore_ascii_case(language))
+                })
+            })
+            .or_else(|| descriptions().find(|p| p.language.as_deref() == Some("x-default")))
+            .or_else(|| descriptions().next())
+            .map(|p| p.value.as_str())
+    }
+
+    pub(crate) fn tiff_dimensions(&self) -> Option<Dimensions> {
+        let pair = |ifd, width, height| {
+            Dimensions::new(
+                self.tag(ifd, width)?.value.unsigned()?,
+                self.tag(ifd, height)?.value.unsigned()?,
+            )
+        };
+        pair(Ifd::Image(0), 0x100, 0x101).or_else(|| pair(Ifd::Exif(0), 0xa002, 0xa003))
+    }
+
+    pub(crate) fn text(&self, ifd: Ifd, id: u16) -> Option<&str> {
+        let value = self.tag(ifd, id)?.value.text()?.trim();
+        (!value.is_empty()).then_some(value)
+    }
+
+    fn positive_number(&self, id: u16) -> Option<f64> {
+        let tag = self.tag(Ifd::Exif(0), id)?;
+        let value = tag.value.number(0)?;
+        (tag.count == 1 && value > 0.0).then_some(value)
+    }
+}
+
+fn location(latitude: f64, longitude: f64) -> Option<Location> {
+    ((-90.0..=90.0).contains(&latitude) && (-180.0..=180.0).contains(&longitude)).then_some(
+        Location {
+            latitude,
+            longitude,
+        },
+    )
+}
+
+fn hemisphere(value: &str, positive: u8, negative: u8) -> Option<f64> {
+    match value.trim().as_bytes() {
+        [v] if v.to_ascii_uppercase() == positive => Some(1.0),
+        [v] if v.to_ascii_uppercase() == negative => Some(-1.0),
+        _ => None,
+    }
+}
+
+fn xmp_coordinate(value: &str, reference: Option<&str>, positive: u8, negative: u8) -> Option<f64> {
+    let value = value.trim();
+    let (value, sign) = if value.as_bytes().last().is_some_and(u8::is_ascii_alphabetic) {
+        let (value, suffix) = value.split_at(value.len() - 1);
+        (value, hemisphere(suffix, positive, negative)?)
+    } else {
+        (value, hemisphere(reference?, positive, negative)?)
+    };
+    let mut parts = value.split(',');
+    let degrees = parts.next()?.trim().parse::<f64>().ok()?;
+    let mut coordinate = degrees;
+    for divisor in [60.0, 3600.0] {
+        if let Some(part) = parts.next() {
+            let part = part.trim().parse::<f64>().ok()?;
+            if !(0.0..60.0).contains(&part) {
+                return None;
+            }
+            coordinate += part / divisor;
+        }
+    }
+    if degrees < 0.0 || parts.next().is_some() {
+        return None;
+    }
+    Some(sign * coordinate)
+}

--- a/rust/crates/exif/src/metadata.rs
+++ b/rust/crates/exif/src/metadata.rs
@@ -6,9 +6,7 @@ use crate::{
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Metadata {
     pub format: Format,
-    /// Stored primary-image dimensions, before applying any transforms.
     pub dimensions: Option<Dimensions>,
-    /// Primary-image transforms in application order, independent of EXIF/XMP.
     pub transforms: Vec<Transform>,
     pub tags: Vec<Tag>,
     pub xmp: Vec<Property>,
@@ -31,30 +29,21 @@ pub struct Location {
 }
 
 impl Metadata {
-    /// Default capture-date selection. See [`photo::capture_date_time`].
     pub fn capture_date_time(&self) -> Option<CaptureDateTime> {
         photo::capture_date_time(self)
     }
-
-    /// Default date selection with caller resolution/rejection. See [`photo::capture_date_time_with`].
     pub fn capture_date_time_with(
         &self,
         accept: impl FnMut(&mut CaptureDateTime) -> bool,
     ) -> Option<CaptureDateTime> {
         photo::capture_date_time_with(self, accept)
     }
-
-    /// Default display-size selection. See [`photo::display_dimensions`].
     pub fn display_dimensions(&self) -> Option<Dimensions> {
         photo::display_dimensions(self)
     }
-
-    /// First matching tag. The raw collection preserves duplicates.
     pub fn tag(&self, ifd: Ifd, id: u16) -> Option<&Tag> {
         self.tags.iter().find(|tag| tag.ifd == ifd && tag.id == id)
     }
-
-    /// First matching namespace URI/local name. Raw properties preserve duplicates.
     pub fn property(&self, namespace: &str, name: &str) -> Option<&str> {
         self.xmp
             .iter()
@@ -71,14 +60,9 @@ impl Metadata {
             .iter()
             .filter(move |p| p.namespace == namespace && p.name == name)
     }
-
-    /// Raw EXIF orientation. Native container/codestream transforms are separate.
     pub fn orientation(&self) -> Option<u32> {
         self.tag(Ifd::Image(0), 0x112)?.value.unsigned()
     }
-
-    /// GPano cylindrical/equirectangular projection or EXIF CustomRendered = 6.
-    /// Does not infer panoramas from aspect ratio.
     pub fn is_panorama(&self) -> bool {
         matches!(
             self.property(namespace::GPANO, "ProjectionType"),
@@ -88,18 +72,12 @@ impl Metadata {
             .and_then(|t| t.value.unsigned())
             == Some(6)
     }
-
-    /// Stored primary-image width, before orientation or cropping.
     pub fn width(&self) -> Option<u32> {
         self.dimensions.map(|d| d.width)
     }
-
-    /// Stored primary-image height, before orientation or cropping.
     pub fn height(&self) -> Option<u32> {
         self.dimensions.map(|d| d.height)
     }
-
-    /// Dimensions from one XMP namespace/pair, without orientation or source fallback.
     pub fn xmp_dimensions(&self) -> Option<Dimensions> {
         [
             (namespace::TIFF, "ImageWidth", "ImageLength"),
@@ -113,23 +91,15 @@ impl Metadata {
             )
         })
     }
-
-    /// EXIF camera make; trimmed and borrowed. Empty values are absent.
     pub fn camera_make(&self) -> Option<&str> {
         self.text(Ifd::Image(0), 0x10f)
     }
-
-    /// EXIF camera model; trimmed and borrowed.
     pub fn camera_model(&self) -> Option<&str> {
         self.text(Ifd::Image(0), 0x110)
     }
-
-    /// EXIF lens model; trimmed and borrowed.
     pub fn lens_model(&self) -> Option<&str> {
         self.text(Ifd::Exif(0), 0xa434)
     }
-
-    /// Exact positive EXIF exposure time in seconds, without display rounding.
     pub fn exposure_time(&self) -> Option<Rational> {
         let Value::Rational(values) = &self.tag(Ifd::Exif(0), 0x829a)?.value else {
             return None;
@@ -139,35 +109,21 @@ impl Metadata {
         };
         (value.as_f64()? > 0.0).then_some(*value)
     }
-
-    /// Positive EXIF f-number (for example, 2.8).
     pub fn f_number(&self) -> Option<f64> {
         self.positive_number(0x829d)
     }
-
-    /// Positive EXIF focal length in millimetres.
     pub fn focal_length(&self) -> Option<f64> {
         self.positive_number(0x920a)
     }
-
-    /// Legacy EXIF sensitivity values (0x8827), including any 65535 sentinel.
-    /// Does not infer ISO speed from the newer sensitivity-type/extended tags.
     pub fn iso_speed_ratings(&self) -> Option<&[u32]> {
         match &self.tag(Ifd::Exif(0), 0x8827)?.value {
             Value::Unsigned(values) => Some(values),
             _ => None,
         }
     }
-
-    /// EXIF ImageDescription only; no XMP/IPTC precedence or character-set guess.
     pub fn exif_description(&self) -> Option<&str> {
         self.text(Ifd::Image(0), 0x10e)
     }
-
-    /// EXIF coordinates only. Preserves (0, 0); source precedence belongs to the caller.
-    /// Signed D/M/S components supply the sign only when both references are absent.
-    /// Rejects incomplete/out-of-range coordinates, malformed references, non-finite
-    /// values and minute/second magnitudes of 60 or more.
     pub fn exif_location(&self) -> Option<Location> {
         let latitude_ref = self.tag(Ifd::Gps(0), 1);
         let longitude_ref = self.tag(Ifd::Gps(0), 3);
@@ -204,22 +160,6 @@ impl Metadata {
             coordinate(4, longitude_ref, b'E', b'W')?,
         )
     }
-
-    /// XMP decimal or comma-separated degree/minute/second coordinates.
-    /// A suffix or separate hemisphere reference is required for each axis.
-    ///
-    /// ```rust,no_run
-    /// # use ente_exif::{Limits, Mode, namespace};
-    /// # let mut file = std::fs::File::open("photo.jpg")?;
-    /// let metadata = ente_exif::read(&mut file, Mode::Details, Limits::default())?;
-    /// let exif_location = metadata.exif_location();
-    /// let xmp_location = metadata.xmp_location();
-    /// let description = metadata.xmp_description(Some("en"));
-    /// for keyword in metadata.properties(namespace::DC, "subject") {
-    ///     println!("{}", keyword.value);
-    /// }
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
     pub fn xmp_location(&self) -> Option<Location> {
         location(
             xmp_coordinate(
@@ -236,9 +176,6 @@ impl Metadata {
             )?,
         )
     }
-
-    /// Preferred language, then x-default, then the first XMP description.
-    /// IPTC encoding and cross-source caption precedence remain explicit in the caller.
     pub fn xmp_description(&self, language: Option<&str>) -> Option<&str> {
         let descriptions = || self.properties(namespace::DC, "description");
         language

--- a/rust/crates/exif/src/motion.rs
+++ b/rust/crates/exif/src/motion.rs
@@ -1,0 +1,326 @@
+use crate::boxes::box_at;
+use crate::read::{Error, Reader, State, be32, le32, range};
+use crate::{Format, namespace};
+use std::io::{Read, Seek};
+
+/// Half-open extraction range `[start, end)` for appended motion video.
+/// Selects the largest candidate, ending at the next recognized video or EOF;
+/// vendor trailers may be included. Checks `ftyp` and bounded `moov`/`mdat` boxes,
+/// not codec decodability. Detection uses XMP directories/MicroVideo offsets,
+/// HEIF `mpvd`, Samsung SEF or OnePlus JXRS. An explicit MotionPhoto value other
+/// than `1` disables detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VideoRange {
+    pub start: u64,
+    pub end: u64,
+}
+
+pub(crate) fn read<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+) -> Result<(), Error> {
+    if !matches!(state.metadata.format, Format::Jpeg | Format::Heif) || reader.len < 8 {
+        return Ok(());
+    }
+    if matches!(state.metadata.property(namespace::CAMERA, "MotionPhoto"), Some(value) if value != "1")
+    {
+        return Ok(());
+    }
+    let footer = reader.array::<8>(reader.len - 8)?;
+    let mut starts = Vec::new();
+    let result = samsung(reader, state, &footer, &mut starts);
+    state.recover(reader.len - 8, result)?;
+    let result = oplus(reader, state, &footer, &mut starts);
+    state.recover(reader.len - 8, result)?;
+    let result = xmp_starts(state, reader.len, &mut starts);
+    state.recover(0, result)?;
+    if state.metadata.format == Format::Heif {
+        let result = mpvd(reader, state, &mut starts);
+        state.recover(0, result)?;
+    }
+    starts.sort_unstable();
+    starts.dedup();
+    let mut videos = Vec::new();
+    for start in starts {
+        if start == 0 || reader.len.saturating_sub(start) < 16 {
+            continue;
+        }
+        let result = video_starts(reader, state, start, &mut videos);
+        state.recover(start, result)?;
+    }
+    videos.sort_unstable();
+    videos.dedup();
+    state.metadata.motion_video = videos
+        .iter()
+        .enumerate()
+        .map(|(i, start)| VideoRange {
+            start: *start,
+            end: videos.get(i + 1).copied().unwrap_or(reader.len),
+        })
+        .max_by_key(|v| v.end - v.start);
+    Ok(())
+}
+
+fn xmp_starts(state: &State, len: u64, starts: &mut Vec<u64>) -> Result<(), Error> {
+    let mut end = len;
+    let mut items: Vec<u32> = state
+        .metadata
+        .xmp
+        .iter()
+        .filter(|p| p.namespace == namespace::ITEM)
+        .filter_map(|p| p.item)
+        .collect();
+    items.sort_unstable();
+    items.dedup();
+    for item in items.into_iter().rev() {
+        let property = |name| {
+            state
+                .metadata
+                .xmp
+                .iter()
+                .find(|p| p.namespace == namespace::ITEM && p.item == Some(item) && p.name == name)
+                .map(|p| p.value.as_str())
+        };
+        // https://developer.android.com/media/platform/motion-photo-format
+        if property("Semantic") == Some("Primary") {
+            continue;
+        }
+        let length = property("Length")
+            .unwrap_or("0")
+            .parse::<u64>()
+            .map_err(|_| Error::Malformed("motion item length"))?;
+        if length > end {
+            return Err(Error::Malformed("motion item length"));
+        }
+        end -= length;
+        if property("Semantic") == Some("MotionPhoto")
+            && matches!(property("Mime"), Some("video/mp4" | "video/quicktime"))
+            && length != 0
+        {
+            starts.push(end);
+        }
+    }
+    if let Some(offset) = state
+        .metadata
+        .property(namespace::CAMERA, "MicroVideoOffset")
+        .and_then(|s| s.parse::<u64>().ok())
+        && offset != 0
+        && offset < len
+    {
+        starts.push(len - offset);
+    }
+    Ok(())
+}
+
+fn oplus<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    footer: &[u8; 8],
+    starts: &mut Vec<u64>,
+) -> Result<(), Error> {
+    if &footer[..4] != b"jxrs" {
+        return Ok(());
+    }
+    let len = u64::from(le32(&footer[4..]));
+    if len < 8 || len > state.limits.value_bytes as u64 {
+        return Err(Error::Limit("JXRS index"));
+    }
+    let base = reader
+        .len
+        .checked_sub(len)
+        .ok_or(Error::Malformed("JXRS length"))?;
+    let bytes = reader.bytes(base, (len - 8) as usize)?;
+    let bytes = bytes.strip_suffix(&[0]).unwrap_or(&bytes);
+    let json: serde_json::Value =
+        serde_json::from_slice(bytes).map_err(|_| Error::Malformed("JXRS JSON"))?;
+    let mut pending = vec![(&json, 0)];
+    while let Some((value, depth)) = pending.pop() {
+        state.entries(1)?;
+        if depth > state.limits.depth {
+            return Err(Error::Limit("JSON depth"));
+        }
+        match value {
+            serde_json::Value::Array(items) => pending.extend(items.iter().map(|v| (v, depth + 1))),
+            serde_json::Value::Object(items) => {
+                pending.extend(items.values().map(|v| (v, depth + 1)))
+            }
+            _ => {}
+        }
+    }
+    for item in json
+        .as_array()
+        .ok_or(Error::Malformed("JXRS index array"))?
+    {
+        if item["name"] != "live.subVideo" {
+            continue;
+        }
+        let offset = item["offset"]
+            .as_u64()
+            .ok_or(Error::Malformed("JXRS offset"))?;
+        let len = item["length"]
+            .as_u64()
+            .ok_or(Error::Malformed("JXRS video length"))?;
+        let start = base
+            .checked_sub(offset)
+            .ok_or(Error::Malformed("JXRS video offset"))?;
+        range(0, base, start, len)?;
+        starts.push(start);
+    }
+    Ok(())
+}
+
+fn samsung<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    footer: &[u8; 8],
+    starts: &mut Vec<u64>,
+) -> Result<(), Error> {
+    if &footer[4..] != b"SEFT" {
+        return Ok(());
+    }
+    let len = u64::from(le32(footer));
+    let start = reader
+        .len
+        .checked_sub(len + 8)
+        .ok_or(Error::Malformed("SEF footer"))?;
+    if len < 12 {
+        return Err(Error::Malformed("SEF directory"));
+    }
+    let header = reader.array::<12>(start)?;
+    if &header[..4] != b"SEFH" {
+        return Err(Error::Malformed("SEF signature"));
+    }
+    let count = le32(&header[8..]) as usize;
+    state.entries(count)?;
+    if count as u64 * 12 != len - 12 {
+        return Err(Error::Malformed("SEF entry count"));
+    }
+    let entries = reader.bytes(start + 12, count * 12)?;
+    for entry in entries.as_chunks::<12>().0 {
+        let kind = u16::from_le_bytes([entry[2], entry[3]]);
+        if !matches!(kind, 0x0a30 | 0x0a33) {
+            continue;
+        }
+        let position = start
+            .checked_sub(u64::from(le32(&entry[4..])))
+            .ok_or(Error::Malformed("SEF record offset"))?;
+        let size = u64::from(le32(&entry[8..]));
+        range(0, start, position, size)?;
+        if size < 8 {
+            return Err(Error::Malformed("SEF record"));
+        }
+        let header = reader.array::<8>(position)?;
+        let name_len = u64::from(le32(&header[4..]));
+        range(position, size, 8, name_len + 12)?;
+        if name_len > 64 {
+            return Err(Error::Malformed("SEF record name"));
+        }
+        let name = reader.bytes(position + 8, name_len as usize)?;
+        if !matches!(
+            name.as_slice(),
+            b"MotionPhoto_Data" | b"MotionPhoto_AutoPlay"
+        ) {
+            continue;
+        }
+        let data = position + 8 + name_len;
+        let header = reader.array::<12>(data)?;
+        if &header[..4] == b"mpv2" {
+            let offset = u64::from(be32(&header[4..]));
+            let length = u64::from(be32(&header[8..]));
+            range(0, reader.len, offset, length)?;
+            starts.push(offset);
+        } else if &header[4..8] == b"ftyp" {
+            starts.push(data);
+        }
+    }
+    Ok(())
+}
+
+fn mpvd<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    starts: &mut Vec<u64>,
+) -> Result<(), Error> {
+    let mut offset = 0;
+    while reader.len - offset >= 8 {
+        state.entries(1)?;
+        let b = match box_at(reader, offset, reader.len) {
+            Ok(b) => b,
+            Err(Error::Malformed(_)) => break,
+            Err(e) => return Err(e),
+        };
+        if &b.kind == b"mpvd" {
+            starts.push(b.start);
+        }
+        offset = b.end();
+    }
+    Ok(())
+}
+
+fn video_starts<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    start: u64,
+    videos: &mut Vec<u64>,
+) -> Result<(), Error> {
+    let first = reader.array::<12>(start)?;
+    if &first[4..8] != b"ftyp" {
+        return Ok(());
+    }
+    let mut offset = start;
+    let mut current = None;
+    let mut moov = false;
+    let mut mdat = false;
+    while reader.len - offset >= 8 {
+        state.entries(1)?;
+        let b = match box_at(reader, offset, reader.len) {
+            Ok(b) => b,
+            Err(Error::Malformed(_)) if moov && mdat => break,
+            Err(e) => return Err(e),
+        };
+        match &b.kind {
+            b"ftyp" => {
+                if moov
+                    && mdat
+                    && let Some(start) = current
+                {
+                    videos.push(start);
+                }
+                if b.len < 8 {
+                    return Err(Error::Malformed("video ftyp"));
+                }
+                let brand = reader.array::<4>(b.start)?;
+                if !matches!(
+                    &brand,
+                    b"isom"
+                        | b"iso2"
+                        | b"iso5"
+                        | b"iso6"
+                        | b"mp41"
+                        | b"mp42"
+                        | b"avc1"
+                        | b"qt  "
+                        | b"M4V "
+                        | b"3gp4"
+                        | b"3gp5"
+                ) {
+                    break;
+                }
+                current = Some(offset);
+                moov = false;
+                mdat = false;
+            }
+            b"moov" => moov = true,
+            b"mdat" => mdat = true,
+            _ => {}
+        }
+        offset = b.end();
+    }
+    if moov
+        && mdat
+        && let Some(start) = current
+    {
+        videos.push(start);
+    }
+    Ok(())
+}

--- a/rust/crates/exif/src/motion.rs
+++ b/rust/crates/exif/src/motion.rs
@@ -114,7 +114,10 @@ fn oplus<R: Read + Seek>(
         return Ok(());
     }
     let len = u64::from(le32(&footer[4..]));
-    if len < 8 || len > state.limits.value_bytes as u64 {
+    if len < 8 {
+        return Err(Error::Malformed("JXRS length"));
+    }
+    if len > state.limits.value_bytes as u64 {
         return Err(Error::Limit("JXRS index"));
     }
     let base = reader
@@ -278,24 +281,31 @@ fn video_starts<R: Read + Seek>(
                 {
                     videos.push(start);
                 }
-                if b.len < 8 {
+                if b.len < 8 || b.len % 4 != 0 {
                     return Err(Error::Malformed("video ftyp"));
                 }
-                let brand = reader.array::<4>(b.start)?;
-                if !matches!(
-                    &brand,
-                    b"isom"
-                        | b"iso2"
-                        | b"iso5"
-                        | b"iso6"
-                        | b"mp41"
-                        | b"mp42"
-                        | b"avc1"
-                        | b"qt  "
-                        | b"M4V "
-                        | b"3gp4"
-                        | b"3gp5"
-                ) {
+                let mut supported = false;
+                for position in std::iter::once(0).chain((8..b.len).step_by(4)) {
+                    let brand = reader.array::<4>(b.start + position)?;
+                    if matches!(
+                        &brand,
+                        b"isom"
+                            | b"iso2"
+                            | b"iso5"
+                            | b"iso6"
+                            | b"mp41"
+                            | b"mp42"
+                            | b"avc1"
+                            | b"qt  "
+                            | b"M4V "
+                            | b"3gp4"
+                            | b"3gp5"
+                    ) {
+                        supported = true;
+                        break;
+                    }
+                }
+                if !supported {
                     break;
                 }
                 current = Some(offset);

--- a/rust/crates/exif/src/motion.rs
+++ b/rust/crates/exif/src/motion.rs
@@ -2,13 +2,6 @@ use crate::boxes::box_at;
 use crate::read::{Error, Reader, State, be32, le32, range};
 use crate::{Format, namespace};
 use std::io::{Read, Seek};
-
-/// Half-open extraction range `[start, end)` for appended motion video.
-/// Selects the largest candidate, ending at the next recognized video or EOF;
-/// vendor trailers may be included. Checks `ftyp` and bounded `moov`/`mdat` boxes,
-/// not codec decodability. Detection uses XMP directories/MicroVideo offsets,
-/// HEIF `mpvd`, Samsung SEF or OnePlus JXRS. An explicit MotionPhoto value other
-/// than `1` disables detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VideoRange {
     pub start: u64,
@@ -81,7 +74,6 @@ fn xmp_starts(state: &State, len: u64, starts: &mut Vec<u64>) -> Result<(), Erro
                 .find(|p| p.namespace == namespace::ITEM && p.item == Some(item) && p.name == name)
                 .map(|p| p.value.as_str())
         };
-        // https://developer.android.com/media/platform/motion-photo-format
         if property("Semantic") == Some("Primary") {
             continue;
         }

--- a/rust/crates/exif/src/photo.rs
+++ b/rust/crates/exif/src/photo.rs
@@ -1,68 +1,18 @@
-//! Default capture-date and display-size policies, built on the public parser API.
-//! Applications can replace these functions with their own source selection,
-//! normalization and decoder rules. Reading metadata does not call this module.
-
 use crate::{
     DateTime, DateTimeKind, DateTimePrecision, DateTimeSource, Dimensions, Metadata, Transform,
     namespace,
 };
 
-/// Resolved capture metadata. Local time and the embedded offset remain separate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CaptureDateTime {
-    /// ISO local date/time without a timezone suffix; retains nanosecond precision.
     pub date_time: String,
-    /// Embedded UTC offset, normalized to ±HH:MM. None means absent, not UTC.
     pub offset_time: Option<String>,
-    /// Epoch microseconds. None when a full timestamp has no embedded offset.
-    /// Date-only inputs use midnight UTC without inventing an embedded offset.
     pub timestamp_micros: Option<i64>,
     pub source: DateTimeSource,
 }
-
-/// First parseable capture date, in this order:
-///
-/// | Family | Sources |
-/// | --- | --- |
-/// | Original | XMP `exif:DateTimeOriginal`, IPTC 2:55/60, EXIF Original, XMP `photoshop:DateCreated` |
-/// | Digitized | XMP `exif:DateTimeDigitized`, IPTC 2:62/63, EXIF Digitized, XMP `xmp:CreateDate` |
-/// | Metadata change | XMP `xmp:MetadataDate` |
-/// | Modified | XMP `tiff:DateTime`, EXIF Modified, XMP `xmp:ModifyDate` |
-///
-/// Year/month/date-only values use the start of that period at midnight UTC,
-/// without inventing an embedded offset. Omitted seconds become zero. Full times
-/// without offsets remain unresolved; no host timezone or sentinel filtering is
-/// assumed. Valid epoch zero and unusual years are preserved.
-///
-/// Local text retains nanoseconds, epoch values retain microseconds, and `Z`
-/// normalizes to `+00:00`. Only the selected candidate's strings are allocated.
-/// Use [`Metadata::date_time`] for source precision without normalization.
 pub fn capture_date_time(metadata: &Metadata) -> Option<CaptureDateTime> {
     capture_date_time_with(metadata, |_| true)
 }
-
-/// Resolve or reject each candidate before choosing the first accepted one.
-/// The callback can fill `timestamp_micros` from a host timezone and reject
-/// application-specific sentinel dates by returning false. An assumed device
-/// offset should not be stored in `offset_time`, which describes the source.
-/// Does not inspect filenames, filesystem timestamps or external sidecars.
-///
-/// ```rust,no_run
-/// # use ente_exif::{Limits, Mode};
-/// # let mut file = std::fs::File::open("photo.jpg")?;
-/// # let metadata = ente_exif::read(&mut file, Mode::Summary, Limits::default())?;
-/// # fn local_timestamp_in_host_timezone(_: &str) -> Option<i64> { None }
-/// let capture = metadata.capture_date_time_with(|candidate| {
-///     if candidate.timestamp_micros.is_none() {
-///         // Supplied by the application: resolve this date in the host's timezone,
-///         // including its daylight-saving rules, rather than using today's offset.
-///         candidate.timestamp_micros = local_timestamp_in_host_timezone(&candidate.date_time);
-///     }
-///     // Returning false skips this candidate and continues through the table.
-///     candidate.timestamp_micros.is_some()
-/// });
-/// # Ok::<(), Box<dyn std::error::Error>>(())
-/// ```
 pub fn capture_date_time_with(
     metadata: &Metadata,
     mut accept: impl FnMut(&mut CaptureDateTime) -> bool,
@@ -119,19 +69,6 @@ pub fn capture_date_time_with(
         accept(&mut result).then_some(result)
     })
 }
-
-/// Final pixel dimensions: container/EXIF size, then a complete XMP pair.
-/// Applies HEIF transforms in order. A nonzero HEIF rotation or any mirror
-/// suppresses EXIF/XMP orientation; otherwise valid EXIF wins over XMP.
-/// Zero HEIF rotation allows EXIF/XMP fallback; mirrors do not swap axes.
-/// JPEG XL's codestream orientation always overrides EXIF/XMP, including normal
-/// orientation. Its dimensions exclude optional intrinsic display resampling.
-/// XMP-only dimensions use XMP orientation only. Missing/invalid orientation
-/// leaves dimensions unchanged. Does not apply transforms to decoded pixels.
-///
-/// Returns `None` for missing dimensions or a crop that is not a positive,
-/// integer, pixel-aligned rectangle within its input image. Pixel aspect
-/// ratio, scaling and decoder-specific rendering policies are not applied.
 pub fn display_dimensions(metadata: &Metadata) -> Option<Dimensions> {
     let mut dimensions = metadata.dimensions.or_else(|| metadata.xmp_dimensions())?;
     let mut oriented = false;

--- a/rust/crates/exif/src/photo.rs
+++ b/rust/crates/exif/src/photo.rs
@@ -1,0 +1,168 @@
+//! Default capture-date and display-size policies, built on the public parser API.
+//! Applications can replace these functions with their own source selection,
+//! normalization and decoder rules. Reading metadata does not call this module.
+
+use crate::{
+    DateTime, DateTimeKind, DateTimePrecision, DateTimeSource, Dimensions, Metadata, Transform,
+    namespace,
+};
+
+/// Resolved capture metadata. Local time and the embedded offset remain separate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureDateTime {
+    /// ISO local date/time without a timezone suffix; retains nanosecond precision.
+    pub date_time: String,
+    /// Embedded UTC offset, normalized to ±HH:MM. None means absent, not UTC.
+    pub offset_time: Option<String>,
+    /// Epoch microseconds. None when a full timestamp has no embedded offset.
+    /// Date-only inputs use midnight UTC without inventing an embedded offset.
+    pub timestamp_micros: Option<i64>,
+    pub source: DateTimeSource,
+}
+
+/// First parseable capture date, in this order:
+///
+/// | Family | Sources |
+/// | --- | --- |
+/// | Original | XMP `exif:DateTimeOriginal`, IPTC 2:55/60, EXIF Original, XMP `photoshop:DateCreated` |
+/// | Digitized | XMP `exif:DateTimeDigitized`, IPTC 2:62/63, EXIF Digitized, XMP `xmp:CreateDate` |
+/// | Metadata change | XMP `xmp:MetadataDate` |
+/// | Modified | XMP `tiff:DateTime`, EXIF Modified, XMP `xmp:ModifyDate` |
+///
+/// Year/month/date-only values use the start of that period at midnight UTC,
+/// without inventing an embedded offset. Omitted seconds become zero. Full times
+/// without offsets remain unresolved; no host timezone or sentinel filtering is
+/// assumed. Valid epoch zero and unusual years are preserved.
+///
+/// Local text retains nanoseconds, epoch values retain microseconds, and `Z`
+/// normalizes to `+00:00`. Only the selected candidate's strings are allocated.
+/// Use [`Metadata::date_time`] for source precision without normalization.
+pub fn capture_date_time(metadata: &Metadata) -> Option<CaptureDateTime> {
+    capture_date_time_with(metadata, |_| true)
+}
+
+/// Resolve or reject each candidate before choosing the first accepted one.
+/// The callback can fill `timestamp_micros` from a host timezone and reject
+/// application-specific sentinel dates by returning false. An assumed device
+/// offset should not be stored in `offset_time`, which describes the source.
+/// Does not inspect filenames, filesystem timestamps or external sidecars.
+///
+/// ```rust,no_run
+/// # use ente_exif::{Limits, Mode};
+/// # let mut file = std::fs::File::open("photo.jpg")?;
+/// # let metadata = ente_exif::read(&mut file, Mode::Summary, Limits::default())?;
+/// # fn local_timestamp_in_host_timezone(_: &str) -> Option<i64> { None }
+/// let capture = metadata.capture_date_time_with(|candidate| {
+///     if candidate.timestamp_micros.is_none() {
+///         // Supplied by the application: resolve this date in the host's timezone,
+///         // including its daylight-saving rules, rather than using today's offset.
+///         candidate.timestamp_micros = local_timestamp_in_host_timezone(&candidate.date_time);
+///     }
+///     // Returning false skips this candidate and continues through the table.
+///     candidate.timestamp_micros.is_some()
+/// });
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn capture_date_time_with(
+    metadata: &Metadata,
+    mut accept: impl FnMut(&mut CaptureDateTime) -> bool,
+) -> Option<CaptureDateTime> {
+    use DateTimeKind::{Digitized, Modified, Original};
+    use DateTimeSource::{Exif, Iptc, Xmp};
+    [
+        Xmp(namespace::EXIF, "DateTimeOriginal"),
+        Iptc(55, 60),
+        Exif(Original),
+        Xmp(namespace::PHOTOSHOP, "DateCreated"),
+        Xmp(namespace::EXIF, "DateTimeDigitized"),
+        Iptc(62, 63),
+        Exif(Digitized),
+        Xmp(namespace::XMP, "CreateDate"),
+        Xmp(namespace::XMP, "MetadataDate"),
+        Xmp(namespace::TIFF, "DateTime"),
+        Exif(Modified),
+        Xmp(namespace::XMP, "ModifyDate"),
+    ]
+    .into_iter()
+    .find_map(|source| {
+        let value = metadata.date_time(source)?;
+        let date = value.date_time;
+        let local = DateTime {
+            offset_minutes: None,
+            ..date
+        };
+        let absolute = if matches!(
+            value.precision,
+            DateTimePrecision::Year | DateTimePrecision::Month | DateTimePrecision::Day
+        ) {
+            DateTime {
+                offset_minutes: Some(0),
+                ..date
+            }
+        } else {
+            date
+        };
+        let mut result = CaptureDateTime {
+            date_time: local.to_string(),
+            offset_time: date.offset_minutes.map(|offset| {
+                let minutes = offset.unsigned_abs();
+                format!(
+                    "{}{:02}:{:02}",
+                    if offset < 0 { '-' } else { '+' },
+                    minutes / 60,
+                    minutes % 60
+                )
+            }),
+            timestamp_micros: absolute.unix_micros(),
+            source,
+        };
+        accept(&mut result).then_some(result)
+    })
+}
+
+/// Final pixel dimensions: container/EXIF size, then a complete XMP pair.
+/// Applies HEIF transforms in order. A nonzero HEIF rotation or any mirror
+/// suppresses EXIF/XMP orientation; otherwise valid EXIF wins over XMP.
+/// Zero HEIF rotation allows EXIF/XMP fallback; mirrors do not swap axes.
+/// JPEG XL's codestream orientation always overrides EXIF/XMP, including normal
+/// orientation. Its dimensions exclude optional intrinsic display resampling.
+/// XMP-only dimensions use XMP orientation only. Missing/invalid orientation
+/// leaves dimensions unchanged. Does not apply transforms to decoded pixels.
+///
+/// Returns `None` for missing dimensions or a crop that is not a positive,
+/// integer, pixel-aligned rectangle within its input image. Pixel aspect
+/// ratio, scaling and decoder-specific rendering policies are not applied.
+pub fn display_dimensions(metadata: &Metadata) -> Option<Dimensions> {
+    let mut dimensions = metadata.dimensions.or_else(|| metadata.xmp_dimensions())?;
+    let mut oriented = false;
+    for transform in &metadata.transforms {
+        match *transform {
+            Transform::Orientation(value @ 1..=8) => {
+                dimensions = dimensions.with_exif_orientation(u32::from(value));
+                oriented = true;
+            }
+            Transform::Rotate(turns @ 0..=3) => {
+                if turns % 2 != 0 {
+                    std::mem::swap(&mut dimensions.width, &mut dimensions.height);
+                }
+                oriented |= turns != 0;
+            }
+            Transform::Mirror(0..=1) => oriented = true,
+            Transform::Crop(crop) => dimensions = crop.cropped_dimensions(dimensions)?,
+            _ => return None,
+        }
+    }
+    if !oriented {
+        let exif = metadata.dimensions.and(metadata.orientation());
+        let orientation = exif.filter(|v| (1..=8).contains(v)).or_else(|| {
+            metadata
+                .property(namespace::TIFF, "Orientation")?
+                .trim()
+                .parse::<u32>()
+                .ok()
+                .filter(|v| (1..=8).contains(v))
+        });
+        dimensions = dimensions.with_exif_orientation(orientation.unwrap_or(1));
+    }
+    (dimensions.width != 0 && dimensions.height != 0).then_some(dimensions)
+}

--- a/rust/crates/exif/src/photoshop.rs
+++ b/rust/crates/exif/src/photoshop.rs
@@ -1,0 +1,29 @@
+use crate::read::{Cursor, Error, State};
+use crate::{iptc, xmp};
+
+pub(crate) fn read(data: &[u8], state: &mut State) -> Result<(), Error> {
+    let data = data.strip_prefix(b"Photoshop 3.0\0").unwrap_or(data);
+    if !data.starts_with(b"8BIM") {
+        return Ok(());
+    }
+    let mut cursor = Cursor::new(data);
+    while cursor.pos < data.len() {
+        state.entries(1)?;
+        if cursor.take(4)? != b"8BIM" {
+            return Err(Error::Malformed("Photoshop resource"));
+        }
+        let id = cursor.number(2)?;
+        let name_length = cursor.number(1)? as usize;
+        cursor.take(name_length + ((name_length + 1) & 1))?;
+        let size = cursor.number(4)? as usize;
+        let value = cursor.take(size)?;
+        cursor.take(size & 1)?;
+        if id == 0x404 {
+            iptc::read(value, state)?;
+        }
+        if id == 0x424 {
+            xmp::read(value, state)?;
+        }
+    }
+    Ok(())
+}

--- a/rust/crates/exif/src/photoshop.rs
+++ b/rust/crates/exif/src/photoshop.rs
@@ -16,14 +16,15 @@ pub(crate) fn read(data: &[u8], state: &mut State) -> Result<(), Error> {
         let name_length = cursor.number(1)? as usize;
         cursor.take(name_length + ((name_length + 1) & 1))?;
         let size = cursor.number(4)? as usize;
+        let offset = cursor.pos as u64;
         let value = cursor.take(size)?;
         cursor.take(size & 1)?;
-        if id == 0x404 {
-            iptc::read(value, state)?;
-        }
-        if id == 0x424 {
-            xmp::read(value, state)?;
-        }
+        let result = match id {
+            0x404 => iptc::read(value, state),
+            0x424 => xmp::read(value, state),
+            _ => Ok(()),
+        };
+        state.recover(offset, result)?;
     }
     Ok(())
 }

--- a/rust/crates/exif/src/png.rs
+++ b/rust/crates/exif/src/png.rs
@@ -48,6 +48,7 @@ fn text(data: &[u8], kind: &[u8], state: &mut State) -> Result<(), Error> {
         return Err(Error::Malformed("PNG keyword"));
     }
     let mut compressed = false;
+    let mut language = None;
     if kind == b"iTXt" {
         let flag = cursor.number(1)?;
         let method = cursor.number(1)?;
@@ -55,7 +56,7 @@ fn text(data: &[u8], kind: &[u8], state: &mut State) -> Result<(), Error> {
             return Err(Error::Unsupported("PNG text compression"));
         }
         compressed = flag == 1;
-        cursor.string()?;
+        language = Some(cursor.string()?).filter(|value| !value.is_empty());
         cursor.string()?;
     } else if kind == b"zTXt" {
         if cursor.number(1)? != 0 {
@@ -121,7 +122,10 @@ fn text(data: &[u8], kind: &[u8], state: &mut State) -> Result<(), Error> {
         Cow::Owned(text.iter().copied().map(char::from).collect::<String>())
     };
     let key: String = key.iter().copied().map(char::from).collect();
-    xmp::store(state, "urn:png:text", &key, &text, None, None)
+    if language.is_some_and(|value| value.len() > state.limits.value_bytes) {
+        return Err(Error::Limit("PNG language"));
+    }
+    xmp::store(state, "urn:png:text", &key, &text, language, None)
 }
 
 fn profile(key: &[u8], text: &[u8], state: &mut State) -> Result<(), Error> {

--- a/rust/crates/exif/src/png.rs
+++ b/rust/crates/exif/src/png.rs
@@ -3,6 +3,8 @@ use crate::{Dimensions, Mode, iptc, photoshop, tiff, xmp};
 use std::borrow::Cow;
 use std::io::{Read, Seek};
 
+const MAX_KEYWORD_LEN: usize = 79;
+
 pub(crate) fn read<R: Read + Seek>(
     reader: &mut Reader<'_, R>,
     state: &mut State,
@@ -24,9 +26,7 @@ pub(crate) fn read<R: Read + Seek>(
                 Ok(())
             }
             b"eXIf" => tiff::read(reader, state, start, len),
-            b"iTXt" | b"zTXt" | b"tEXt" => {
-                text(&reader.bytes(start, len as usize)?, &header[4..], state)
-            }
+            b"iTXt" | b"zTXt" | b"tEXt" => text(reader, start, len as usize, &header[4..], state),
             b"IEND" => {
                 if len != 0 || state.metadata.dimensions.is_none() {
                     return Err(Error::Malformed("PNG IEND"));
@@ -41,12 +41,45 @@ pub(crate) fn read<R: Read + Seek>(
     Err(Error::Malformed("missing PNG IEND"))
 }
 
-fn text(data: &[u8], kind: &[u8], state: &mut State) -> Result<(), Error> {
-    let mut cursor = Cursor::new(data);
+fn text<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    start: u64,
+    len: usize,
+    kind: &[u8],
+    state: &mut State,
+) -> Result<(), Error> {
+    let mut header = [0; MAX_KEYWORD_LEN + 1];
+    let header = &mut header[..len.min(MAX_KEYWORD_LEN + 1)];
+    reader.fill(start, header)?;
+    let mut cursor = Cursor::new(header);
     let key = cursor.terminated_bytes()?;
-    if !(1..=79).contains(&key.len()) {
+    if !(1..=MAX_KEYWORD_LEN).contains(&key.len()) {
         return Err(Error::Malformed("PNG keyword"));
     }
+    let is_profile = matches!(
+        key,
+        b"Raw profile type exif"
+            | b"Raw profile type APP1"
+            | b"Raw profile type iptc"
+            | b"Raw profile type 8bim"
+            | b"Raw profile type xmp"
+    );
+    if key != b"XML:com.adobe.xmp" && !is_profile && state.mode == Mode::Summary {
+        return Ok(());
+    }
+    let prefix = &header[cursor.pos..];
+    let data = if len == header.len() {
+        Cow::Borrowed(prefix)
+    } else {
+        let remaining = len - header.len();
+        let offset = start + header.len() as u64;
+        reader.check(offset, remaining)?;
+        let mut data = vec![0; prefix.len() + remaining];
+        data[..prefix.len()].copy_from_slice(prefix);
+        reader.fill(offset, &mut data[prefix.len()..])?;
+        Cow::Owned(data)
+    };
+    let mut cursor = Cursor::new(&data);
     let mut compressed = false;
     let mut language = None;
     if kind == b"iTXt" {
@@ -63,17 +96,6 @@ fn text(data: &[u8], kind: &[u8], state: &mut State) -> Result<(), Error> {
             return Err(Error::Unsupported("PNG text compression"));
         }
         compressed = true;
-    }
-    let is_profile = matches!(
-        key,
-        b"Raw profile type exif"
-            | b"Raw profile type APP1"
-            | b"Raw profile type iptc"
-            | b"Raw profile type 8bim"
-            | b"Raw profile type xmp"
-    );
-    if key != b"XML:com.adobe.xmp" && !is_profile && state.mode == Mode::Summary {
-        return Ok(());
     }
     let bytes = &data[cursor.pos..];
     let decoded;

--- a/rust/crates/exif/src/png.rs
+++ b/rust/crates/exif/src/png.rs
@@ -1,0 +1,175 @@
+use crate::read::{Cursor, Error, Reader, State, be32, range};
+use crate::{Dimensions, Mode, iptc, photoshop, tiff, xmp};
+use std::borrow::Cow;
+use std::io::{Read, Seek};
+
+pub(crate) fn read<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+) -> Result<(), Error> {
+    let mut offset = 8;
+    while offset < reader.len {
+        state.entries(1)?;
+        let header = reader.array::<8>(offset)?;
+        let len = u64::from(be32(&header));
+        range(0, reader.len, offset, len + 12)?;
+        let start = offset + 8;
+        let result = match &header[4..] {
+            b"IHDR" => {
+                if offset != 8 || len != 13 {
+                    return Err(Error::Malformed("PNG IHDR"));
+                }
+                let data = reader.array::<8>(start)?;
+                state.metadata.dimensions = Dimensions::new(be32(&data), be32(&data[4..]));
+                Ok(())
+            }
+            b"eXIf" => tiff::read(reader, state, start, len),
+            b"iTXt" | b"zTXt" | b"tEXt" => {
+                text(&reader.bytes(start, len as usize)?, &header[4..], state)
+            }
+            b"IEND" => {
+                if len != 0 || state.metadata.dimensions.is_none() {
+                    return Err(Error::Malformed("PNG IEND"));
+                }
+                return Ok(());
+            }
+            _ => Ok(()),
+        };
+        state.recover(offset, result)?;
+        offset += len + 12;
+    }
+    Err(Error::Malformed("missing PNG IEND"))
+}
+
+fn text(data: &[u8], kind: &[u8], state: &mut State) -> Result<(), Error> {
+    let mut cursor = Cursor::new(data);
+    let key = cursor.terminated_bytes()?;
+    if !(1..=79).contains(&key.len()) {
+        return Err(Error::Malformed("PNG keyword"));
+    }
+    let mut compressed = false;
+    if kind == b"iTXt" {
+        let flag = cursor.number(1)?;
+        let method = cursor.number(1)?;
+        if flag > 1 || method != 0 {
+            return Err(Error::Unsupported("PNG text compression"));
+        }
+        compressed = flag == 1;
+        cursor.string()?;
+        cursor.string()?;
+    } else if kind == b"zTXt" {
+        if cursor.number(1)? != 0 {
+            return Err(Error::Unsupported("PNG text compression"));
+        }
+        compressed = true;
+    }
+    let is_profile = matches!(
+        key,
+        b"Raw profile type exif"
+            | b"Raw profile type APP1"
+            | b"Raw profile type iptc"
+            | b"Raw profile type 8bim"
+            | b"Raw profile type xmp"
+    );
+    if key != b"XML:com.adobe.xmp" && !is_profile && state.mode == Mode::Summary {
+        return Ok(());
+    }
+    let bytes = &data[cursor.pos..];
+    let decoded;
+    let text = if compressed {
+        let value_limit = if is_profile {
+            state.limits.read_bytes
+        } else {
+            state.limits.value_bytes
+        };
+        decoded = miniz_oxide::inflate::decompress_to_vec_zlib_with_limit(
+            bytes,
+            state.expansion_limit().min(value_limit),
+        )
+        .map_err(|e| {
+            if e.status == miniz_oxide::inflate::TINFLStatus::HasMoreOutput {
+                Error::Limit(if state.expansion_limit() < value_limit {
+                    "expanded bytes"
+                } else {
+                    "compressed PNG text"
+                })
+            } else {
+                Error::Malformed("compressed PNG text")
+            }
+        })?;
+        state.expanded(decoded.len())?;
+        &decoded[..]
+    } else {
+        bytes
+    };
+    if is_profile {
+        return profile(key, text, state);
+    }
+    if key == b"XML:com.adobe.xmp" {
+        return xmp::read(text, state);
+    }
+    if text.len() > state.limits.value_bytes {
+        return Err(Error::Limit("PNG text"));
+    }
+    let text = if kind == b"iTXt" {
+        Cow::Borrowed(std::str::from_utf8(text).map_err(|_| Error::Malformed("PNG UTF-8"))?)
+    } else {
+        let extra = text.iter().filter(|b| **b >= 128).count();
+        if extra > state.limits.value_bytes - text.len() {
+            return Err(Error::Limit("PNG text"));
+        }
+        Cow::Owned(text.iter().copied().map(char::from).collect::<String>())
+    };
+    let key: String = key.iter().copied().map(char::from).collect();
+    xmp::store(state, "urn:png:text", &key, &text, None, None)
+}
+
+fn profile(key: &[u8], text: &[u8], state: &mut State) -> Result<(), Error> {
+    let mut lines = text.splitn(4, |b| *b == b'\n');
+    if lines.next() != Some(b"") || lines.next().is_none() {
+        return Err(Error::Malformed("PNG profile header"));
+    }
+    let length = lines
+        .next()
+        .and_then(|v| std::str::from_utf8(v).ok())
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .ok_or(Error::Malformed("PNG profile length"))?;
+    let hex = lines.next().ok_or(Error::Malformed("PNG profile hex"))?;
+    if length > hex.len() / 2 {
+        return Err(Error::Malformed("PNG profile length"));
+    }
+    state.expanded(length)?;
+    let mut bytes = Vec::with_capacity(length);
+    let mut digits = hex.iter().copied().filter(|b| !b.is_ascii_whitespace());
+    for _ in 0..length {
+        let mut byte = 0;
+        for _ in 0..2 {
+            let digit = digits
+                .next()
+                .and_then(|v| char::from(v).to_digit(16))
+                .ok_or(Error::Malformed("PNG profile hex"))?;
+            byte = byte * 16 + digit as u8;
+        }
+        bytes.push(byte);
+    }
+    if digits.next().is_some() {
+        return Err(Error::Malformed("PNG profile length"));
+    }
+    match key {
+        b"Raw profile type exif" | b"Raw profile type APP1" => {
+            if let Some(xml) = bytes.strip_prefix(b"http://ns.adobe.com/xap/1.0/\0") {
+                return xmp::read(xml, state);
+            }
+            let tiff = bytes.strip_prefix(b"Exif\0\0").unwrap_or(&bytes);
+            tiff::read_bytes(tiff, state)
+        }
+        b"Raw profile type iptc" | b"Raw profile type 8bim" => {
+            if bytes.starts_with(b"\x1c") {
+                iptc::read(&bytes, state)
+            } else {
+                photoshop::read(&bytes, state)
+            }
+        }
+        _ => xmp::read(&bytes, state),
+    }
+}

--- a/rust/crates/exif/src/read.rs
+++ b/rust/crates/exif/src/read.rs
@@ -40,20 +40,12 @@ impl From<io::Error> for Error {
         Self::Io(e)
     }
 }
-
-/// Per-read resource budgets; not an exact heap/RSS cap. Retained accounting
-/// excludes allocator capacity, caller buffering and dependency internals.
-/// XML additionally allows at most 64 namespace declarations per element.
 #[derive(Debug, Clone, Copy)]
 pub struct Limits {
-    /// Logical source reads; also sets a separate cumulative expanded-text budget
-    /// and the maximum Brotli window size.
     pub read_bytes: usize,
-    /// Maximum retained value or decompressed text chunk (raw profiles use read_bytes).
     pub value_bytes: usize,
     pub output_bytes: usize,
     pub entries: usize,
-    /// TIFF directories per block.
     pub directories: usize,
     pub depth: usize,
 }
@@ -73,7 +65,6 @@ impl Default for Limits {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Statistics {
-    /// Logical source bytes, excluding read-ahead inside a caller's BufReader.
     pub bytes_read: u64,
     pub reads: usize,
 }

--- a/rust/crates/exif/src/read.rs
+++ b/rust/crates/exif/src/read.rs
@@ -1,0 +1,270 @@
+use crate::{Metadata, Mode};
+use std::fmt;
+use std::io::{self, Read, Seek, SeekFrom};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Issue {
+    pub offset: u64,
+    pub message: &'static str,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    Malformed(&'static str),
+    Unsupported(&'static str),
+    Limit(&'static str),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => e.fmt(f),
+            Self::Malformed(s) => write!(f, "malformed {s}"),
+            Self::Unsupported(s) => write!(f, "unsupported {s}"),
+            Self::Limit(s) => write!(f, "{s} limit exceeded"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Per-read resource budgets; not an exact heap/RSS cap. Retained accounting
+/// excludes allocator capacity, caller buffering and dependency internals.
+/// XML additionally allows at most 64 namespace declarations per element.
+#[derive(Debug, Clone, Copy)]
+pub struct Limits {
+    /// Logical source reads; also sets a separate cumulative expanded-text budget
+    /// and the maximum Brotli window size.
+    pub read_bytes: usize,
+    /// Maximum retained value or decompressed text chunk (raw profiles use read_bytes).
+    pub value_bytes: usize,
+    pub output_bytes: usize,
+    pub entries: usize,
+    /// TIFF directories per block.
+    pub directories: usize,
+    pub depth: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            read_bytes: 8 * 1024 * 1024,
+            value_bytes: 64 * 1024,
+            output_bytes: 512 * 1024,
+            entries: 16384,
+            directories: 64,
+            depth: 32,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Statistics {
+    /// Logical source bytes, excluding read-ahead inside a caller's BufReader.
+    pub bytes_read: u64,
+    pub reads: usize,
+}
+
+pub(crate) struct Reader<'a, R> {
+    source: &'a mut R,
+    pub len: u64,
+    position: u64,
+    remaining: usize,
+    pub statistics: Statistics,
+}
+
+impl<'a, R: Read + Seek> Reader<'a, R> {
+    pub fn new(source: &'a mut R, limits: Limits) -> Result<Self, Error> {
+        let len = source.seek(SeekFrom::End(0))?;
+        Ok(Self {
+            source,
+            len,
+            position: len,
+            remaining: limits.read_bytes,
+            statistics: Statistics::default(),
+        })
+    }
+
+    pub fn bytes(&mut self, offset: u64, count: usize) -> Result<Vec<u8>, Error> {
+        self.check(offset, count)?;
+        let mut bytes = vec![0; count];
+        self.fill(offset, &mut bytes)?;
+        Ok(bytes)
+    }
+
+    pub fn array<const N: usize>(&mut self, offset: u64) -> Result<[u8; N], Error> {
+        let mut bytes = [0; N];
+        self.fill(offset, &mut bytes)?;
+        Ok(bytes)
+    }
+
+    pub fn fill(&mut self, offset: u64, bytes: &mut [u8]) -> Result<(), Error> {
+        self.check(offset, bytes.len())?;
+        if self.position != offset {
+            if let Ok(delta) = i64::try_from(i128::from(offset) - i128::from(self.position)) {
+                self.source.seek_relative(delta)?;
+            } else {
+                self.source.seek(SeekFrom::Start(offset))?;
+            }
+        }
+        self.source.read_exact(bytes)?;
+        self.position = offset + bytes.len() as u64;
+        self.remaining -= bytes.len();
+        self.statistics.bytes_read += bytes.len() as u64;
+        self.statistics.reads += 1;
+        Ok(())
+    }
+
+    fn check(&self, offset: u64, count: usize) -> Result<(), Error> {
+        if offset > self.len || count as u64 > self.len - offset {
+            return Err(Error::Malformed("range"));
+        }
+        if count > self.remaining {
+            return Err(Error::Limit("read bytes"));
+        }
+        Ok(())
+    }
+}
+
+pub(crate) struct State<'a> {
+    pub metadata: Metadata,
+    pub mode: Mode,
+    pub limits: Limits,
+    pub structure: Option<&'a mut crate::XmpStructure>,
+    entries: usize,
+    output: usize,
+    expanded: usize,
+}
+
+impl State<'_> {
+    pub fn new(mode: Mode, limits: Limits) -> Self {
+        Self {
+            metadata: Metadata::default(),
+            mode,
+            limits,
+            structure: None,
+            entries: 0,
+            output: 0,
+            expanded: 0,
+        }
+    }
+
+    pub fn entries(&mut self, count: usize) -> Result<(), Error> {
+        self.entries = self
+            .entries
+            .checked_add(count)
+            .ok_or(Error::Limit("entries"))?;
+        if self.entries > self.limits.entries {
+            return Err(Error::Limit("entries"));
+        }
+        Ok(())
+    }
+
+    pub fn retain(&mut self, count: usize) -> Result<(), Error> {
+        self.output = self
+            .output
+            .checked_add(count)
+            .ok_or(Error::Limit("output bytes"))?;
+        if self.output > self.limits.output_bytes {
+            return Err(Error::Limit("output bytes"));
+        }
+        Ok(())
+    }
+
+    pub fn expanded(&mut self, count: usize) -> Result<(), Error> {
+        if count > self.limits.read_bytes.saturating_sub(self.expanded) {
+            return Err(Error::Limit("expanded bytes"));
+        }
+        self.expanded += count;
+        Ok(())
+    }
+
+    pub fn expansion_limit(&self) -> usize {
+        self.limits.read_bytes - self.expanded
+    }
+
+    pub fn recover(&mut self, offset: u64, result: Result<(), Error>) -> Result<(), Error> {
+        match result {
+            Ok(()) => Ok(()),
+            Err(Error::Malformed(message) | Error::Unsupported(message)) => {
+                self.retain(std::mem::size_of::<Issue>())?;
+                self.metadata.issues.push(Issue { offset, message });
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub(crate) fn range(base: u64, length: u64, offset: u64, count: u64) -> Result<u64, Error> {
+    if offset > length || count > length - offset {
+        return Err(Error::Malformed("offset"));
+    }
+    base.checked_add(offset)
+        .ok_or(Error::Malformed("offset overflow"))
+}
+
+pub(crate) fn be16(bytes: &[u8]) -> u16 {
+    u16::from_be_bytes([bytes[0], bytes[1]])
+}
+pub(crate) fn be32(bytes: &[u8]) -> u32 {
+    u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+pub(crate) fn le32(bytes: &[u8]) -> u32 {
+    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+}
+
+pub(crate) struct Cursor<'a> {
+    pub bytes: &'a [u8],
+    pub pos: usize,
+}
+impl<'a> Cursor<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+    pub fn take(&mut self, count: usize) -> Result<&'a [u8], Error> {
+        let end = self
+            .pos
+            .checked_add(count)
+            .ok_or(Error::Malformed("length"))?;
+        let bytes = self
+            .bytes
+            .get(self.pos..end)
+            .ok_or(Error::Malformed("truncated field"))?;
+        self.pos = end;
+        Ok(bytes)
+    }
+    pub fn number(&mut self, width: usize) -> Result<u64, Error> {
+        if width > 8 {
+            return Err(Error::Unsupported("integer width"));
+        }
+        Ok(self
+            .take(width)?
+            .iter()
+            .fold(0, |value, b| (value << 8) | u64::from(*b)))
+    }
+    pub fn string(&mut self) -> Result<&'a str, Error> {
+        std::str::from_utf8(self.terminated_bytes()?).map_err(|_| Error::Malformed("UTF-8"))
+    }
+    pub fn terminated_bytes(&mut self) -> Result<&'a [u8], Error> {
+        let length = self.bytes[self.pos..]
+            .iter()
+            .position(|b| *b == 0)
+            .ok_or(Error::Malformed("terminated string"))?;
+        let bytes = self.take(length + 1)?;
+        Ok(&bytes[..length])
+    }
+}

--- a/rust/crates/exif/src/read.rs
+++ b/rust/crates/exif/src/read.rs
@@ -119,7 +119,7 @@ impl<'a, R: Read + Seek> Reader<'a, R> {
         Ok(())
     }
 
-    fn check(&self, offset: u64, count: usize) -> Result<(), Error> {
+    pub fn check(&self, offset: u64, count: usize) -> Result<(), Error> {
         if offset > self.len || count as u64 > self.len - offset {
             return Err(Error::Malformed("range"));
         }

--- a/rust/crates/exif/src/tags.rs
+++ b/rust/crates/exif/src/tags.rs
@@ -1,0 +1,258 @@
+use crate::{TextEncoding, text};
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Ifd {
+    Image(u16),
+    Exif(u16),
+    Gps(u16),
+    Interop(u16),
+}
+
+impl Ifd {
+    pub(crate) fn image(self) -> u16 {
+        match self {
+            Self::Image(n) | Self::Exif(n) | Self::Gps(n) | Self::Interop(n) => n,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Tag {
+    pub ifd: Ifd,
+    pub id: u16,
+    pub field_type: u16,
+    pub count: u32,
+    pub value: Value,
+}
+
+impl Tag {
+    pub fn name(&self) -> Option<&'static str> {
+        name(self.ifd, self.id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Unsigned(Vec<u32>),
+    Signed(Vec<i32>),
+    Rational(Vec<Rational>),
+    Float(Vec<f64>),
+    /// Original bytes, including any TIFF string terminator.
+    Ascii(Vec<u8>),
+    Bytes(Vec<u8>),
+    /// Opaque/unknown binary fields are described without retaining their payload.
+    Omitted {
+        bytes: u64,
+    },
+}
+
+impl Value {
+    /// Reads one finite number without allocating a converted vector.
+    pub fn number(&self, index: usize) -> Option<f64> {
+        match self {
+            Self::Unsigned(v) => v.get(index).map(|n| f64::from(*n)),
+            Self::Signed(v) => v.get(index).map(|n| f64::from(*n)),
+            Self::Rational(v) => v.get(index)?.as_f64(),
+            Self::Float(v) => v.get(index).copied().filter(|n| n.is_finite()),
+            _ => None,
+        }
+    }
+
+    pub fn unsigned(&self) -> Option<u32> {
+        match self {
+            Self::Unsigned(v) if v.len() == 1 => Some(v[0]),
+            _ => None,
+        }
+    }
+
+    pub fn text(&self) -> Option<&str> {
+        let Self::Ascii(bytes) = self else {
+            return None;
+        };
+        let end = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
+        std::str::from_utf8(&bytes[..end]).ok()
+    }
+
+    /// Decode a TIFF ASCII field up to its first NUL. Legacy encodings are a
+    /// caller-selected compatibility policy; TIFF specifies ASCII.
+    /// ASCII and UTF-8 results borrow the original bytes.
+    ///
+    /// ```rust
+    /// use ente_exif::{Metadata, TextEncoding, Value};
+    ///
+    /// let value = Value::Ascii(b"Caf\xe9\0".to_vec());
+    /// assert_eq!(value.text_with(TextEncoding::Latin1).as_deref(), Some("Café"));
+    /// let metadata = Metadata::default();
+    /// let caption = metadata.iptc_caption(TextEncoding::Windows1252);
+    /// ```
+    pub fn text_with(&self, encoding: TextEncoding) -> Option<Cow<'_, str>> {
+        let Self::Ascii(bytes) = self else {
+            return None;
+        };
+        let end = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
+        text::decode(&bytes[..end], encoding)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rational {
+    pub numerator: i64,
+    pub denominator: i64,
+}
+
+impl Rational {
+    pub fn as_f64(self) -> Option<f64> {
+        (self.denominator != 0).then(|| self.numerator as f64 / self.denominator as f64)
+    }
+}
+
+pub(crate) fn selected(ifd: Ifd, id: u16) -> bool {
+    if ifd.image() != 0 {
+        return false;
+    }
+    match ifd {
+        Ifd::Image(_) => matches!(
+            id,
+            0x100 | 0x101 | 0x10e | 0x10f | 0x110 | 0x112 | 0x132 | 0x13b | 0x8298
+        ),
+        Ifd::Exif(_) => {
+            matches!(id, 0x829a | 0x829d | 0x8827 | 0x9003 | 0x9004 | 0x9010..=0x9012 | 0x920a | 0x9290..=0x9292 | 0xa001..=0xa003 | 0xa401 | 0xa405 | 0xa434)
+        }
+        Ifd::Gps(_) => matches!(id, 1..=7 | 18),
+        Ifd::Interop(_) => false,
+    }
+}
+
+pub(crate) fn name(ifd: Ifd, id: u16) -> Option<&'static str> {
+    Some(match ifd {
+        Ifd::Gps(_) => match id {
+            0 => "GPSVersionID",
+            1 => "GPSLatitudeRef",
+            2 => "GPSLatitude",
+            3 => "GPSLongitudeRef",
+            4 => "GPSLongitude",
+            5 => "GPSAltitudeRef",
+            6 => "GPSAltitude",
+            7 => "GPSTimeStamp",
+            8 => "GPSSatellites",
+            9 => "GPSStatus",
+            10 => "GPSMeasureMode",
+            11 => "GPSDOP",
+            12 => "GPSSpeedRef",
+            13 => "GPSSpeed",
+            14 => "GPSTrackRef",
+            15 => "GPSTrack",
+            16 => "GPSImgDirectionRef",
+            17 => "GPSImgDirection",
+            18 => "GPSMapDatum",
+            29 => "GPSDateStamp",
+            30 => "GPSDifferential",
+            31 => "GPSHPositioningError",
+            _ => return None,
+        },
+        Ifd::Interop(_) => match id {
+            1 => "InteroperabilityIndex",
+            2 => "InteroperabilityVersion",
+            _ => return None,
+        },
+        Ifd::Image(_) | Ifd::Exif(_) => match id {
+            0x100 => "ImageWidth",
+            0x101 => "ImageLength",
+            0x102 => "BitsPerSample",
+            0x103 => "Compression",
+            0x106 => "PhotometricInterpretation",
+            0x10e => "ImageDescription",
+            0x10f => "Make",
+            0x110 => "Model",
+            0x111 => "StripOffsets",
+            0x112 => "Orientation",
+            0x115 => "SamplesPerPixel",
+            0x116 => "RowsPerStrip",
+            0x117 => "StripByteCounts",
+            0x11a => "XResolution",
+            0x11b => "YResolution",
+            0x11c => "PlanarConfiguration",
+            0x128 => "ResolutionUnit",
+            0x12d => "TransferFunction",
+            0x131 => "Software",
+            0x132 => "DateTime",
+            0x13b => "Artist",
+            0x13e => "WhitePoint",
+            0x13f => "PrimaryChromaticities",
+            0x14a => "SubIFDs",
+            0x201 => "JPEGInterchangeFormat",
+            0x202 => "JPEGInterchangeFormatLength",
+            0x211 => "YCbCrCoefficients",
+            0x212 => "YCbCrSubSampling",
+            0x213 => "YCbCrPositioning",
+            0x214 => "ReferenceBlackWhite",
+            0x2bc => "XMP",
+            0x8298 => "Copyright",
+            0x829a => "ExposureTime",
+            0x829d => "FNumber",
+            0x8769 => "ExifIFDPointer",
+            0x8822 => "ExposureProgram",
+            0x8824 => "SpectralSensitivity",
+            0x8825 => "GPSInfoIFDPointer",
+            0x8827 => "ISOSpeedRatings",
+            0x8830 => "SensitivityType",
+            0x8831 => "StandardOutputSensitivity",
+            0x8832 => "RecommendedExposureIndex",
+            0x8833 => "ISOSpeed",
+            0x9000 => "ExifVersion",
+            0x9003 => "DateTimeOriginal",
+            0x9004 => "DateTimeDigitized",
+            0x9010 => "OffsetTime",
+            0x9011 => "OffsetTimeOriginal",
+            0x9012 => "OffsetTimeDigitized",
+            0x9101 => "ComponentsConfiguration",
+            0x9102 => "CompressedBitsPerPixel",
+            0x9201 => "ShutterSpeedValue",
+            0x9202 => "ApertureValue",
+            0x9203 => "BrightnessValue",
+            0x9204 => "ExposureBiasValue",
+            0x9205 => "MaxApertureValue",
+            0x9206 => "SubjectDistance",
+            0x9207 => "MeteringMode",
+            0x9208 => "LightSource",
+            0x9209 => "Flash",
+            0x920a => "FocalLength",
+            0x9214 => "SubjectArea",
+            0x927c => "MakerNote",
+            0x9286 => "UserComment",
+            0x9290 => "SubSecTime",
+            0x9291 => "SubSecTimeOriginal",
+            0x9292 => "SubSecTimeDigitized",
+            0xa000 => "FlashpixVersion",
+            0xa001 => "ColorSpace",
+            0xa002 => "PixelXDimension",
+            0xa003 => "PixelYDimension",
+            0xa005 => "InteroperabilityIFDPointer",
+            0xa20e => "FocalPlaneXResolution",
+            0xa20f => "FocalPlaneYResolution",
+            0xa210 => "FocalPlaneResolutionUnit",
+            0xa217 => "SensingMethod",
+            0xa300 => "FileSource",
+            0xa301 => "SceneType",
+            0xa401 => "CustomRendered",
+            0xa402 => "ExposureMode",
+            0xa403 => "WhiteBalance",
+            0xa404 => "DigitalZoomRatio",
+            0xa405 => "FocalLengthIn35mmFilm",
+            0xa406 => "SceneCaptureType",
+            0xa407 => "GainControl",
+            0xa408 => "Contrast",
+            0xa409 => "Saturation",
+            0xa40a => "Sharpness",
+            0xa420 => "ImageUniqueID",
+            0xa430 => "CameraOwnerName",
+            0xa431 => "BodySerialNumber",
+            0xa432 => "LensSpecification",
+            0xa433 => "LensMake",
+            0xa434 => "LensModel",
+            0xa435 => "LensSerialNumber",
+            _ => return None,
+        },
+    })
+}

--- a/rust/crates/exif/src/tags.rs
+++ b/rust/crates/exif/src/tags.rs
@@ -38,17 +38,12 @@ pub enum Value {
     Signed(Vec<i32>),
     Rational(Vec<Rational>),
     Float(Vec<f64>),
-    /// Original bytes, including any TIFF string terminator.
     Ascii(Vec<u8>),
     Bytes(Vec<u8>),
-    /// Opaque/unknown binary fields are described without retaining their payload.
-    Omitted {
-        bytes: u64,
-    },
+    Omitted { bytes: u64 },
 }
 
 impl Value {
-    /// Reads one finite number without allocating a converted vector.
     pub fn number(&self, index: usize) -> Option<f64> {
         match self {
             Self::Unsigned(v) => v.get(index).map(|n| f64::from(*n)),
@@ -73,19 +68,6 @@ impl Value {
         let end = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
         std::str::from_utf8(&bytes[..end]).ok()
     }
-
-    /// Decode a TIFF ASCII field up to its first NUL. Legacy encodings are a
-    /// caller-selected compatibility policy; TIFF specifies ASCII.
-    /// ASCII and UTF-8 results borrow the original bytes.
-    ///
-    /// ```rust
-    /// use ente_exif::{Metadata, TextEncoding, Value};
-    ///
-    /// let value = Value::Ascii(b"Caf\xe9\0".to_vec());
-    /// assert_eq!(value.text_with(TextEncoding::Latin1).as_deref(), Some("Café"));
-    /// let metadata = Metadata::default();
-    /// let caption = metadata.iptc_caption(TextEncoding::Windows1252);
-    /// ```
     pub fn text_with(&self, encoding: TextEncoding) -> Option<Cow<'_, str>> {
         let Self::Ascii(bytes) = self else {
             return None;

--- a/rust/crates/exif/src/text.rs
+++ b/rust/crates/exif/src/text.rs
@@ -1,6 +1,4 @@
 use std::borrow::Cow;
-
-/// Explicit decoding for metadata bytes. No character-set detection is performed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TextEncoding {
     Ascii,
@@ -16,7 +14,6 @@ pub(crate) fn decode(bytes: &[u8], encoding: TextEncoding) -> Option<Cow<'_, str
     if encoding == TextEncoding::Ascii {
         return None;
     }
-    // https://encoding.spec.whatwg.org/index-windows-1252.txt
     const C1: [char; 32] = [
         '€', '\u{81}', '‚', 'ƒ', '„', '…', '†', '‡', 'ˆ', '‰', 'Š', '‹', 'Œ', '\u{8d}', 'Ž',
         '\u{8f}', '\u{90}', '‘', '’', '“', '”', '•', '–', '—', '˜', '™', 'š', '›', 'œ', '\u{9d}',

--- a/rust/crates/exif/src/text.rs
+++ b/rust/crates/exif/src/text.rs
@@ -1,0 +1,37 @@
+use std::borrow::Cow;
+
+/// Explicit decoding for metadata bytes. No character-set detection is performed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextEncoding {
+    Ascii,
+    Utf8,
+    Latin1,
+    Windows1252,
+}
+
+pub(crate) fn decode(bytes: &[u8], encoding: TextEncoding) -> Option<Cow<'_, str>> {
+    if encoding == TextEncoding::Utf8 || bytes.is_ascii() {
+        return std::str::from_utf8(bytes).ok().map(Cow::Borrowed);
+    }
+    if encoding == TextEncoding::Ascii {
+        return None;
+    }
+    // https://encoding.spec.whatwg.org/index-windows-1252.txt
+    const C1: [char; 32] = [
+        '€', '\u{81}', '‚', 'ƒ', '„', '…', '†', '‡', 'ˆ', '‰', 'Š', '‹', 'Œ', '\u{8d}', 'Ž',
+        '\u{8f}', '\u{90}', '‘', '’', '“', '”', '•', '–', '—', '˜', '™', 'š', '›', 'œ', '\u{9d}',
+        'ž', 'Ÿ',
+    ];
+    Some(Cow::Owned(
+        bytes
+            .iter()
+            .map(|&b| {
+                if encoding == TextEncoding::Windows1252 && (0x80..=0x9f).contains(&b) {
+                    C1[usize::from(b - 0x80)]
+                } else {
+                    char::from(b)
+                }
+            })
+            .collect(),
+    ))
+}

--- a/rust/crates/exif/src/tiff.rs
+++ b/rust/crates/exif/src/tiff.rs
@@ -1,0 +1,316 @@
+use crate::Mode;
+use crate::read::{Error, Reader, State, be32, range};
+use crate::tags::{self, Ifd, Rational, Tag, Value};
+use std::io::{Read, Seek};
+
+pub(crate) fn read_bytes(bytes: &[u8], state: &mut State) -> Result<(), Error> {
+    let mut source = std::io::Cursor::new(bytes);
+    let mut reader = Reader::new(&mut source, state.limits)?;
+    read(&mut reader, state, 0, bytes.len() as u64)
+}
+
+pub(crate) fn exif_block<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    start: u64,
+    len: u64,
+) -> Result<(), Error> {
+    let offset = u64::from(be32(&reader.array::<4>(range(start, len, 0, 4)?)?)) + 4;
+    let base = range(start, len, offset, 8)?;
+    read(reader, state, base, len - offset)
+}
+
+pub(crate) fn read<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+    base: u64,
+    len: u64,
+) -> Result<(), Error> {
+    let header = reader.array::<8>(range(base, len, 0, 8)?)?;
+    let endian = match &header[..2] {
+        b"II" => Endian::Little,
+        b"MM" => Endian::Big,
+        _ => return Err(Error::Malformed("TIFF byte order")),
+    };
+    match endian.u16(&header[2..]) {
+        42 => {}
+        43 => return Err(Error::Unsupported("BigTIFF")),
+        _ => return Err(Error::Malformed("TIFF magic")),
+    }
+    let mut tiff = Tiff {
+        base,
+        len,
+        endian,
+        pending: vec![(u64::from(endian.u32(&header[4..])), Ifd::Image(0), 0)],
+        seen: Vec::new(),
+        image_index: 0,
+    };
+    while let Some((offset, ifd, depth)) = tiff.pending.pop() {
+        if offset == 0 {
+            continue;
+        }
+        if tiff.seen.contains(&offset) {
+            return Err(Error::Malformed("cyclic IFD"));
+        }
+        if tiff.seen.len() >= state.limits.directories {
+            return Err(Error::Limit("directories"));
+        }
+        if depth >= state.limits.depth {
+            return Err(Error::Limit("IFD depth"));
+        }
+        tiff.seen.push(offset);
+        let result = tiff.read_ifd(reader, state, offset, ifd, depth);
+        state.recover(base, result)?;
+    }
+    Ok(())
+}
+
+struct Tiff {
+    base: u64,
+    len: u64,
+    endian: Endian,
+    pending: Vec<(u64, Ifd, usize)>,
+    seen: Vec<u64>,
+    image_index: u16,
+}
+
+impl Tiff {
+    fn read_ifd<R: Read + Seek>(
+        &mut self,
+        reader: &mut Reader<'_, R>,
+        state: &mut State,
+        offset: u64,
+        ifd: Ifd,
+        depth: usize,
+    ) -> Result<(), Error> {
+        let count = usize::from(
+            self.endian
+                .u16(&reader.array::<2>(range(self.base, self.len, offset, 2)?)?),
+        );
+        state.entries(count)?;
+        let table_size = count * 12 + 4;
+        let table = reader.bytes(
+            range(self.base, self.len, offset + 2, table_size as u64)?,
+            table_size,
+        )?;
+        for entry in table[..count * 12].as_chunks::<12>().0 {
+            let id = self.endian.u16(entry);
+            let field_type = self.endian.u16(&entry[2..]);
+            let count = self.endian.u32(&entry[4..]);
+            let width = match field_type {
+                1 | 2 | 6 | 7 => 1,
+                3 | 8 => 2,
+                4 | 9 | 11 | 13 => 4,
+                5 | 10 | 12 => 8,
+                _ => {
+                    state.recover(
+                        self.base + offset,
+                        Err(Error::Unsupported("TIFF field type")),
+                    )?;
+                    continue;
+                }
+            };
+            let bytes = u64::from(count) * width;
+            let pointer = matches!(id, 0x8769 | 0x8825 | 0xa005 | 0x14a);
+            let embedded = matches!(id, 0x2bc | 0x83bb | 0x8649);
+            if !pointer && !embedded && state.mode == Mode::Summary && !tags::selected(ifd, id) {
+                continue;
+            }
+            let omitted = !pointer
+                && !embedded
+                && (id == 0x927c
+                    || tags::name(ifd, id).is_none()
+                    || matches!(id, 0x111 | 0x117 | 0x144 | 0x145 | 0x201 | 0x202));
+            if omitted {
+                state.retain(std::mem::size_of::<Tag>())?;
+                state.metadata.tags.push(Tag {
+                    ifd,
+                    id,
+                    field_type,
+                    count,
+                    value: Value::Omitted { bytes },
+                });
+                continue;
+            }
+            if bytes > state.limits.value_bytes as u64 && !embedded {
+                return Err(Error::Limit("tag value"));
+            }
+            let location = if bytes <= 4 {
+                None
+            } else {
+                Some(u64::from(self.endian.u32(&entry[8..])))
+            };
+            let data = match location {
+                None => entry[8..8 + bytes as usize].to_vec(),
+                Some(position) => {
+                    let position = match range(self.base, self.len, position, bytes) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            state.recover(self.base + offset, Err(e))?;
+                            continue;
+                        }
+                    };
+                    reader.bytes(
+                        position,
+                        usize::try_from(bytes).map_err(|_| Error::Limit("tag value"))?,
+                    )?
+                }
+            };
+            if embedded {
+                let result = match id {
+                    0x2bc => crate::xmp::read(&data, state),
+                    0x83bb => crate::iptc::read(&data, state),
+                    _ => crate::photoshop::read(&data, state),
+                };
+                state.recover(location.unwrap_or(offset) + self.base, result)?;
+                continue;
+            }
+            if pointer {
+                if !matches!(field_type, 4 | 13) {
+                    state.recover(
+                        self.base + offset,
+                        Err(Error::Malformed("IFD pointer type")),
+                    )?;
+                    continue;
+                }
+                for bytes in data.as_chunks::<4>().0 {
+                    if self.pending.len() + self.seen.len() >= state.limits.directories {
+                        return Err(Error::Limit("directories"));
+                    }
+                    let child = match id {
+                        0x8769 => Ifd::Exif(ifd.image()),
+                        0x8825 => Ifd::Gps(ifd.image()),
+                        0xa005 => Ifd::Interop(ifd.image()),
+                        _ => {
+                            self.image_index = self
+                                .image_index
+                                .checked_add(1)
+                                .ok_or(Error::Limit("image indices"))?;
+                            Ifd::Image(self.image_index)
+                        }
+                    };
+                    if state.mode == Mode::Details || child.image() == 0 {
+                        self.pending
+                            .push((u64::from(self.endian.u32(bytes)), child, depth + 1));
+                    }
+                }
+                continue;
+            }
+            state.retain(std::mem::size_of::<Tag>() + data.len() * 4)?;
+            state.metadata.tags.push(Tag {
+                ifd,
+                id,
+                field_type,
+                count,
+                value: decode(self.endian, field_type, data),
+            });
+        }
+        let next = self.endian.u32(&table[count * 12..]);
+        if next != 0 && state.mode == Mode::Details {
+            self.image_index = self
+                .image_index
+                .checked_add(1)
+                .ok_or(Error::Limit("image indices"))?;
+            self.pending
+                .push((u64::from(next), Ifd::Image(self.image_index), depth + 1));
+        }
+        Ok(())
+    }
+}
+
+fn decode(endian: Endian, field_type: u16, data: Vec<u8>) -> Value {
+    match field_type {
+        1 => Value::Unsigned(data.into_iter().map(u32::from).collect()),
+        2 => Value::Ascii(data),
+        3 => Value::Unsigned(
+            data.as_chunks::<2>()
+                .0
+                .iter()
+                .map(|b| u32::from(endian.u16(b)))
+                .collect(),
+        ),
+        4 | 13 => Value::Unsigned(
+            data.as_chunks::<4>()
+                .0
+                .iter()
+                .map(|b| endian.u32(b))
+                .collect(),
+        ),
+        5 | 10 => Value::Rational(
+            data.as_chunks::<8>()
+                .0
+                .iter()
+                .map(|b| {
+                    let number = |b| {
+                        if field_type == 10 {
+                            i64::from(endian.u32(b) as i32)
+                        } else {
+                            i64::from(endian.u32(b))
+                        }
+                    };
+                    Rational {
+                        numerator: number(b),
+                        denominator: number(&b[4..]),
+                    }
+                })
+                .collect(),
+        ),
+        6 => Value::Signed(data.into_iter().map(|b| i32::from(b as i8)).collect()),
+        8 => Value::Signed(
+            data.as_chunks::<2>()
+                .0
+                .iter()
+                .map(|b| i32::from(endian.u16(b) as i16))
+                .collect(),
+        ),
+        9 => Value::Signed(
+            data.as_chunks::<4>()
+                .0
+                .iter()
+                .map(|b| endian.u32(b) as i32)
+                .collect(),
+        ),
+        11 => Value::Float(
+            data.as_chunks::<4>()
+                .0
+                .iter()
+                .map(|b| f64::from(f32::from_bits(endian.u32(b))))
+                .collect(),
+        ),
+        12 => Value::Float(
+            data.as_chunks::<8>()
+                .0
+                .iter()
+                .map(|b| {
+                    let a = endian.u32(b) as u64;
+                    let z = endian.u32(&b[4..]) as u64;
+                    f64::from_bits(match endian {
+                        Endian::Little => a | (z << 32),
+                        Endian::Big => (a << 32) | z,
+                    })
+                })
+                .collect(),
+        ),
+        _ => Value::Bytes(data),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Endian {
+    Little,
+    Big,
+}
+impl Endian {
+    fn u16(self, b: &[u8]) -> u16 {
+        match self {
+            Self::Little => u16::from_le_bytes([b[0], b[1]]),
+            Self::Big => u16::from_be_bytes([b[0], b[1]]),
+        }
+    }
+    fn u32(self, b: &[u8]) -> u32 {
+        match self {
+            Self::Little => u32::from_le_bytes([b[0], b[1], b[2], b[3]]),
+            Self::Big => u32::from_be_bytes([b[0], b[1], b[2], b[3]]),
+        }
+    }
+}

--- a/rust/crates/exif/src/webp.rs
+++ b/rust/crates/exif/src/webp.rs
@@ -1,0 +1,64 @@
+use crate::read::{Error, Reader, State, le32, range};
+use crate::{Dimensions, tiff, xmp};
+use std::io::{Read, Seek};
+
+pub(crate) fn read<R: Read + Seek>(
+    reader: &mut Reader<'_, R>,
+    state: &mut State,
+) -> Result<(), Error> {
+    let end = u64::from(le32(&reader.array::<4>(4)?)) + 8;
+    if end < 12 {
+        return Err(Error::Malformed("RIFF size"));
+    }
+    range(0, reader.len, 0, end)?;
+    let mut offset = 12;
+    while offset < end {
+        state.entries(1)?;
+        range(0, end, offset, 8)?;
+        let header = reader.array::<8>(offset)?;
+        let len = u64::from(le32(&header[4..]));
+        range(0, end, offset, 8 + len + (len & 1))?;
+        let start = offset + 8;
+        let result = match &header[..4] {
+            b"EXIF" => {
+                let prefix = reader.bytes(start, len.min(6) as usize)?;
+                let skip = if prefix == b"Exif\0\0" { 6 } else { 0 };
+                tiff::read(reader, state, start + skip, len - skip)
+            }
+            b"XMP " => xmp::read(&reader.bytes(start, len as usize)?, state),
+            b"VP8X" if len >= 10 => {
+                let data = reader.array::<10>(start)?;
+                let u24 =
+                    |b: &[u8]| u32::from(b[0]) | (u32::from(b[1]) << 8) | (u32::from(b[2]) << 16);
+                state.metadata.dimensions =
+                    Dimensions::new(u24(&data[4..]) + 1, u24(&data[7..]) + 1);
+                Ok(())
+            }
+            b"VP8 " if len >= 10 && state.metadata.dimensions.is_none() => {
+                let data = reader.array::<10>(start)?;
+                if data[3..6] != [0x9d, 0x01, 0x2a] {
+                    return Err(Error::Malformed("VP8 frame"));
+                }
+                state.metadata.dimensions = Dimensions::new(
+                    u32::from(u16::from_le_bytes([data[6], data[7]]) & 0x3fff),
+                    u32::from(u16::from_le_bytes([data[8], data[9]]) & 0x3fff),
+                );
+                Ok(())
+            }
+            b"VP8L" if len >= 5 && state.metadata.dimensions.is_none() => {
+                let data = reader.array::<5>(start)?;
+                if data[0] != 0x2f {
+                    return Err(Error::Malformed("VP8L frame"));
+                }
+                let bits = le32(&data[1..]);
+                state.metadata.dimensions =
+                    Dimensions::new((bits & 0x3fff) + 1, ((bits >> 14) & 0x3fff) + 1);
+                Ok(())
+            }
+            _ => Ok(()),
+        };
+        state.recover(offset, result)?;
+        offset += 8 + len + (len & 1);
+    }
+    Ok(())
+}

--- a/rust/crates/exif/src/xmp.rs
+++ b/rust/crates/exif/src/xmp.rs
@@ -27,14 +27,12 @@ pub struct Property {
     pub name: String,
     pub value: String,
     pub language: Option<String>,
-    /// Associates properties from the same RDF list item, preserving item order.
     pub item: Option<u32>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct XmpStructure {
     pub nodes: Vec<XmpNode>,
-    /// One parent-node index per entry in Metadata::xmp.
     pub parents: Vec<Option<u32>>,
 }
 

--- a/rust/crates/exif/src/xmp.rs
+++ b/rust/crates/exif/src/xmp.rs
@@ -1,0 +1,451 @@
+use crate::Mode;
+use crate::read::{Error, State};
+use quick_xml::events::Event;
+use quick_xml::name::ResolveResult;
+use quick_xml::{NsReader, XmlVersion};
+use std::borrow::Cow;
+
+pub mod namespace {
+    pub const EXIF: &str = "http://ns.adobe.com/exif/1.0/";
+    pub const EXIF_EX: &str = "http://cipa.jp/exif/1.0/";
+    pub const TIFF: &str = "http://ns.adobe.com/tiff/1.0/";
+    pub const XMP: &str = "http://ns.adobe.com/xap/1.0/";
+    pub const DC: &str = "http://purl.org/dc/elements/1.1/";
+    pub const PHOTOSHOP: &str = "http://ns.adobe.com/photoshop/1.0/";
+    pub const GPANO: &str = "http://ns.google.com/photos/1.0/panorama/";
+    pub const CAMERA: &str = "http://ns.google.com/photos/1.0/camera/";
+    pub const CONTAINER: &str = "http://ns.google.com/photos/1.0/container/";
+    pub const ITEM: &str = "http://ns.google.com/photos/1.0/container/item/";
+    pub const NOTE: &str = "http://ns.adobe.com/xmp/note/";
+    pub const RDF: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+    pub const XML: &str = "http://www.w3.org/XML/1998/namespace";
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Property {
+    pub namespace: String,
+    pub name: String,
+    pub value: String,
+    pub language: Option<String>,
+    /// Associates properties from the same RDF list item, preserving item order.
+    pub item: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct XmpStructure {
+    pub nodes: Vec<XmpNode>,
+    /// One parent-node index per entry in Metadata::xmp.
+    pub parents: Vec<Option<u32>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XmpNode {
+    pub namespace: String,
+    pub name: String,
+    pub parent: Option<u32>,
+    pub item: Option<u32>,
+}
+
+pub(crate) fn read(bytes: &[u8], state: &mut State) -> Result<(), Error> {
+    if bytes.len() > state.limits.read_bytes {
+        return Err(Error::Limit("XMP bytes"));
+    }
+    let text = text(bytes, state)?;
+    let mut reader = NsReader::from_str(text.trim_end_matches('\0'));
+    reader.resolver_mut().set_max_declarations_per_element(64);
+    let mut stack: Vec<Frame> = Vec::new();
+    let mut paths = Vec::new();
+    let mut item_id = state
+        .metadata
+        .xmp
+        .iter()
+        .filter_map(|p| p.item)
+        .max()
+        .unwrap_or(0);
+    let mut saw_rdf = false;
+    let mut saw_root = false;
+    loop {
+        state.entries(1)?;
+        let event = reader
+            .read_event()
+            .map_err(|_| Error::Malformed("XMP XML"))?;
+        let empty = matches!(event, Event::Empty(_));
+        match event {
+            Event::Start(element) | Event::Empty(element) => {
+                if stack.is_empty() {
+                    if saw_root {
+                        return Err(Error::Malformed("multiple XML roots"));
+                    }
+                    saw_root = true;
+                }
+                if stack.len() >= state.limits.depth {
+                    return Err(Error::Limit("XML depth"));
+                }
+                let (ns, local) = reader.resolver().resolve_element(element.name());
+                let ns = namespace_text(ns)?;
+                let name = std::str::from_utf8(local.as_ref())
+                    .map_err(|_| Error::Malformed("XML name"))?;
+                if ns.len() + name.len() > state.limits.value_bytes {
+                    return Err(Error::Limit("XML name"));
+                }
+                saw_rdf |= ns == namespace::RDF && name == "RDF";
+                let item = if ns == namespace::RDF && name == "li" {
+                    item_id = item_id.checked_add(1).ok_or(Error::Limit("RDF items"))?;
+                    Some(item_id)
+                } else {
+                    stack.last().and_then(|f| f.item)
+                };
+                let mut language = stack.last().and_then(|f| f.language.clone());
+                for attribute in element.attributes() {
+                    let attribute = attribute.map_err(|_| Error::Malformed("XML attribute"))?;
+                    if attribute.key.as_ref() == b"xml:lang" {
+                        if attribute.value.len() > state.limits.value_bytes {
+                            return Err(Error::Limit("XML language"));
+                        }
+                        language = Some(
+                            attribute
+                                .decoded_and_normalized_value(
+                                    XmlVersion::Implicit1_0,
+                                    reader.decoder(),
+                                )
+                                .map_err(|_| Error::Malformed("XML language"))?
+                                .into_owned(),
+                        );
+                    }
+                }
+                if state.structure.is_some() {
+                    let key = if ns == "adobe:ns:meta/"
+                        || (ns == namespace::RDF && !matches!(name, "Bag" | "Seq" | "Alt" | "li"))
+                    {
+                        None
+                    } else {
+                        Some((ns.to_owned(), name.to_owned()))
+                    };
+                    paths.push(PathFrame {
+                        key,
+                        item,
+                        node: None,
+                        ready: false,
+                    });
+                }
+                let key = if ns == namespace::RDF {
+                    stack.last().and_then(|f| f.key.clone())
+                } else if ns == "adobe:ns:meta/" || !wanted(state.mode, ns, name) {
+                    None
+                } else {
+                    Some((ns.to_owned(), name.to_owned()))
+                };
+                stack.push(Frame {
+                    key,
+                    language,
+                    item,
+                    text: String::new(),
+                });
+                for attribute in element.attributes() {
+                    state.entries(1)?;
+                    let attribute = attribute.map_err(|_| Error::Malformed("XML attribute"))?;
+                    if attribute.key.as_ref() == b"xmlns"
+                        || attribute.key.as_ref().starts_with(b"xmlns:")
+                    {
+                        continue;
+                    }
+                    let (ans, aname) = reader.resolver().resolve_attribute(attribute.key);
+                    let ans = namespace_text(ans)?;
+                    let aname = std::str::from_utf8(aname.as_ref())
+                        .map_err(|_| Error::Malformed("XML attribute name"))?;
+                    let (ans, aname) = if ans == namespace::RDF && aname == "resource" {
+                        let Some((ns, name)) = stack.last().and_then(|f| f.key.as_ref()) else {
+                            continue;
+                        };
+                        (ns.as_str(), name.as_str())
+                    } else if ans == namespace::RDF || ans == namespace::XML || ans.is_empty() {
+                        continue;
+                    } else {
+                        (ans, aname)
+                    };
+                    if !wanted(state.mode, ans, aname) {
+                        continue;
+                    }
+                    if attribute.value.len() > state.limits.value_bytes {
+                        return Err(Error::Limit("XML attribute"));
+                    }
+                    let value = attribute
+                        .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
+                        .map_err(|_| Error::Malformed("XML attribute value"))?;
+                    let language = stack.last().and_then(|f| f.language.as_deref());
+                    store(state, ans, aname, &value, language, item)?;
+                    if state.structure.is_some() {
+                        let parent = path(&mut paths, state)?;
+                        *state
+                            .structure
+                            .as_mut()
+                            .unwrap()
+                            .parents
+                            .last_mut()
+                            .unwrap() = parent;
+                    }
+                }
+                if empty {
+                    finish(&mut stack, &mut paths, state)?;
+                }
+            }
+            Event::End(_) => {
+                finish(&mut stack, &mut paths, state)?;
+            }
+            Event::Text(text) => {
+                if stack.last().is_some_and(|f| f.key.is_none()) {
+                    continue;
+                }
+                let text = text
+                    .xml_content(XmlVersion::Implicit1_0)
+                    .map_err(|_| Error::Malformed("XML text"))?;
+                append(&mut stack, &text, state)?;
+            }
+            Event::CData(text) => {
+                if stack.last().is_some_and(|f| f.key.is_none()) {
+                    continue;
+                }
+                let text = text.decode().map_err(|_| Error::Malformed("XML CDATA"))?;
+                append(&mut stack, &text, state)?;
+            }
+            Event::GeneralRef(entity) => {
+                let text = if let Some(c) = entity
+                    .resolve_char_ref()
+                    .map_err(|_| Error::Malformed("XML character reference"))?
+                {
+                    c.to_string()
+                } else {
+                    match entity.as_ref() {
+                        b"amp" => "&",
+                        b"lt" => "<",
+                        b"gt" => ">",
+                        b"apos" => "'",
+                        b"quot" => "\"",
+                        _ => return Err(Error::Unsupported("XML entity")),
+                    }
+                    .to_owned()
+                };
+                append(&mut stack, &text, state)?;
+            }
+            Event::DocType(_) => return Err(Error::Unsupported("XML DTD")),
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    if !stack.is_empty() {
+        return Err(Error::Malformed("unclosed XML"));
+    }
+    if !saw_rdf {
+        return Err(Error::Unsupported("XMP document"));
+    }
+    Ok(())
+}
+
+fn text<'a>(bytes: &'a [u8], state: &mut State) -> Result<Cow<'a, str>, Error> {
+    let little = bytes.starts_with(b"\xff\xfe");
+    if !little && !bytes.starts_with(b"\xfe\xff") {
+        return std::str::from_utf8(bytes)
+            .map(Cow::Borrowed)
+            .map_err(|_| Error::Unsupported("XMP encoding"));
+    }
+    if !bytes.len().is_multiple_of(2) {
+        return Err(Error::Malformed("UTF-16 XMP"));
+    }
+    let units = bytes[2..].as_chunks::<2>().0.iter().map(|b| {
+        if little {
+            u16::from_le_bytes(*b)
+        } else {
+            u16::from_be_bytes(*b)
+        }
+    });
+    let mut decoded = String::with_capacity(bytes.len());
+    for ch in char::decode_utf16(units) {
+        let ch = ch.map_err(|_| Error::Malformed("UTF-16 XMP"))?;
+        if decoded.len() + ch.len_utf8() > state.limits.read_bytes {
+            return Err(Error::Limit("XMP bytes"));
+        }
+        decoded.push(ch);
+    }
+    state.expanded(decoded.len())?;
+    Ok(Cow::Owned(decoded))
+}
+
+pub(crate) fn store(
+    state: &mut State,
+    ns: &str,
+    name: &str,
+    value: &str,
+    language: Option<&str>,
+    item: Option<u32>,
+) -> Result<(), Error> {
+    if !wanted(state.mode, ns, name) {
+        return Ok(());
+    }
+    if value.len() > state.limits.value_bytes {
+        return Err(Error::Limit("property value"));
+    }
+    state.retain(
+        std::mem::size_of::<Property>()
+            + ns.len()
+            + name.len()
+            + value.len()
+            + language.map_or(0, str::len),
+    )?;
+    if state.structure.is_some() {
+        state.retain(std::mem::size_of::<Option<u32>>())?;
+        state.structure.as_mut().unwrap().parents.push(None);
+    }
+    state.metadata.xmp.push(Property {
+        namespace: ns.to_owned(),
+        name: name.to_owned(),
+        value: value.to_owned(),
+        language: language.map(str::to_owned),
+        item,
+    });
+    Ok(())
+}
+
+fn wanted(mode: Mode, ns: &str, name: &str) -> bool {
+    if ns == namespace::CAMERA && name == "HdrPlusMakernote" {
+        return false;
+    }
+    mode == Mode::Details || selected(ns, name)
+}
+
+fn selected(ns: &str, name: &str) -> bool {
+    match ns {
+        namespace::EXIF | namespace::EXIF_EX | namespace::TIFF => matches!(
+            name,
+            "DateTimeOriginal"
+                | "DateTimeDigitized"
+                | "DateTime"
+                | "ImageWidth"
+                | "ImageLength"
+                | "PixelXDimension"
+                | "PixelYDimension"
+                | "Orientation"
+                | "GPSLatitude"
+                | "GPSLongitude"
+                | "GPSLatitudeRef"
+                | "GPSLongitudeRef"
+                | "Make"
+                | "Model"
+        ),
+        namespace::XMP => matches!(name, "CreateDate" | "ModifyDate" | "MetadataDate"),
+        namespace::PHOTOSHOP => name == "DateCreated",
+        namespace::DC => name == "description",
+        namespace::GPANO => name == "ProjectionType",
+        namespace::CAMERA => matches!(
+            name,
+            "MotionPhoto"
+                | "MicroVideo"
+                | "MicroVideoOffset"
+                | "MotionPhotoPresentationTimestampUs"
+        ),
+        namespace::ITEM => matches!(name, "Mime" | "Semantic" | "Length" | "Padding"),
+        namespace::NOTE => name == "HasExtendedXMP",
+        _ => false,
+    }
+}
+
+struct Frame {
+    key: Option<(String, String)>,
+    language: Option<String>,
+    item: Option<u32>,
+    text: String,
+}
+
+struct PathFrame {
+    key: Option<(String, String)>,
+    item: Option<u32>,
+    node: Option<u32>,
+    ready: bool,
+}
+
+fn path(stack: &mut [PathFrame], state: &mut State) -> Result<Option<u32>, Error> {
+    let Some((frame, rest)) = stack.split_last_mut() else {
+        return Ok(None);
+    };
+    if frame.ready {
+        return Ok(frame.node);
+    }
+    let parent = path(rest, state)?;
+    frame.ready = true;
+    let Some((ns, name)) = &frame.key else {
+        frame.node = parent;
+        return Ok(parent);
+    };
+    state.retain(std::mem::size_of::<XmpNode>() + ns.len() + name.len())?;
+    let nodes = &mut state.structure.as_mut().unwrap().nodes;
+    let index = u32::try_from(nodes.len()).map_err(|_| Error::Limit("XMP nodes"))?;
+    nodes.push(XmpNode {
+        namespace: ns.to_owned(),
+        name: name.to_owned(),
+        parent,
+        item: frame.item,
+    });
+    frame.node = Some(index);
+    Ok(Some(index))
+}
+
+fn append(stack: &mut [Frame], text: &str, state: &State) -> Result<(), Error> {
+    if let Some(frame) = stack.last_mut() {
+        if frame.key.is_none() {
+            return Ok(());
+        }
+        if text.len() > state.limits.value_bytes.saturating_sub(frame.text.len()) {
+            return Err(Error::Limit("XML text"));
+        }
+        frame.text.push_str(text);
+    } else if !text.trim().is_empty() {
+        return Err(Error::Malformed("XML text outside root"));
+    }
+    Ok(())
+}
+
+fn finish(
+    stack: &mut Vec<Frame>,
+    paths: &mut Vec<PathFrame>,
+    state: &mut State,
+) -> Result<(), Error> {
+    let frame = stack.pop().ok_or(Error::Malformed("XML nesting"))?;
+    if let Some((ns, name)) = frame.key
+        && !frame.text.trim().is_empty()
+    {
+        store(
+            state,
+            &ns,
+            &name,
+            frame.text.trim(),
+            frame.language.as_deref(),
+            frame.item,
+        )?;
+        if state.structure.is_some() {
+            let is_item = paths
+                .last()
+                .and_then(|p| p.key.as_ref())
+                .is_some_and(|(ns, n)| ns == namespace::RDF && n == "li");
+            let len = paths.len() - usize::from(!is_item);
+            let parent = path(&mut paths[..len], state)?;
+            *state
+                .structure
+                .as_mut()
+                .unwrap()
+                .parents
+                .last_mut()
+                .unwrap() = parent;
+        }
+    }
+    paths.pop();
+    Ok(())
+}
+
+fn namespace_text(ns: ResolveResult<'_>) -> Result<&str, Error> {
+    match ns {
+        ResolveResult::Bound(ns) => {
+            std::str::from_utf8(ns.0).map_err(|_| Error::Malformed("XML namespace"))
+        }
+        ResolveResult::Unbound => Ok(""),
+        ResolveResult::Unknown(_) => Err(Error::Malformed("undeclared XML namespace")),
+    }
+}

--- a/rust/crates/exif/tests/README.md
+++ b/rust/crates/exif/tests/README.md
@@ -1,0 +1,48 @@
+# Test fixtures
+
+Generate small inputs from format specifications and explicit API contracts, with
+independently calculable expected values. Use common scenarios or independently
+documented behavior; do not copy fixtures or distinctive cases from other projects.
+Malformed lengths, truncations, cycles and budgets exercise parser invariants.
+
+One integration-test binary shares the fixture builders. The inputs describe
+metadata layouts, not fully decodable media: PNG CRCs and video sample tables are
+not populated. Motion tests establish byte ranges, not playback or proprietary
+vendor conformance. Truncation/mutation sweeps are deterministic regression checks,
+not coverage-guided fuzzing.
+
+## References
+
+- ISO/IEC 18181-1:2024 Annex D and 18181-2:2021 clauses 8–9: JPEG XL
+  dimensions/orientation, boxes and ordered partial codestreams.
+- [RFC 7932 §§9.1–9.3](https://www.rfc-editor.org/rfc/rfc7932.html): Brotli windows
+  and stored blocks. The inline compressed sample is its test XML plus 40,000
+  spaces, generated with `brotli -q 5 -w 16`; tests need no encoder.
+- [PNG textual profiles](https://exiftool.org/TagNames/PNG.html#TextualData) and
+  [Exiv2's metadata book](https://clanmills.com/exiv2/book/#PNG): ImageMagick raw profiles.
+- [WHATWG Windows-1252](https://encoding.spec.whatwg.org/index-windows-1252.txt):
+  explicit legacy decoding, a caller compatibility choice for TIFF ASCII fields.
+- [XML namespaces](https://www.w3.org/TR/xml-names/) §§2, 6 and
+  [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/) §§2.5, 2.7, 2.11, 2.15:
+  namespace identity, attributes, languages, structures and list ownership.
+- [Adobe XMP](https://developer.adobe.com/xmp/docs/) and
+  [date types](https://developer.adobe.com/xmp/docs/xmp-namespaces/xmp-data-types/):
+  shared photo fields and date precision. Missing timezones remain unknown;
+  capture-date normalization is this library's policy.
+- [CIPA EXIF specifications](https://www.cipa.jp/e/std/std-sec.html) and
+  [Exif 2.32 §4.6.6 F](https://www.cipa.jp/std/documents/e/DC-X008-Translation-2019-E.pdf):
+  GPS coordinates, date families, subseconds and blank offsets.
+- [HEIF](https://nokiatech.github.io/heif/technical.html) and
+  [QuickTime clean aperture](https://developer.apple.com/documentation/quicktime-file-format/clean_aperture):
+  primary-image properties and ordered transforms. Exact pixel crops and EXIF
+  fallback without an active native orientation are library policies.
+- [Motion Photo](https://developer.android.com/media/platform/motion-photo-format):
+  Camera/Container fields, padding and appended video; not a legacy footer spec.
+- [Google tag documentation](https://exiftool.org/TagNames/Google.html): opaque
+  HDRPlusMakerNote data. Skipping it without exhausting retention is library policy.
+- [Photoshop resources](https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/):
+  resource IDs, lengths and padding.
+- [PNG text](https://www.w3.org/TR/png-3/#11keywords): keywords and text encodings.
+- [IPTC IIM 4.2](https://iptc.org/std/IIM/4.2/specification/IIMV4.2.pdf): headers,
+  values, UTF-8 announcements and record scope. Accepting a zero-filled trailing
+  region, while rejecting nonzero malformed tails, is library policy.

--- a/rust/crates/exif/tests/integration/capture.rs
+++ b/rust/crates/exif/tests/integration/capture.rs
@@ -1,0 +1,415 @@
+use super::common::*;
+use ente_exif::{
+    DateTime, DateTimeKind, DateTimePrecision, DateTimeSource, Ifd, Iptc, Metadata, Mode, Tag,
+    Value, namespace,
+};
+
+#[test]
+fn source_dates_preserve_precision_without_assuming_utc() {
+    use DateTimePrecision::{Day, Minute, Month, Second, Year};
+    for mode in [Mode::Summary, Mode::Details] {
+        for (input, precision, complete) in [
+            ("2004", Year, "2004-01-01T00:00:00"),
+            ("2004-02", Month, "2004-02-01T00:00:00"),
+            ("2004-02-29", Day, "2004-02-29T00:00:00"),
+            ("2004-02-29T12:34", Minute, "2004-02-29T12:34:00"),
+            ("2004-02-29T12:34Z", Minute, "2004-02-29T12:34:00Z"),
+            ("2004-02-29T12:34-0030", Minute, "2004-02-29T12:34:00-00:30"),
+            ("2004-02-29T12:34:56.125", Second, "2004-02-29T12:34:56.125"),
+        ] {
+            let metadata = read(
+                packet(&format!("<x:CreateDate>{input}</x:CreateDate>")).as_bytes(),
+                mode,
+            );
+            let value = metadata
+                .date_time(DateTimeSource::Xmp(namespace::XMP, "CreateDate"))
+                .unwrap();
+            assert_eq!(value.precision, precision, "{input}");
+            assert_eq!(
+                value.date_time,
+                DateTime::parse(complete).unwrap(),
+                "{input}"
+            );
+            assert_eq!(
+                value.date_time.unix_micros().is_some(),
+                value.date_time.offset_minutes.is_some()
+            );
+        }
+    }
+}
+
+#[test]
+fn source_dates_do_not_select_another_family_or_fallback() {
+    let mut metadata = read(
+        packet("<e:DateTimeOriginal>invalid</e:DateTimeOriginal><x:CreateDate>2004</x:CreateDate>")
+            .as_bytes(),
+        Mode::Summary,
+    );
+    metadata.iptc = vec![iptc(55, b"20040229"), iptc(63, b"123456+0530")];
+    metadata
+        .tags
+        .push(tag(Ifd::Exif(0), 0x9003, "2003:01:02 03:04:05"));
+    assert_eq!(
+        metadata.date_time(DateTimeSource::Xmp(namespace::EXIF, "DateTimeOriginal")),
+        None
+    );
+    assert_eq!(
+        metadata.date_time(DateTimeSource::Exif(DateTimeKind::Modified)),
+        None
+    );
+    assert_eq!(metadata.date_time(DateTimeSource::Iptc(62, 63)), None);
+    let original = metadata
+        .date_time(DateTimeSource::Exif(DateTimeKind::Original))
+        .unwrap();
+    assert_eq!(original.precision, DateTimePrecision::Second);
+    assert_eq!(
+        original.date_time,
+        DateTime::parse("2003-01-02T03:04:05").unwrap()
+    );
+    let iptc_date = metadata.date_time(DateTimeSource::Iptc(55, 60)).unwrap();
+    assert_eq!(iptc_date.precision, DateTimePrecision::Day);
+    assert_eq!(
+        iptc_date.date_time,
+        DateTime::parse("2004-02-29T00:00:00").unwrap()
+    );
+    assert_eq!(iptc_date.date_time.unix_micros(), None);
+    metadata.iptc.push(iptc(60, b"123456+0530"));
+    let iptc_date = metadata.date_time(DateTimeSource::Iptc(55, 60)).unwrap();
+    assert_eq!(iptc_date.precision, DateTimePrecision::Second);
+    assert_eq!(
+        iptc_date.date_time,
+        DateTime::parse("2004-02-29T12:34:56+05:30").unwrap()
+    );
+}
+
+#[test]
+fn capture_prefers_original_sources_before_digitized_metadata_and_modified() {
+    use DateTimeKind::{Digitized, Modified, Original};
+    use DateTimeSource::{Exif, Iptc, Xmp};
+    let mut metadata = Metadata::default();
+    for (kind, value) in [
+        (Original, "2003:01:02 03:04:05"),
+        (Digitized, "2007:01:02 03:04:05"),
+        (Modified, "2011:01:02 03:04:05"),
+    ] {
+        let (ifd, id) = if kind == Modified {
+            (Ifd::Image(0), 0x132)
+        } else {
+            (Ifd::Exif(0), if kind == Original { 0x9003 } else { 0x9004 })
+        };
+        metadata.tags.push(tag(ifd, id, value));
+    }
+    metadata.xmp = read(
+        packet(
+            r#"
+        <e:DateTimeOriginal>2001-01-02T03:04:05Z</e:DateTimeOriginal>
+        <p:DateCreated>2004-01-02T03:04:05Z</p:DateCreated>
+        <e:DateTimeDigitized>2005-01-02T03:04:05Z</e:DateTimeDigitized>
+        <x:CreateDate>2008-01-02T03:04:05Z</x:CreateDate>
+        <x:MetadataDate>2009-01-02T03:04:05Z</x:MetadataDate>
+        <t:DateTime>2010-01-02T03:04:05Z</t:DateTime>
+        <x:ModifyDate>2012-01-02T03:04:05Z</x:ModifyDate>"#,
+        )
+        .as_bytes(),
+        Mode::Summary,
+    )
+    .xmp;
+    metadata.iptc = vec![
+        iptc(55, b"20020102"),
+        iptc(60, b"030405+0000"),
+        iptc(62, b"20060102"),
+        iptc(63, b"030405+0000"),
+    ];
+    for (index, source) in [
+        Xmp(namespace::EXIF, "DateTimeOriginal"),
+        Iptc(55, 60),
+        Exif(Original),
+        Xmp(namespace::PHOTOSHOP, "DateCreated"),
+        Xmp(namespace::EXIF, "DateTimeDigitized"),
+        Iptc(62, 63),
+        Exif(Digitized),
+        Xmp(namespace::XMP, "CreateDate"),
+        Xmp(namespace::XMP, "MetadataDate"),
+        Xmp(namespace::TIFF, "DateTime"),
+        Exif(Modified),
+        Xmp(namespace::XMP, "ModifyDate"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let capture = metadata.capture_date_time().unwrap();
+        assert_eq!(capture.source, source);
+        assert_eq!(
+            capture.date_time,
+            format!("{}-01-02T03:04:05", 2001 + index)
+        );
+        match source {
+            Exif(kind) => metadata.tags.retain(|t| {
+                t.id != match kind {
+                    Original => 0x9003,
+                    Digitized => 0x9004,
+                    Modified => 0x132,
+                }
+            }),
+            Xmp(ns, name) => metadata.xmp.retain(|p| p.namespace != ns || p.name != name),
+            Iptc(date, time) => metadata
+                .iptc
+                .retain(|p| p.dataset != date && p.dataset != time),
+        }
+    }
+    assert_eq!(metadata.capture_date_time(), None);
+}
+
+#[test]
+fn offsets_stay_separate_from_local_time_and_epoch_microseconds() {
+    for mode in [Mode::Summary, Mode::Details] {
+        for (value, local, offset, timestamp) in [
+            (
+                "1970-01-02T00:15:00.123456789+0030",
+                "1970-01-02T00:15:00.123456789",
+                Some("+00:30"),
+                Some(85_500_123_456),
+            ),
+            (
+                "1970-01-02T00:15:00-00:30",
+                "1970-01-02T00:15:00",
+                Some("-00:30"),
+                Some(89_100_000_000),
+            ),
+            (
+                "1970-01-02T00:15:00Z",
+                "1970-01-02T00:15:00",
+                Some("+00:00"),
+                Some(87_300_000_000),
+            ),
+            ("1970-01-02T00:15:00", "1970-01-02T00:15:00", None, None),
+            (
+                "1970-01-01T00:00:00Z",
+                "1970-01-01T00:00:00",
+                Some("+00:00"),
+                Some(0),
+            ),
+        ] {
+            let metadata = read(
+                packet(&format!("<p:DateCreated>{value}</p:DateCreated>")).as_bytes(),
+                mode,
+            );
+            let capture = metadata.capture_date_time().unwrap();
+            assert_eq!(capture.date_time, local);
+            assert_eq!(capture.offset_time.as_deref(), offset);
+            assert_eq!(capture.timestamp_micros, timestamp);
+        }
+    }
+}
+
+#[test]
+fn host_policy_can_resolve_local_time_and_reject_candidates_before_fallback() {
+    let metadata = read(packet("<e:DateTimeOriginal>1970-01-02T12:00:00</e:DateTimeOriginal><x:CreateDate>1970-01-03T12:00:00Z</x:CreateDate>").as_bytes(), Mode::Summary);
+    let mut visits = 0;
+    let capture = metadata
+        .capture_date_time_with(|candidate| {
+            visits += 1;
+            assert_eq!(candidate.timestamp_micros, None);
+            assert_eq!(candidate.offset_time, None);
+            candidate.timestamp_micros = Some(109_800_000_000);
+            true
+        })
+        .unwrap();
+    assert_eq!(visits, 1);
+    assert_eq!(capture.timestamp_micros, Some(109_800_000_000));
+    assert_eq!(capture.offset_time, None);
+    let capture = metadata
+        .capture_date_time_with(|candidate| candidate.timestamp_micros.is_some())
+        .unwrap();
+    assert_eq!(
+        capture.source,
+        DateTimeSource::Xmp(namespace::XMP, "CreateDate")
+    );
+    assert_eq!(metadata.capture_date_time_with(|_| false), None);
+
+    let metadata = read(packet("<x:MetadataDate>1970-01-02T12:00:00Z</x:MetadataDate><t:DateTime>1970-01-03T12:00:00Z</t:DateTime><x:ModifyDate>1970-01-04T12:00:00Z</x:ModifyDate>").as_bytes(), Mode::Summary);
+    let capture = metadata
+        .capture_date_time_with(|candidate| candidate.date_time.starts_with("1970-01-04"))
+        .unwrap();
+    assert_eq!(
+        capture.source,
+        DateTimeSource::Xmp(namespace::XMP, "ModifyDate")
+    );
+}
+
+#[test]
+fn reduced_xmp_dates_use_period_start_without_inventing_an_embedded_offset() {
+    for (value, expected, timestamp) in [
+        ("1971", "1971-01-01T00:00:00", Some(31_536_000_000_000)),
+        ("1970-02", "1970-02-01T00:00:00", Some(2_678_400_000_000)),
+        ("1970-01-02", "1970-01-02T00:00:00", Some(86_400_000_000)),
+        ("1970-01-02T00:15", "1970-01-02T00:15:00", None),
+        (
+            "1970-01-02T00:15+00:30",
+            "1970-01-02T00:15:00",
+            Some(85_500_000_000),
+        ),
+    ] {
+        assert_eq!(DateTime::parse(value), None);
+        for mode in [Mode::Summary, Mode::Details] {
+            let capture = read(
+                packet(&format!("<x:CreateDate>{value}</x:CreateDate>")).as_bytes(),
+                mode,
+            )
+            .capture_date_time()
+            .unwrap();
+            assert_eq!(capture.date_time, expected);
+            assert_eq!(capture.timestamp_micros, timestamp);
+            if value.len() <= 10 {
+                assert_eq!(capture.offset_time, None);
+            }
+        }
+    }
+}
+
+#[test]
+fn malformed_preferred_fields_fall_through_without_mixing_date_families() {
+    for value in [
+        "",
+        "bad",
+        "1970-13",
+        "1900-02-29",
+        "1970-01-02T00:00:99Z",
+        "1970-01-02T00:00+24:00",
+        "1970-01-02T00:00日本",
+    ] {
+        let mut metadata = read(packet(&format!("<e:DateTimeOriginal>{value}</e:DateTimeOriginal><t:DateTime>{value}</t:DateTime><x:ModifyDate>1970-01-03T00:00:00Z</x:ModifyDate>")).as_bytes(), Mode::Summary);
+        metadata.tags = vec![
+            tag(Ifd::Image(0), 0x132, "1970:01:02 00:00:00"),
+            tag(Ifd::Exif(0), 0x9011, "+06:00"),
+        ];
+        let capture = metadata.capture_date_time().unwrap();
+        assert_eq!(capture.source, DateTimeSource::Exif(DateTimeKind::Modified));
+        assert_eq!(capture.offset_time, None);
+        assert_eq!(capture.timestamp_micros, None);
+    }
+}
+
+#[test]
+fn generated_iptc_dates_pair_only_their_own_time_dataset() {
+    for mode in [Mode::Summary, Mode::Details] {
+        for (time, offset, timestamp) in [
+            (None, None, Some(86_400_000_000)),
+            (Some("001500"), None, None),
+            (Some("001500-0030"), Some("-00:30"), Some(89_100_000_000)),
+        ] {
+            let mut fields = vec![
+                (55, b"19700102".as_slice()),
+                (63, b"120000+0600".as_slice()),
+            ];
+            if let Some(time) = time {
+                fields.push((60, time.as_bytes()));
+            }
+            let metadata = read(&iptc_tiff(&fields), mode);
+            let capture = metadata.capture_date_time().unwrap();
+            assert_eq!(capture.source, DateTimeSource::Iptc(55, 60));
+            assert_eq!(capture.offset_time.as_deref(), offset);
+            assert_eq!(capture.timestamp_micros, timestamp);
+        }
+        for (date, time) in [
+            ("19700100", "120000+0000"),
+            ("00000102", "120000+0000"),
+            ("19700102", ""),
+            ("19700102", "240000+0000"),
+            ("19700102", "120000+2460"),
+        ] {
+            let metadata = read(
+                &iptc_tiff(&[
+                    (55, date.as_bytes()),
+                    (60, time.as_bytes()),
+                    (62, b"19700103"),
+                    (63, b"120000+0000"),
+                ]),
+                mode,
+            );
+            let capture = metadata.capture_date_time().unwrap();
+            assert_eq!(capture.source, DateTimeSource::Iptc(62, 63));
+            assert_eq!(capture.date_time, "1970-01-03T12:00:00");
+        }
+    }
+}
+
+#[test]
+fn generated_exif_capture_uses_matching_subseconds_and_offset() {
+    let bytes = child_ifd(
+        0x8769,
+        tiff(
+            &[
+                (0x9003, 2, 20, b"1970:01:02 00:15:00\0".to_vec()),
+                (0x9291, 2, 4, b"125\0".to_vec()),
+                (0x9011, 2, 7, b"+00:30\0".to_vec()),
+            ],
+            false,
+        ),
+    );
+    for mode in [Mode::Summary, Mode::Details] {
+        let capture = read(&bytes, mode).capture_date_time().unwrap();
+        assert_eq!(capture.date_time, "1970-01-02T00:15:00.125000000");
+        assert_eq!(capture.offset_time.as_deref(), Some("+00:30"));
+        assert_eq!(capture.timestamp_micros, Some(85_500_125_000));
+    }
+}
+
+#[test]
+fn partial_date_and_iptc_mutations_do_not_panic() {
+    for input in [b"2000-02-29T12:34-0030".as_slice(), b"2000-02-29"] {
+        for len in 0..=input.len() {
+            let mut metadata = read(packet("").as_bytes(), Mode::Summary);
+            for replacement in 0..=127 {
+                let mut value = input[..len].to_vec();
+                if let Some(last) = value.last_mut() {
+                    *last = replacement;
+                }
+                metadata.xmp = read(
+                    packet("<x:CreateDate>2000</x:CreateDate>").as_bytes(),
+                    Mode::Summary,
+                )
+                .xmp;
+                metadata.xmp[0].value = String::from_utf8(value.clone()).unwrap();
+                let _ = metadata.capture_date_time();
+                metadata.xmp.clear();
+                metadata.iptc = vec![iptc(55, &value), iptc(60, &value)];
+                let _ = metadata.capture_date_time();
+            }
+        }
+    }
+}
+
+fn packet(body: &str) -> String {
+    format!(
+        r#"<r:RDF xmlns:r="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><r:Description xmlns:e="http://ns.adobe.com/exif/1.0/" xmlns:p="http://ns.adobe.com/photoshop/1.0/" xmlns:t="http://ns.adobe.com/tiff/1.0/" xmlns:x="http://ns.adobe.com/xap/1.0/">{body}</r:Description></r:RDF>"#
+    )
+}
+
+fn tag(ifd: Ifd, id: u16, value: &str) -> Tag {
+    Tag {
+        ifd,
+        id,
+        field_type: 2,
+        count: value.len() as u32,
+        value: Value::Ascii(value.as_bytes().to_vec()),
+    }
+}
+
+fn iptc(dataset: u8, value: &[u8]) -> Iptc {
+    Iptc {
+        record: 2,
+        dataset,
+        value: value.to_vec(),
+    }
+}
+
+fn iptc_tiff(fields: &[(u8, &[u8])]) -> Vec<u8> {
+    let mut bytes = vec![];
+    for (dataset, value) in fields {
+        bytes.extend([0x1c, 2, *dataset]);
+        bytes.extend((value.len() as u16).to_be_bytes());
+        bytes.extend(*value);
+    }
+    tiff(&[(0x83bb, 7, bytes.len() as u32, bytes)], false)
+}

--- a/rust/crates/exif/tests/integration/common.rs
+++ b/rust/crates/exif/tests/integration/common.rs
@@ -1,0 +1,185 @@
+use ente_exif::{Limits, Metadata, Mode};
+use std::io::Cursor;
+
+pub fn read(bytes: &[u8], mode: Mode) -> Metadata {
+    ente_exif::read(&mut Cursor::new(bytes), mode, Limits::default()).unwrap()
+}
+
+pub fn exercise(bytes: &[u8], limits: Limits) {
+    let _ = ente_exif::read(&mut Cursor::new(bytes), Mode::Summary, limits);
+    let ordinary = ente_exif::read(&mut Cursor::new(bytes), Mode::Details, limits);
+    if let Ok(structured) = ente_exif::read_structured(&mut Cursor::new(bytes), limits) {
+        assert_eq!(ordinary.unwrap(), structured.metadata);
+        assert_eq!(structured.xmp.parents.len(), structured.metadata.xmp.len());
+        for (index, node) in structured.xmp.nodes.iter().enumerate() {
+            assert!(node.parent.is_none_or(|parent| (parent as usize) < index));
+        }
+        for parent in structured.xmp.parents.iter().flatten() {
+            assert!((*parent as usize) < structured.xmp.nodes.len());
+        }
+    }
+}
+
+pub fn child_ifd(pointer: u16, mut child: Vec<u8>) -> Vec<u8> {
+    let mut result = tiff(&[(pointer, 4, 1, 26u32.to_le_bytes().to_vec())], false);
+    let count = u16::from_le_bytes(child[8..10].try_into().unwrap()) as usize;
+    for entry in child[10..10 + count * 12].as_chunks_mut::<12>().0 {
+        let kind = u16::from_le_bytes(entry[2..4].try_into().unwrap());
+        let count = u32::from_le_bytes(entry[4..8].try_into().unwrap());
+        let width = match kind {
+            3 | 8 => 2,
+            4 | 9 | 11 | 13 => 4,
+            5 | 10 | 12 => 8,
+            _ => 1,
+        };
+        if count * width > 4 {
+            let old = u32::from_le_bytes(entry[8..12].try_into().unwrap());
+            entry[8..12].copy_from_slice(&(old + 18).to_le_bytes());
+        }
+    }
+    result.extend(&child[8..]);
+    result
+}
+
+pub fn tiff(entries: &[(u16, u16, u32, Vec<u8>)], big: bool) -> Vec<u8> {
+    let u16 = |v: u16| {
+        if big {
+            v.to_be_bytes()
+        } else {
+            v.to_le_bytes()
+        }
+    };
+    let u32 = |v: u32| {
+        if big {
+            v.to_be_bytes()
+        } else {
+            v.to_le_bytes()
+        }
+    };
+    let mut result = if big {
+        b"MM\0*\0\0\0\x08".to_vec()
+    } else {
+        b"II*\0\x08\0\0\0".to_vec()
+    };
+    result.extend(u16(entries.len() as u16));
+    let mut values: Vec<u8> = Vec::new();
+    let start = 8 + 2 + entries.len() * 12 + 4;
+    for (id, kind, count, value) in entries {
+        result.extend(u16(*id));
+        result.extend(u16(*kind));
+        result.extend(u32(*count));
+        if value.len() <= 4 {
+            result.extend(value);
+            result.resize(result.len() + 4 - value.len(), 0);
+        } else {
+            result.extend(u32((start + values.len()) as u32));
+            values.extend(value);
+        }
+    }
+    result.extend([0; 4]);
+    result.extend(values);
+    result
+}
+
+pub fn segment(marker: u8, bytes: &[u8]) -> Vec<u8> {
+    let mut result = vec![0xff, marker];
+    result.extend(((bytes.len() + 2) as u16).to_be_bytes());
+    result.extend(bytes);
+    result
+}
+
+pub fn jpeg(exif: &[u8], xmp: &str) -> Vec<u8> {
+    let mut result = vec![0xff, 0xd8];
+    if !exif.is_empty() {
+        result.extend(segment(0xe1, &[b"Exif\0\0".as_slice(), exif].concat()));
+    }
+    if !xmp.is_empty() {
+        result.extend(segment(
+            0xe1,
+            &[b"http://ns.adobe.com/xap/1.0/\0".as_slice(), xmp.as_bytes()].concat(),
+        ));
+    }
+    result.extend(segment(0xc0, &[8, 0, 20, 0, 30, 1, 1, 0x11, 0]));
+    result.extend([0xff, 0xda, 0, 8, 1, 1, 0, 0, 63, 0, 0xff, 0xd9]);
+    result
+}
+
+pub fn xmp(body: &str) -> String {
+    format!(
+        r#"<r:RDF xmlns:r="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><r:Description xmlns:t="http://ns.adobe.com/tiff/1.0/" xmlns:e="http://ns.adobe.com/exif/1.0/" xmlns:p="http://ns.google.com/photos/1.0/panorama/" xmlns:d="http://purl.org/dc/elements/1.1/">{body}</r:Description></r:RDF>"#
+    )
+}
+
+pub fn box_bytes(kind: &[u8; 4], data: &[u8]) -> Vec<u8> {
+    let mut result = ((data.len() + 8) as u32).to_be_bytes().to_vec();
+    result.extend(kind);
+    result.extend(data);
+    result
+}
+
+pub fn png_chunk(kind: &[u8; 4], data: &[u8]) -> Vec<u8> {
+    let mut result = (data.len() as u32).to_be_bytes().to_vec();
+    result.extend(kind);
+    result.extend(data);
+    result.extend([0; 4]);
+    result
+}
+
+pub fn heif(exif: &[u8], method: u16, split: bool) -> Vec<u8> {
+    let ftyp = box_bytes(b"ftyp", b"heic\0\0\0\0mif1heic");
+    let mut infe = vec![2, 0, 0, 0, 0, 2, 0, 0];
+    infe.extend(b"Exif\0");
+    let iinf = box_bytes(
+        b"iinf",
+        &[vec![0, 0, 0, 0, 0, 1], box_bytes(b"infe", &infe)].concat(),
+    );
+    let pitm = box_bytes(b"pitm", &[0, 0, 0, 0, 0, 1]);
+    let mut ispe = vec![0; 4];
+    ispe.extend(800u32.to_be_bytes());
+    ispe.extend(600u32.to_be_bytes());
+    let clap: Vec<u8> = [640u32, 1, 480, 1, u32::MAX, 2, 0, 1]
+        .into_iter()
+        .flat_map(u32::to_be_bytes)
+        .collect();
+    let ipco = box_bytes(
+        b"ipco",
+        &[
+            box_bytes(b"ispe", &ispe),
+            box_bytes(b"irot", &[1]),
+            box_bytes(b"clap", &clap),
+        ]
+        .concat(),
+    );
+    let ipma = box_bytes(b"ipma", &[0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 3, 1, 0x82, 0x83]);
+    let iprp = box_bytes(b"iprp", &[ipco, ipma].concat());
+    let data = [vec![0; 4], exif.to_vec()].concat();
+    let extents = if split {
+        vec![(0, 10), (10, data.len() - 10)]
+    } else {
+        vec![(0, data.len())]
+    };
+    let mut iloc = vec![1, 0, 0, 0, 0x44, 0x40, 0, 1, 0, 2];
+    iloc.extend(method.to_be_bytes());
+    iloc.extend([0; 2]);
+    let base_position = iloc.len();
+    iloc.extend([0; 4]);
+    iloc.extend((extents.len() as u16).to_be_bytes());
+    for (offset, size) in extents {
+        iloc.extend((offset as u32).to_be_bytes());
+        iloc.extend((size as u32).to_be_bytes());
+    }
+    if method == 0 {
+        let meta_size = 12 + pitm.len() + iinf.len() + iprp.len() + 8 + iloc.len();
+        iloc[base_position..base_position + 4]
+            .copy_from_slice(&((ftyp.len() + meta_size + 8) as u32).to_be_bytes());
+    }
+    let mut meta = [vec![0; 4], pitm, iinf, iprp, box_bytes(b"iloc", &iloc)].concat();
+    if method == 1 {
+        meta.extend(box_bytes(b"idat", &data));
+    }
+    let mut result = [ftyp, box_bytes(b"meta", &meta)].concat();
+    if method == 0 {
+        result.extend(box_bytes(b"mdat", &data));
+    }
+    result
+}

--- a/rust/crates/exif/tests/integration/datetime.rs
+++ b/rust/crates/exif/tests/integration/datetime.rs
@@ -1,0 +1,276 @@
+use super::common::*;
+use ente_exif::{DateTime, DateTimeKind, Ifd, Metadata, Mode, Tag, Value};
+
+#[test]
+fn complete_dates_preserve_local_time_fraction_and_offset() {
+    for (input, nano, offset) in [
+        (" 2004:02:29 12:34:56 ", 0, None),
+        ("2004:02:29 12:34:56.125", 125_000_000, None),
+        ("2004-02-29T12:34:56.1234567899Z", 123_456_789, Some(0)),
+        ("2004-02-29 12:34:56:01-00:30", 10_000_000, Some(-30)),
+        ("2004-02-29t12:34:56z", 0, Some(0)),
+        ("2004-02-29T12:34:56+0545", 0, Some(345)),
+        ("2004-02-29T12:34:56-03:30", 0, Some(-210)),
+    ] {
+        let date = DateTime::parse(input).unwrap();
+        assert_eq!(
+            date,
+            DateTime {
+                year: 2004,
+                month: 2,
+                day: 29,
+                hour: 12,
+                minute: 34,
+                second: 56,
+                nanosecond: nano,
+                offset_minutes: offset
+            }
+        );
+        assert_eq!(date.unix_micros().is_some(), offset.is_some());
+        assert_eq!(DateTime::parse(&date.to_string()), Some(date));
+    }
+}
+
+#[test]
+fn dates_reject_invalid_calendar_fields_and_incomplete_values() {
+    for value in [
+        "",
+        "2004",
+        "2004-02",
+        "2004-02-29",
+        "2004-02-29T12:34",
+        "0000:00:00 00:00:00",
+        "    :  :     :  :  ",
+        "0000-01-01T00:00:00Z",
+        "1900-02-29T00:00:00Z",
+        "2100-02-29T00:00:00Z",
+        "2004-04-31T00:00:00Z",
+        "2004-00-10T00:00:00Z",
+        "2004-13-10T00:00:00Z",
+        "2004-02-00T00:00:00Z",
+        "2004-02-29T24:00:00Z",
+        "2004-02-29T12:60:00Z",
+        "2004-02-29T12:00:60Z",
+        "2004-02-29T12:00:00+24:00",
+        "2004-02-29T12:00:00+00:60",
+        "2004-02-29T12:00:00+5:30",
+        "2004-02-29T12:00:00UTC",
+        "2004-02-29T12:00:00Ztail",
+        "2004-02-29T12:00:00.Z",
+        "2004-02-29T12:00:00.1xZ",
+        "2004:02-29T12:00:00Z",
+        "2004-02-29T12:00:0éZ",
+        "2004-02-29T12:00:00.é",
+        "٢٠٠٤-02-29T12:00:00Z",
+    ] {
+        assert_eq!(DateTime::parse(value), None, "{value}");
+    }
+}
+
+#[test]
+fn epoch_conversion_handles_leap_centuries_offsets_and_pre_epoch_fractions() {
+    for (input, expected) in [
+        ("1970-01-01T00:00:00Z", 0),
+        ("1970-01-01T00:00:00+00:30", -1_800_000_000),
+        ("1970-01-01T00:00:00-00:30", 1_800_000_000),
+        ("1969-12-31T23:59:59.123456789Z", -876_544),
+        ("2000-02-29T12:34:56.123456Z", 951_827_696_123_456),
+        ("0001-01-01T00:00:00Z", -62_135_596_800_000_000),
+        ("9999-12-31T23:59:59.999999Z", 253_402_300_799_999_999),
+    ] {
+        assert_eq!(
+            DateTime::parse(input).unwrap().unix_micros(),
+            Some(expected),
+            "{input}"
+        );
+    }
+    let valid = DateTime::parse("2000-01-01T00:00:00Z").unwrap();
+    for invalid in [
+        DateTime { year: 0, ..valid },
+        DateTime {
+            year: 10000,
+            ..valid
+        },
+        DateTime { month: 0, ..valid },
+        DateTime { month: 13, ..valid },
+        DateTime { day: 0, ..valid },
+        DateTime { day: 32, ..valid },
+        DateTime { hour: 24, ..valid },
+        DateTime {
+            minute: 60,
+            ..valid
+        },
+        DateTime {
+            second: 60,
+            ..valid
+        },
+        DateTime {
+            nanosecond: 1_000_000_000,
+            ..valid
+        },
+        DateTime {
+            offset_minutes: Some(i16::MIN),
+            ..valid
+        },
+    ] {
+        assert_eq!(invalid.unix_micros(), None);
+    }
+}
+
+#[test]
+fn exif_date_families_use_their_own_subseconds_and_offsets() {
+    let metadata = dates(&[
+        (Ifd::Image(0), 0x132, "2010:05:06 07:08:09"),
+        (Ifd::Exif(0), 0x9003, "2000:01:02 03:04:05"),
+        (Ifd::Exif(0), 0x9004, "2001:02:03 04:05:06"),
+        (Ifd::Exif(0), 0x9290, "1"),
+        (Ifd::Exif(0), 0x9010, "+01:00"),
+        (Ifd::Exif(0), 0x9291, "25"),
+        (Ifd::Exif(0), 0x9011, "-00:30"),
+        (Ifd::Exif(0), 0x9292, "125"),
+        (Ifd::Exif(0), 0x9012, "+05:45"),
+    ]);
+    for (kind, expected) in [
+        (
+            DateTimeKind::Original,
+            "2000-01-02T03:04:05.250000000-00:30",
+        ),
+        (
+            DateTimeKind::Digitized,
+            "2001-02-03T04:05:06.125000000+05:45",
+        ),
+        (
+            DateTimeKind::Modified,
+            "2010-05-06T07:08:09.100000000+01:00",
+        ),
+    ] {
+        assert_eq!(metadata.exif_date_time(kind).unwrap().to_string(), expected);
+    }
+    let metadata = dates(&[
+        (Ifd::Image(0), 0x132, "2010:05:06 07:08:09"),
+        (Ifd::Exif(0), 0x9003, "2000:01:02 03:04:05"),
+        (Ifd::Exif(0), 0x9010, "+05:00"),
+    ]);
+    assert_eq!(
+        metadata
+            .exif_date_time(DateTimeKind::Original)
+            .unwrap()
+            .offset_minutes,
+        None
+    );
+    assert_eq!(metadata.exif_date_time(DateTimeKind::Digitized), None);
+}
+
+#[test]
+fn exif_auxiliary_fields_distinguish_blank_from_malformed() {
+    for (subsec, offset, expected) in [
+        ("", "", Some("2000-01-02T03:04:05")),
+        ("  ", "   :  ", Some("2000-01-02T03:04:05")),
+        (
+            "05  ",
+            " +0530 ",
+            Some("2000-01-02T03:04:05.050000000+05:30"),
+        ),
+        ("bad", "+00:00", None),
+        ("1.2", "+00:00", None),
+        ("1", "CDT", None),
+        ("1", "+05:99", None),
+    ] {
+        let metadata = dates(&[
+            (Ifd::Exif(0), 0x9003, "2000:01:02 03:04:05"),
+            (Ifd::Exif(0), 0x9291, subsec),
+            (Ifd::Exif(0), 0x9011, offset),
+        ]);
+        assert_eq!(
+            metadata
+                .exif_date_time(DateTimeKind::Original)
+                .map(|d| d.to_string())
+                .as_deref(),
+            expected
+        );
+    }
+    let mut metadata = dates(&[
+        (Ifd::Exif(0), 0x9003, "2000-01-02T03:04:05.25-00:30"),
+        (Ifd::Exif(0), 0x9291, "75"),
+        (Ifd::Exif(0), 0x9011, "+05:00"),
+    ]);
+    assert_eq!(
+        metadata
+            .exif_date_time(DateTimeKind::Original)
+            .unwrap()
+            .to_string(),
+        "2000-01-02T03:04:05.250000000-00:30"
+    );
+    for tag in &mut metadata.tags[1..] {
+        tag.value = ente_exif::Value::Unsigned(vec![1]);
+    }
+    assert_eq!(
+        metadata.exif_date_time(DateTimeKind::Original),
+        DateTime::parse("2000-01-02T03:04:05.25-00:30")
+    );
+    metadata.tags[0].value = ente_exif::Value::Ascii(b"2000:01:02 03:04:05".to_vec());
+    assert_eq!(metadata.exif_date_time(DateTimeKind::Original), None);
+}
+
+#[test]
+fn generated_exif_dates_work_in_both_modes_and_retain_raw_precision() {
+    let bytes = child_ifd(
+        0x8769,
+        tiff(
+            &[
+                (0x9003, 2, 20, b"2000:01:02 03:04:05\0".to_vec()),
+                (0x9291, 2, 11, b"1234567899\0".to_vec()),
+                (0x9011, 2, 7, b"-00:30\0".to_vec()),
+            ],
+            false,
+        ),
+    );
+    for mode in [Mode::Summary, Mode::Details] {
+        let metadata = read(&bytes, mode);
+        assert_eq!(
+            metadata
+                .exif_date_time(DateTimeKind::Original)
+                .unwrap()
+                .to_string(),
+            "2000-01-02T03:04:05.123456789-00:30"
+        );
+        assert_eq!(
+            metadata.tag(Ifd::Exif(0), 0x9291).unwrap().value.text(),
+            Some("1234567899")
+        );
+    }
+}
+
+#[test]
+fn timestamp_truncations_and_mutations_do_not_panic() {
+    let seed = b"2000-02-29T12:34:56.123456789-00:30";
+    for len in 0..=seed.len() {
+        let _ = DateTime::parse(std::str::from_utf8(&seed[..len]).unwrap());
+    }
+    for index in 0..seed.len() {
+        for value in 0..=127 {
+            let mut bytes = *seed;
+            bytes[index] = value;
+            if let Some(date) = DateTime::parse(std::str::from_utf8(&bytes).unwrap()) {
+                assert_eq!(DateTime::parse(&date.to_string()), Some(date));
+                assert_eq!(date.unix_micros().is_some(), date.offset_minutes.is_some());
+            }
+        }
+    }
+}
+
+fn dates(entries: &[(Ifd, u16, &str)]) -> Metadata {
+    Metadata {
+        tags: entries
+            .iter()
+            .map(|(ifd, id, text)| Tag {
+                ifd: *ifd,
+                id: *id,
+                field_type: 2,
+                count: text.len() as u32,
+                value: Value::Ascii(text.as_bytes().to_vec()),
+            })
+            .collect(),
+        ..Metadata::default()
+    }
+}

--- a/rust/crates/exif/tests/integration/dimensions.rs
+++ b/rust/crates/exif/tests/integration/dimensions.rs
@@ -1,0 +1,254 @@
+use super::common::*;
+use ente_exif::{CleanAperture, Dimensions, Limits, Metadata, Mode, Rational, Transform};
+use std::io::Cursor;
+
+#[test]
+fn display_orientation_uses_valid_exif_then_xmp_and_complete_sizes() {
+    for mode in [Mode::Summary, Mode::Details] {
+        let mut metadata = read(
+            xmp("<t:ImageWidth>800</t:ImageWidth><t:ImageLength>600</t:ImageLength><t:Orientation>6</t:Orientation>").as_bytes(),
+            mode,
+        );
+        assert_eq!(metadata.display_dimensions(), Some(size(600, 800)));
+        for (orientation, expected) in [
+            (1u32, size(900, 700)),
+            (8, size(700, 900)),
+            (0, size(700, 900)),
+        ] {
+            metadata.tags = read(
+                &tiff(&[(0x112, 4, 1, orientation.to_le_bytes().to_vec())], false),
+                mode,
+            )
+            .tags;
+            assert_eq!(metadata.display_dimensions(), Some(size(600, 800)));
+            metadata.dimensions = Some(size(900, 700));
+            assert_eq!(metadata.display_dimensions(), Some(expected));
+            metadata.dimensions = None;
+        }
+        for orientation in ["0", "9", "left", "6.0", ""] {
+            let metadata = read(xmp(&format!("<e:PixelXDimension>800</e:PixelXDimension><e:PixelYDimension>600</e:PixelYDimension><t:Orientation>{orientation}</t:Orientation>")).as_bytes(), mode);
+            assert_eq!(metadata.display_dimensions(), Some(size(800, 600)));
+        }
+    }
+}
+
+#[test]
+fn heif_orientation_suppresses_duplicate_exif_and_xmp_rotation() {
+    for mode in [Mode::Summary, Mode::Details] {
+        let mut metadata = read(
+            &heif(&tiff(&[(0x112, 3, 1, vec![6, 0])], false), 0, false),
+            mode,
+        );
+        for (transform, expected) in [
+            (Transform::Rotate(0), size(600, 800)),
+            (Transform::Rotate(1), size(600, 800)),
+            (Transform::Rotate(2), size(800, 600)),
+            (Transform::Rotate(3), size(600, 800)),
+            (Transform::Mirror(0), size(800, 600)),
+            (Transform::Mirror(1), size(800, 600)),
+        ] {
+            metadata.transforms = vec![transform];
+            assert_eq!(metadata.display_dimensions(), Some(expected));
+        }
+        metadata.tags.clear();
+        metadata.xmp = read(xmp("<t:Orientation>8</t:Orientation>").as_bytes(), mode).xmp;
+        metadata.transforms = vec![Transform::Rotate(3)];
+        assert_eq!(metadata.display_dimensions(), Some(size(600, 800)));
+        metadata.transforms.clear();
+        assert_eq!(metadata.display_dimensions(), Some(size(600, 800)));
+    }
+}
+
+#[test]
+fn heif_applies_primary_properties_in_association_order() {
+    for mode in [Mode::Summary, Mode::Details] {
+        for (order, expected) in [
+            (vec![1, 2, 3, 4], size(200, 400)),
+            (vec![1, 3, 4, 2], size(400, 200)),
+        ] {
+            let bytes = transformed_heif(&order);
+            let metadata = read(&bytes, mode);
+            assert_eq!(metadata.dimensions, Some(size(800, 600)));
+            assert_eq!(metadata.display_dimensions(), Some(expected));
+            assert_eq!(metadata.transforms.len(), 3);
+            assert!(metadata.issues.is_empty());
+        }
+        let bytes = transformed_heif(&[1, 2, 3, 4]);
+        assert!(matches!(
+            ente_exif::read(
+                &mut Cursor::new(bytes),
+                mode,
+                Limits {
+                    output_bytes: std::mem::size_of::<Transform>() * 2,
+                    ..Limits::default()
+                }
+            ),
+            Err(ente_exif::Error::Limit("output bytes"))
+        ));
+    }
+}
+
+#[test]
+fn crops_require_exact_pixel_rectangles_at_each_step() {
+    let base = crop(400, 200);
+    let metadata = |crop| Metadata {
+        dimensions: Some(size(800, 600)),
+        transforms: vec![Transform::Crop(crop)],
+        ..Metadata::default()
+    };
+    assert_eq!(metadata(base).display_dimensions(), Some(size(400, 200)));
+    for offset in [-200, 200] {
+        let edge = CleanAperture {
+            horizontal_offset: rational(offset, 1),
+            ..base
+        };
+        assert_eq!(metadata(edge).display_dimensions(), Some(size(400, 200)));
+    }
+    let half_offset = CleanAperture {
+        width: rational(798, 2),
+        horizontal_offset: rational(-1, 2),
+        ..base
+    };
+    assert_eq!(
+        metadata(half_offset).display_dimensions(),
+        Some(size(399, 200))
+    );
+    for invalid in [
+        CleanAperture {
+            width: rational(0, 1),
+            ..base
+        },
+        CleanAperture {
+            width: rational(801, 1),
+            ..base
+        },
+        CleanAperture {
+            width: rational(801, 2),
+            ..base
+        },
+        CleanAperture {
+            width: rational(i64::MAX, 1),
+            ..base
+        },
+        CleanAperture {
+            width: rational(i64::MIN, -1),
+            ..base
+        },
+        CleanAperture {
+            height: rational(200, 0),
+            ..base
+        },
+        CleanAperture {
+            horizontal_offset: rational(201, 1),
+            ..base
+        },
+        CleanAperture {
+            horizontal_offset: rational(-201, 1),
+            ..base
+        },
+        CleanAperture {
+            vertical_offset: rational(1, 2),
+            ..base
+        },
+        CleanAperture {
+            vertical_offset: rational(i64::MIN, i64::MAX),
+            ..base
+        },
+        CleanAperture {
+            vertical_offset: rational(0, 0),
+            ..base
+        },
+    ] {
+        assert_eq!(metadata(invalid).display_dimensions(), None, "{invalid:?}");
+    }
+    let large = Metadata {
+        dimensions: Some(size(u32::MAX, u32::MAX)),
+        transforms: vec![Transform::Crop(CleanAperture {
+            horizontal_offset: rational(0, i64::MAX),
+            vertical_offset: rational(0, i64::MAX),
+            ..crop(u32::MAX, u32::MAX)
+        })],
+        ..Metadata::default()
+    };
+    assert_eq!(large.display_dimensions(), large.dimensions);
+    let successive = Metadata {
+        transforms: vec![
+            Transform::Crop(base),
+            Transform::Rotate(1),
+            Transform::Crop(crop(100, 300)),
+        ],
+        ..metadata(base)
+    };
+    assert_eq!(successive.display_dimensions(), Some(size(100, 300)));
+    for transform in [Transform::Rotate(4), Transform::Mirror(2)] {
+        let invalid = Metadata {
+            transforms: vec![transform],
+            ..metadata(base)
+        };
+        assert_eq!(invalid.display_dimensions(), None);
+    }
+}
+
+fn size(width: u32, height: u32) -> Dimensions {
+    Dimensions { width, height }
+}
+
+fn rational(numerator: i64, denominator: i64) -> Rational {
+    Rational {
+        numerator,
+        denominator,
+    }
+}
+
+fn crop(width: u32, height: u32) -> CleanAperture {
+    CleanAperture {
+        width: rational(i64::from(width), 1),
+        height: rational(i64::from(height), 1),
+        horizontal_offset: rational(0, 1),
+        vertical_offset: rational(0, 1),
+    }
+}
+
+fn transformed_heif(order: &[u8]) -> Vec<u8> {
+    let ispe = [
+        vec![0; 4],
+        800u32.to_be_bytes().to_vec(),
+        600u32.to_be_bytes().to_vec(),
+    ]
+    .concat();
+    let clap: Vec<u8> = [400u32, 1, 200, 1, 0, 1, 0, 1]
+        .into_iter()
+        .flat_map(u32::to_be_bytes)
+        .collect();
+    let properties = [
+        box_bytes(b"ispe", &ispe),
+        box_bytes(b"clap", &clap),
+        box_bytes(b"irot", &[1]),
+        box_bytes(b"imir", &[0]),
+        box_bytes(b"irot", &[2]),
+    ]
+    .concat();
+    let mut associations = vec![0, 0, 0, 0, 0, 0, 0, 2, 0, 1, order.len() as u8];
+    associations.extend(order);
+    associations.extend([0, 2, 1, 5]);
+    [
+        box_bytes(b"ftyp", b"heic\0\0\0\0mif1"),
+        box_bytes(
+            b"meta",
+            &[
+                vec![0; 4],
+                box_bytes(b"pitm", &[0, 0, 0, 0, 0, 1]),
+                box_bytes(
+                    b"iprp",
+                    &[
+                        box_bytes(b"ipco", &properties),
+                        box_bytes(b"ipma", &associations),
+                    ]
+                    .concat(),
+                ),
+            ]
+            .concat(),
+        ),
+    ]
+    .concat()
+}

--- a/rust/crates/exif/tests/integration/formats.rs
+++ b/rust/crates/exif/tests/integration/formats.rs
@@ -488,3 +488,74 @@ fn png_text_encoding_and_bad_compressed_block_recovery() {
     assert_eq!(metadata.issues.len(), 1);
     assert_eq!(metadata.issues[0].message, "compressed PNG text");
 }
+
+#[test]
+fn motion_accepts_compatible_brands_but_not_the_minor_version() {
+    for (brands, valid, malformed) in [
+        (b"newv\0\0\0\0junkisom".as_slice(), true, false),
+        (b"isom\0\0\0\0".as_slice(), true, false),
+        (b"newvisomjunk".as_slice(), false, false),
+        (b"newv\0\0\0\0iso".as_slice(), false, true),
+    ] {
+        let video = [
+            box_bytes(b"ftyp", brands),
+            box_bytes(b"moov", &[]),
+            box_bytes(b"mdat", &[0; 16]),
+        ]
+        .concat();
+        let packet = xmp(&format!(
+            r#"<c:MicroVideoOffset xmlns:c="{}">{}</c:MicroVideoOffset>"#,
+            namespace::CAMERA,
+            video.len()
+        ));
+        let mut bytes = jpeg(&[], &packet);
+        let start = bytes.len() as u64;
+        bytes.extend(video);
+        for mode in [Mode::Summary, Mode::Details] {
+            let metadata = read(&bytes, mode);
+            assert_eq!(
+                metadata.motion_video.map(|v| (v.start, v.end)),
+                valid.then_some((start, bytes.len() as u64))
+            );
+            assert_eq!(!metadata.issues.is_empty(), malformed);
+        }
+    }
+}
+
+#[test]
+fn png_itxt_preserves_languages_with_and_without_compression() {
+    let mut bytes = b"\x89PNG\r\n\x1a\n".to_vec();
+    bytes.extend(png_chunk(b"IHDR", &[0, 0, 0, 1, 0, 0, 0, 1, 8, 2, 0, 0, 0]));
+    for (language, text, compressed) in [
+        ("en", "Snow", false),
+        ("fr", "Neige", true),
+        ("", "Ice", false),
+    ] {
+        let mut data = b"Description\0".to_vec();
+        data.extend([u8::from(compressed), 0]);
+        data.extend(language.as_bytes());
+        data.extend([0, 0]);
+        data.extend(if compressed {
+            miniz_oxide::deflate::compress_to_vec_zlib(text.as_bytes(), 6)
+        } else {
+            text.as_bytes().to_vec()
+        });
+        bytes.extend(png_chunk(b"iTXt", &data));
+    }
+    bytes.extend(png_chunk(b"IEND", &[]));
+    let metadata = read(&bytes, Mode::Details);
+    let values: Vec<_> = metadata
+        .properties("urn:png:text", "Description")
+        .map(|p| (p.language.as_deref(), p.value.as_str()))
+        .collect();
+    assert_eq!(
+        values,
+        [(Some("en"), "Snow"), (Some("fr"), "Neige"), (None, "Ice")]
+    );
+    assert_eq!(
+        read(&bytes, Mode::Summary)
+            .properties("urn:png:text", "Description")
+            .count(),
+        0
+    );
+}

--- a/rust/crates/exif/tests/integration/formats.rs
+++ b/rust/crates/exif/tests/integration/formats.rs
@@ -294,6 +294,91 @@ fn heif_protected_metadata_preserves_image_dimensions() {
 }
 
 #[test]
+fn heif_metadata_prefers_primary_references() {
+    for mime in [
+        None,
+        Some("application/rdf+xml"),
+        Some("application/xml"),
+        Some("text/xml"),
+    ] {
+        for (targets, expected, ambiguous) in [
+            ([Some(1u16), None], Some(6), false),
+            ([None, Some(1)], Some(3), false),
+            ([Some(1), Some(1)], None, true),
+            ([None, None], None, true),
+            ([Some(4), Some(1)], Some(3), false),
+            ([Some(1), Some(4)], Some(6), false),
+            ([None, Some(4)], Some(6), false),
+            ([Some(4), None], Some(3), false),
+            ([Some(4), Some(4)], None, false),
+        ] {
+            let mut info = vec![0, 0, 0, 0, 0, 2];
+            let mut locations = vec![1, 0, 0, 0, 0x44, 0, 0, 2];
+            let mut references = vec![0; 4];
+            let mut data = Vec::new();
+            for (index, target) in targets.into_iter().enumerate() {
+                let id = index as u16 + 2;
+                let orientation = if index == 0 { 6 } else { 3 };
+                let value = if mime.is_some() {
+                    xmp(&format!("<t:Orientation>{orientation}</t:Orientation>")).into_bytes()
+                } else {
+                    [
+                        vec![0; 4],
+                        tiff(&[(0x112, 3, 1, vec![orientation, 0])], false),
+                    ]
+                    .concat()
+                };
+                let mut entry = vec![2, 0, 0, 0];
+                entry.extend(id.to_be_bytes());
+                entry.extend([0, 0]);
+                entry.extend(if mime.is_some() { b"mime\0" } else { b"Exif\0" });
+                if let Some(mime) = mime {
+                    entry.extend(mime.as_bytes());
+                    entry.extend([0, 0]);
+                }
+                info.extend(box_bytes(b"infe", &entry));
+                locations.extend([id, 1, 0, 1].map(u16::to_be_bytes).concat());
+                locations.extend((data.len() as u32).to_be_bytes());
+                locations.extend((value.len() as u32).to_be_bytes());
+                data.extend(value);
+                if let Some(target) = target {
+                    references.extend(box_bytes(
+                        b"cdsc",
+                        &[id, 1, target].map(u16::to_be_bytes).concat(),
+                    ));
+                }
+            }
+            let mut meta = vec![0; 4];
+            meta.extend(box_bytes(b"pitm", &[0, 0, 0, 0, 0, 1]));
+            meta.extend(box_bytes(b"iinf", &info));
+            meta.extend(box_bytes(b"iloc", &locations));
+            meta.extend(box_bytes(b"iref", &references));
+            meta.extend(box_bytes(b"idat", &data));
+            let bytes = [
+                box_bytes(b"ftyp", b"heic\0\0\0\0mif1"),
+                box_bytes(b"meta", &meta),
+            ]
+            .concat();
+            for mode in [Mode::Summary, Mode::Details] {
+                let metadata = read(&bytes, mode);
+                let orientation = if mime.is_some() {
+                    metadata
+                        .property(namespace::TIFF, "Orientation")
+                        .map(|value| value.parse::<u32>().unwrap())
+                } else {
+                    metadata.orientation()
+                };
+                assert_eq!(orientation, expected, "{mime:?} {targets:?} {mode:?}");
+                assert_eq!(metadata.issues.len(), usize::from(ambiguous));
+                if ambiguous {
+                    assert_eq!(metadata.issues[0].message, "ambiguous primary metadata");
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn png_keywords_use_latin1_and_text_obeys_its_chunk_encoding() {
     for (kind, value) in [
         (b"tEXt", b"Caf\xe9\0Andr\xe9".to_vec()),

--- a/rust/crates/exif/tests/integration/formats.rs
+++ b/rust/crates/exif/tests/integration/formats.rs
@@ -232,6 +232,68 @@ fn heif_exif_cannot_read_beyond_its_declared_extent() {
 }
 
 #[test]
+fn heif_protected_metadata_preserves_image_dimensions() {
+    let exif = [vec![0; 4], tiff(&[(0x112, 3, 1, vec![6, 0])], false)].concat();
+    let packet = xmp("<p:ProjectionType>equirectangular</p:ProjectionType>");
+    for mime in [
+        None,
+        Some("application/rdf+xml"),
+        Some("application/xml"),
+        Some("text/xml"),
+    ] {
+        for protected in [false, true] {
+            let data = if mime.is_some() {
+                packet.as_bytes()
+            } else {
+                &exif
+            };
+            let mut info = vec![2, 0, 0, 0, 0, 2, 0, u8::from(protected)];
+            info.extend(if mime.is_some() { b"mime\0" } else { b"Exif\0" });
+            if let Some(mime) = mime {
+                info.extend(mime.as_bytes());
+                info.extend([0, 0]);
+            }
+            let mut location = vec![1, 0, 0, 0, 0x44, 0, 0, 1, 0, 2, 0, 1, 0, 0, 0, 1];
+            location.extend(0u32.to_be_bytes());
+            location.extend((data.len() as u32).to_be_bytes());
+            let image_size = box_bytes(b"ispe", &[0u32, 640, 480].map(u32::to_be_bytes).concat());
+            let mut properties = box_bytes(b"ipco", &image_size);
+            properties.extend(box_bytes(b"ipma", &[0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1]));
+            let mut meta = vec![0; 4];
+            meta.extend(box_bytes(b"pitm", &[0, 0, 0, 0, 0, 1]));
+            meta.extend(box_bytes(
+                b"iinf",
+                &[vec![0, 0, 0, 0, 0, 1], box_bytes(b"infe", &info)].concat(),
+            ));
+            meta.extend(box_bytes(b"iloc", &location));
+            meta.extend(box_bytes(b"iprp", &properties));
+            meta.extend(box_bytes(b"idat", data));
+            let bytes = [
+                box_bytes(b"ftyp", b"heic\0\0\0\0mif1"),
+                box_bytes(b"meta", &meta),
+            ]
+            .concat();
+            for mode in [Mode::Summary, Mode::Details] {
+                let metadata = read(&bytes, mode);
+                assert_eq!(
+                    (metadata.width(), metadata.height()),
+                    (Some(640), Some(480))
+                );
+                assert_eq!(
+                    metadata.orientation(),
+                    (!protected && mime.is_none()).then_some(6)
+                );
+                assert_eq!(metadata.is_panorama(), !protected && mime.is_some());
+                assert_eq!(metadata.issues.len(), usize::from(protected));
+                if protected {
+                    assert_eq!(metadata.issues[0].message, "protected metadata");
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn png_keywords_use_latin1_and_text_obeys_its_chunk_encoding() {
     for (kind, value) in [
         (b"tEXt", b"Caf\xe9\0Andr\xe9".to_vec()),
@@ -305,6 +367,50 @@ fn webp_padding_and_all_frame_headers() {
 }
 
 #[test]
+fn png_summary_skips_text_within_a_small_read_budget() {
+    for (kind, fields, compressed) in [
+        (b"tEXt", b"".as_slice(), false),
+        (b"zTXt", b"\0".as_slice(), true),
+        (b"iTXt", b"\0\0en\0Comment\0".as_slice(), false),
+        (b"iTXt", b"\x01\0en\0Comment\0".as_slice(), true),
+    ] {
+        for size in [1024, 4096] {
+            let text = vec![b'a'; size];
+            let text = if compressed {
+                miniz_oxide::deflate::compress_to_vec_zlib(&text, 0)
+            } else {
+                text
+            };
+            let bytes = [
+                b"\x89PNG\r\n\x1a\n".to_vec(),
+                png_chunk(b"IHDR", &[0, 0, 0, 1, 0, 0, 0, 2, 8, 2, 0, 0, 0]),
+                png_chunk(
+                    kind,
+                    &[vec![b'C'; 79], vec![0], fields.to_vec(), text].concat(),
+                ),
+                png_chunk(b"eXIf", &tiff(&[(0x112, 3, 1, vec![6, 0])], false)),
+                png_chunk(b"IEND", &[]),
+            ]
+            .concat();
+            let limits = ente_exif::Limits {
+                read_bytes: 256,
+                ..ente_exif::Limits::default()
+            };
+            let metadata =
+                ente_exif::read(&mut std::io::Cursor::new(&bytes), Mode::Summary, limits).unwrap();
+            assert_eq!((metadata.width(), metadata.height()), (Some(1), Some(2)));
+            assert_eq!(metadata.orientation(), Some(6));
+            assert!(metadata.issues.is_empty());
+            assert!(metadata.xmp.is_empty());
+            assert!(matches!(
+                ente_exif::read(&mut std::io::Cursor::new(&bytes), Mode::Details, limits),
+                Err(ente_exif::Error::Limit("read bytes"))
+            ));
+        }
+    }
+}
+
+#[test]
 fn gif_xmp_after_image_subblocks() {
     let mut bytes = b"GIF89a\x02\0\x03\0\0\0\0".to_vec();
     bytes.extend([0x2c, 0, 0, 0, 0, 2, 0, 3, 0, 0, 2, 3, 0, 1, 2, 0]);
@@ -355,6 +461,45 @@ fn photoshop_iptc_preserves_encoding_dates_and_caption() {
     assert_eq!(metadata.iptc[0].value, b"\x1b%G");
     assert_eq!(metadata.iptc[3].value, "Snow ☃".as_bytes());
     assert!(metadata.issues.is_empty());
+}
+
+#[test]
+fn photoshop_recovers_each_metadata_resource() {
+    let resource = |id: u16, value: &[u8]| {
+        let mut bytes = b"8BIM".to_vec();
+        bytes.extend(id.to_be_bytes());
+        bytes.extend([0, 0]);
+        bytes.extend((value.len() as u32).to_be_bytes());
+        bytes.extend(value);
+        bytes.resize(bytes.len() + (value.len() & 1), 0);
+        bytes
+    };
+    let packet = xmp("<p:ProjectionType>equirectangular</p:ProjectionType>");
+    for (id, malformed) in [
+        (0x404, b"\x1c\x02\x78\0\x05x".as_slice()),
+        (0x424, b"<".as_slice()),
+    ] {
+        let resources = [
+            b"Photoshop 3.0\0".to_vec(),
+            resource(id, malformed),
+            resource(0x424, packet.as_bytes()),
+        ]
+        .concat();
+        let jpeg = [
+            vec![0xff, 0xd8],
+            segment(0xed, &resources),
+            jpeg(&[], "")[2..].to_vec(),
+        ]
+        .concat();
+        let tiff = tiff(&[(0x8649, 7, resources.len() as u32, resources)], false);
+        for bytes in [&jpeg, &tiff] {
+            for mode in [Mode::Summary, Mode::Details] {
+                let metadata = read(bytes, mode);
+                assert!(metadata.is_panorama());
+                assert_eq!(metadata.issues.len(), 1);
+            }
+        }
+    }
 }
 
 #[test]

--- a/rust/crates/exif/tests/integration/formats.rs
+++ b/rust/crates/exif/tests/integration/formats.rs
@@ -1,0 +1,490 @@
+use super::common::*;
+use ente_exif::{Ifd, Location, Mode, Rational, Value, namespace};
+
+#[test]
+fn gps_hemispheres_zero_denominators_and_raw_dates() {
+    let rational = |n: u32, d: u32| [n.to_le_bytes(), d.to_le_bytes()].concat();
+    for (latitude, longitude, expected) in [
+        ("N", "E", Some((0.0, 0.0))),
+        ("S", "W", Some((-0.0, -0.0))),
+        ("X", "W", None),
+    ] {
+        let gps = tiff(
+            &[
+                (1, 2, 2, vec![latitude.as_bytes()[0], 0]),
+                (2, 5, 3, rational(0, 1).repeat(3)),
+                (3, 2, 2, vec![longitude.as_bytes()[0], 0]),
+                (4, 5, 3, rational(0, 1).repeat(3)),
+            ],
+            false,
+        );
+        let data = child_ifd(0x8825, gps);
+        assert_eq!(
+            read(&data, Mode::Summary).exif_location(),
+            expected.map(|(latitude, longitude)| Location {
+                latitude,
+                longitude
+            })
+        );
+    }
+    for (latitude, longitude, expected) in [
+        (b'N', b'E', (12.5, 20.25)),
+        (b'N', b'W', (12.5, -20.25)),
+        (b'S', b'E', (-12.5, 20.25)),
+        (b'S', b'W', (-12.5, -20.25)),
+    ] {
+        let gps = child_ifd(
+            0x8825,
+            tiff(
+                &[
+                    (1, 2, 2, vec![latitude, 0]),
+                    (3, 2, 2, vec![longitude, 0]),
+                    (
+                        2,
+                        5,
+                        3,
+                        [rational(12, 1), rational(30, 1), rational(0, 1)].concat(),
+                    ),
+                    (
+                        4,
+                        5,
+                        3,
+                        [rational(20, 1), rational(15, 1), rational(0, 1)].concat(),
+                    ),
+                ],
+                false,
+            ),
+        );
+        for mode in [Mode::Summary, Mode::Details] {
+            assert_eq!(
+                read(&gps, mode).exif_location(),
+                Some(Location {
+                    latitude: expected.0,
+                    longitude: expected.1
+                })
+            );
+        }
+    }
+    let broken = child_ifd(
+        0x8825,
+        tiff(
+            &[
+                (2, 5, 3, rational(0, 0).repeat(3)),
+                (4, 5, 3, rational(0, 1).repeat(3)),
+            ],
+            false,
+        ),
+    );
+    assert_eq!(read(&broken, Mode::Summary).exif_location(), None);
+    assert_eq!(
+        read(&broken, Mode::Summary)
+            .tag(Ifd::Gps(0), 2)
+            .unwrap()
+            .value
+            .number(0),
+        None
+    );
+
+    let exif = child_ifd(
+        0x8769,
+        tiff(
+            &[
+                (0x9003, 2, 20, b"2024:03:31 02:30:00\0".to_vec()),
+                (0x9011, 2, 7, b"+05:30\0".to_vec()),
+                (0x9291, 2, 7, b"123456\0".to_vec()),
+                (0x829a, 5, 1, rational(1, 125)),
+                (0xa401, 3, 1, vec![6, 0]),
+            ],
+            false,
+        ),
+    );
+    let metadata = read(&exif, Mode::Summary);
+    assert_eq!(
+        metadata.tag(Ifd::Exif(0), 0x9003).unwrap().value.text(),
+        Some("2024:03:31 02:30:00")
+    );
+    assert_eq!(
+        metadata.tag(Ifd::Exif(0), 0x9011).unwrap().value.text(),
+        Some("+05:30")
+    );
+    assert_eq!(
+        metadata.tag(Ifd::Exif(0), 0x9291).unwrap().value.text(),
+        Some("123456")
+    );
+    assert_eq!(
+        metadata.tag(Ifd::Exif(0), 0x829a).unwrap().value,
+        Value::Rational(vec![Rational {
+            numerator: 1,
+            denominator: 125
+        }])
+    );
+    assert!(metadata.is_panorama());
+}
+
+#[test]
+fn gps_rejects_malformed_references_and_components() {
+    let gps = |mut refs: Vec<(u16, u16, u32, Vec<u8>)>, minutes: i32, seconds: i32| {
+        let ratio = |n: i32| [n.to_le_bytes(), 1i32.to_le_bytes()].concat();
+        refs.extend([
+            (
+                2,
+                10,
+                3,
+                [ratio(-12), ratio(minutes), ratio(seconds)].concat(),
+            ),
+            (4, 10, 3, [ratio(-20), ratio(15), ratio(0)].concat()),
+        ]);
+        child_ifd(0x8825, tiff(&refs, false))
+    };
+    for (refs, expected) in [
+        (
+            vec![],
+            Some(Location {
+                latitude: -12.5,
+                longitude: -20.25,
+            }),
+        ),
+        (
+            vec![(1, 2, 2, b"N\0".to_vec()), (3, 2, 2, b"E\0".to_vec())],
+            Some(Location {
+                latitude: 12.5,
+                longitude: 20.25,
+            }),
+        ),
+        (vec![(1, 2, 2, b"N\0".to_vec())], None),
+        (vec![(1, 2, 2, vec![255, 0]), (3, 2, 2, vec![255, 0])], None),
+        (vec![(1, 2, 1, vec![0]), (3, 2, 1, vec![0])], None),
+        (
+            vec![(1, 4, 1, vec![1, 0, 0, 0]), (3, 4, 1, vec![1, 0, 0, 0])],
+            None,
+        ),
+    ] {
+        for mode in [Mode::Summary, Mode::Details] {
+            assert_eq!(
+                read(&gps(refs.clone(), 30, 0), mode).exif_location(),
+                expected
+            );
+        }
+    }
+    for (minutes, seconds) in [(60, 0), (-60, 0), (0, 60), (0, -60), (90, 0)] {
+        for mode in [Mode::Summary, Mode::Details] {
+            assert_eq!(
+                read(&gps(vec![], minutes, seconds), mode).exif_location(),
+                None
+            );
+        }
+    }
+}
+
+#[test]
+fn heif_contiguous_exif_skips_opaque_values_within_the_read_budget() {
+    let exif = child_ifd(
+        0x8769,
+        tiff(
+            &[
+                (0x927c, 7, 256 * 1024, vec![1; 256 * 1024]),
+                (0xa434, 2, 5, b"Lens\0".to_vec()),
+            ],
+            false,
+        ),
+    );
+    for method in [0, 1] {
+        for mode in [Mode::Summary, Mode::Details] {
+            let limits = ente_exif::Limits {
+                read_bytes: 1024,
+                ..ente_exif::Limits::default()
+            };
+            let direct = ente_exif::read(
+                &mut std::io::Cursor::new(heif(&exif, method, false)),
+                mode,
+                limits,
+            )
+            .unwrap();
+            let assembled = read(&heif(&exif, method, true), mode);
+            assert_eq!(direct.tags, assembled.tags);
+            assert_eq!(
+                direct.tag(Ifd::Exif(0), 0xa434).unwrap().value.text(),
+                Some("Lens")
+            );
+            assert!(direct.issues.is_empty());
+            assert!(direct.statistics.bytes_read < 1024);
+            assert!(assembled.statistics.bytes_read > 256 * 1024);
+        }
+    }
+}
+
+#[test]
+fn heif_exif_cannot_read_beyond_its_declared_extent() {
+    let exif = tiff(&[(0x112, 3, 1, vec![6, 0])], false);
+    for method in [0, 1] {
+        for size in [0u32, 3, 11, 12] {
+            let mut bytes = heif(&exif, method, false);
+            let iloc = bytes.windows(4).position(|b| b == b"iloc").unwrap() + 4;
+            bytes[iloc + 24..iloc + 28].copy_from_slice(&size.to_be_bytes());
+            for mode in [Mode::Summary, Mode::Details] {
+                let metadata = read(&bytes, mode);
+                assert_eq!(metadata.orientation(), None);
+                assert!(metadata.dimensions.is_some());
+                assert!(!metadata.issues.is_empty());
+            }
+        }
+    }
+}
+
+#[test]
+fn png_keywords_use_latin1_and_text_obeys_its_chunk_encoding() {
+    for (kind, value) in [
+        (b"tEXt", b"Caf\xe9\0Andr\xe9".to_vec()),
+        (
+            b"zTXt",
+            [
+                b"Caf\xe9\0\0".to_vec(),
+                miniz_oxide::deflate::compress_to_vec_zlib(b"Andr\xe9", 6),
+            ]
+            .concat(),
+        ),
+        (
+            b"iTXt",
+            [b"Caf\xe9\0\0\0\0\0".to_vec(), "André".as_bytes().to_vec()].concat(),
+        ),
+    ] {
+        let bytes = [
+            b"\x89PNG\r\n\x1a\n".to_vec(),
+            png_chunk(b"IHDR", &[0, 0, 0, 1, 0, 0, 0, 1, 8, 2, 0, 0, 0]),
+            png_chunk(kind, &value),
+            png_chunk(b"IEND", &[]),
+        ]
+        .concat();
+        let details = read(&bytes, Mode::Details);
+        assert_eq!(details.property("urn:png:text", "Café"), Some("André"));
+        assert!(details.issues.is_empty());
+        let summary = read(&bytes, Mode::Summary);
+        assert!(summary.xmp.is_empty());
+        assert!(summary.issues.is_empty());
+    }
+}
+
+#[test]
+fn webp_padding_and_all_frame_headers() {
+    let packet = xmp("<p:ProjectionType>cylindrical</p:ProjectionType>");
+    let exif = tiff(&[(0x112, 3, 1, vec![8, 0])], false);
+    for (kind, data) in [
+        (b"VP8X", vec![0; 10]),
+        (b"VP8 ", vec![0, 0, 0, 0x9d, 1, 0x2a, 1, 0, 1, 0]),
+        (b"VP8L", vec![0x2f, 0, 0, 0, 0]),
+    ] {
+        let chunk = |kind: &[u8; 4], data: &[u8]| {
+            [
+                kind.to_vec(),
+                (data.len() as u32).to_le_bytes().to_vec(),
+                data.to_vec(),
+                vec![0; data.len() & 1],
+            ]
+            .concat()
+        };
+        let body = [
+            b"WEBP".to_vec(),
+            chunk(b"JUNK", &[1]),
+            chunk(kind, &data),
+            chunk(b"EXIF", &exif),
+            chunk(b"XMP ", packet.as_bytes()),
+        ]
+        .concat();
+        let bytes = [
+            b"RIFF".to_vec(),
+            (body.len() as u32).to_le_bytes().to_vec(),
+            body,
+        ]
+        .concat();
+        let metadata = read(&bytes, Mode::Summary);
+        assert_eq!(metadata.dimensions.unwrap().width, 1);
+        assert_eq!(metadata.orientation(), Some(8));
+        assert!(metadata.is_panorama());
+        assert!(metadata.issues.is_empty());
+    }
+}
+
+#[test]
+fn gif_xmp_after_image_subblocks() {
+    let mut bytes = b"GIF89a\x02\0\x03\0\0\0\0".to_vec();
+    bytes.extend([0x2c, 0, 0, 0, 0, 2, 0, 3, 0, 0, 2, 3, 0, 1, 2, 0]);
+    bytes.extend(b"\x21\xff\x0bXMP DataXMP");
+    bytes.extend(xmp("<p:ProjectionType>equirectangular</p:ProjectionType>").as_bytes());
+    bytes.push(1);
+    bytes.extend((0..=255).rev());
+    bytes.extend([0, 0x3b]);
+    let metadata = read(&bytes, Mode::Summary);
+    assert_eq!(metadata.dimensions.unwrap().height, 3);
+    assert!(metadata.is_panorama());
+    assert!(metadata.issues.is_empty());
+}
+
+#[test]
+fn photoshop_iptc_preserves_encoding_dates_and_caption() {
+    let dataset = |r, d, text: &[u8]| {
+        [
+            vec![0x1c, r, d],
+            (text.len() as u16).to_be_bytes().to_vec(),
+            text.to_vec(),
+        ]
+        .concat()
+    };
+    let iptc = [
+        dataset(1, 90, b"\x1b%G"),
+        dataset(2, 55, b"20250131"),
+        dataset(2, 60, b"101112+0530"),
+        dataset(2, 120, "Snow ☃".as_bytes()),
+    ]
+    .concat();
+    let resource = [
+        b"Photoshop 3.0\0".to_vec(),
+        b"8BIM\x04\x04\0\0".to_vec(),
+        (iptc.len() as u32).to_be_bytes().to_vec(),
+        iptc.clone(),
+        vec![0; iptc.len() & 1],
+    ]
+    .concat();
+    let bytes = [
+        vec![0xff, 0xd8],
+        segment(0xed, &resource),
+        jpeg(&[], "")[2..].to_vec(),
+    ]
+    .concat();
+    let metadata = read(&bytes, Mode::Summary);
+    assert_eq!(metadata.iptc.len(), 4);
+    assert_eq!(metadata.iptc[0].value, b"\x1b%G");
+    assert_eq!(metadata.iptc[3].value, "Snow ☃".as_bytes());
+    assert!(metadata.issues.is_empty());
+}
+
+#[test]
+fn iptc_zero_tail_and_malformed_tail_recovery() {
+    for tail in [b"".as_slice(), b"\0", b"\0\0", b"\0\0\0", b"\0\x01"] {
+        let payload = [b"\x1c\x02\x78\0\x03Sky".as_slice(), tail].concat();
+        let bytes = tiff(&[(0x83bb, 7, payload.len() as u32, payload)], false);
+        for mode in [Mode::Summary, Mode::Details] {
+            let metadata = read(&bytes, mode);
+            assert_eq!(metadata.iptc.len(), 1);
+            assert_eq!(metadata.iptc[0].value, b"Sky");
+            assert_eq!(metadata.issues.len(), usize::from(tail.contains(&1)));
+        }
+    }
+}
+
+#[test]
+fn extended_xmp_reorders_fragments_and_rejects_overlap() {
+    let id = "0123456789ABCDEF0123456789ABCDEF";
+    let base = xmp(&format!(
+        r#"<n:HasExtendedXMP xmlns:n="{}">{id}</n:HasExtendedXMP>"#,
+        namespace::NOTE
+    ));
+    let extension = xmp("<p:ProjectionType>equirectangular</p:ProjectionType>");
+    let split = extension.len() / 2;
+    let fragment = |offset: usize, bytes: &[u8]| {
+        segment(
+            0xe1,
+            &[
+                b"http://ns.adobe.com/xmp/extension/\0".as_slice(),
+                id.as_bytes(),
+                &(extension.len() as u32).to_be_bytes(),
+                &(offset as u32).to_be_bytes(),
+                bytes,
+            ]
+            .concat(),
+        )
+    };
+    for overlap in [false, true] {
+        let bytes = [
+            vec![0xff, 0xd8],
+            fragment(
+                if overlap { 0 } else { split },
+                &extension.as_bytes()[split..],
+            ),
+            fragment(0, &extension.as_bytes()[..split]),
+            jpeg(&[], &base)[2..].to_vec(),
+        ]
+        .concat();
+        let metadata = read(&bytes, Mode::Summary);
+        assert_eq!(metadata.is_panorama(), !overlap);
+        assert_eq!(metadata.issues.is_empty(), !overlap);
+    }
+}
+
+#[test]
+fn motion_requires_real_boxes_and_respects_explicit_disable() {
+    let video = [
+        box_bytes(b"ftyp", b"isom\0\0\0\0isom"),
+        box_bytes(b"moov", &[]),
+        box_bytes(b"mdat", &[0; 256]),
+    ]
+    .concat();
+    for flag in ["0", "1"] {
+        for valid in [false, true] {
+            let mut payload = video.clone();
+            if !valid {
+                payload[24..28].copy_from_slice(b"junk");
+            }
+            let packet = xmp(&format!(
+                r#"<c:MotionPhoto xmlns:c="{}">{flag}</c:MotionPhoto><c:MicroVideoOffset xmlns:c="{}">{}</c:MicroVideoOffset>"#,
+                namespace::CAMERA,
+                namespace::CAMERA,
+                payload.len()
+            ));
+            let mut bytes = jpeg(&[], &packet);
+            let start = bytes.len() as u64;
+            bytes.extend(payload);
+            let metadata = read(&bytes, Mode::Summary);
+            assert_eq!(metadata.motion_video.is_some(), valid && flag == "1");
+            if let Some(range) = metadata.motion_video {
+                assert_eq!(range.start, start);
+                assert_eq!(range.end, bytes.len() as u64);
+            }
+        }
+    }
+}
+
+#[test]
+fn motion_directory_accounts_for_primary_padding() {
+    let video = [
+        box_bytes(b"ftyp", b"isom\0\0\0\0isom"),
+        box_bytes(b"moov", &[]),
+        box_bytes(b"mdat", &[0; 256]),
+    ]
+    .concat();
+    let xml = xmp(&format!(
+        r#"<c:Directory xmlns:c="{}" xmlns:i="{}"><r:Seq><r:li><c:Item i:Mime="image/jpeg" i:Semantic="Primary" i:Padding="4"/></r:li><r:li><c:Item i:Mime="video/mp4" i:Semantic="MotionPhoto" i:Length="{}" i:Padding="0"/></r:li></r:Seq></c:Directory>"#,
+        namespace::CONTAINER,
+        namespace::ITEM,
+        video.len()
+    ));
+    let mut bytes = jpeg(&[], &xml);
+    bytes.extend([0; 4]);
+    let start = bytes.len() as u64;
+    bytes.extend(video);
+    assert_eq!(
+        read(&bytes, Mode::Summary).motion_video.unwrap().start,
+        start
+    );
+}
+
+#[test]
+fn png_text_encoding_and_bad_compressed_block_recovery() {
+    let ihdr = [vec![0, 0, 0, 1, 0, 0, 0, 1], vec![8, 2, 0, 0, 0]].concat();
+    let bytes = [
+        b"\x89PNG\r\n\x1a\n".to_vec(),
+        png_chunk(b"IHDR", &ihdr),
+        png_chunk(b"tEXt", b"Author\0Andr\xe9"),
+        png_chunk(b"iTXt", "Description\0\0\0\0\0Snow ☃".as_bytes()),
+        png_chunk(b"zTXt", b"Broken\0\0invalid zlib"),
+        png_chunk(b"IEND", &[]),
+    ]
+    .concat();
+    let metadata = read(&bytes, Mode::Details);
+    assert_eq!(metadata.property("urn:png:text", "Author"), Some("André"));
+    assert_eq!(
+        metadata.property("urn:png:text", "Description"),
+        Some("Snow ☃")
+    );
+    assert_eq!(metadata.issues.len(), 1);
+    assert_eq!(metadata.issues[0].message, "compressed PNG text");
+}

--- a/rust/crates/exif/tests/integration/jxl.rs
+++ b/rust/crates/exif/tests/integration/jxl.rs
@@ -366,8 +366,6 @@ fn header(
     }
     pack(&bits)
 }
-
-// https://www.rfc-editor.org/rfc/rfc7932.html#section-9
 fn stored_brotli(bytes: &[u8]) -> Vec<u8> {
     assert!(!bytes.is_empty() && bytes.len() <= 65536);
     let mut bits = Vec::new();

--- a/rust/crates/exif/tests/integration/jxl.rs
+++ b/rust/crates/exif/tests/integration/jxl.rs
@@ -1,0 +1,398 @@
+use super::common::{self, box_bytes, read, tiff, xmp};
+use ente_exif::{Dimensions, Error, Format, Limits, Mode, Transform};
+use std::io::Cursor;
+
+#[test]
+fn raw_headers_cover_size_encodings_ratios_and_orientations() {
+    for (height, width, selector) in [
+        (129, 257, 0),
+        (3001, 5001, 1),
+        (65539, 90001, 2),
+        (1 << 29, 1 << 30, 3),
+    ] {
+        let bytes = header(false, height, width, 0, selector, None);
+        let metadata = read(&bytes, Mode::Summary);
+        assert_eq!(metadata.format, Format::Jxl);
+        assert_eq!(metadata.dimensions, Some(Dimensions { width, height }));
+        assert_eq!(metadata.display_dimensions(), metadata.dimensions);
+    }
+    for (ratio, width) in [
+        (1, 120),
+        (2, 144),
+        (3, 160),
+        (4, 180),
+        (5, 213),
+        (6, 150),
+        (7, 240),
+    ] {
+        let metadata = read(&header(true, 120, 0, ratio, 0, None), Mode::Summary);
+        assert_eq!(metadata.dimensions, Some(Dimensions { width, height: 120 }));
+    }
+    for orientation in 1..=8 {
+        let metadata = read(
+            &header(true, 24, 40, 0, 0, Some(orientation)),
+            Mode::Summary,
+        );
+        assert_eq!(metadata.transforms, [Transform::Orientation(orientation)]);
+        let expected = if orientation >= 5 {
+            Dimensions {
+                width: 24,
+                height: 40,
+            }
+        } else {
+            Dimensions {
+                width: 40,
+                height: 24,
+            }
+        };
+        assert_eq!(metadata.display_dimensions(), Some(expected));
+    }
+    assert_eq!(
+        read(&header(true, 24, 40, 0, 0, Some(0)), Mode::Summary).transforms,
+        [Transform::Orientation(1)]
+    );
+}
+
+#[test]
+fn codestream_wins_over_stale_exif_size_and_orientation() {
+    let exif = tiff(
+        &[
+            (0x100, 4, 1, 4032u32.to_le_bytes().to_vec()),
+            (0x101, 4, 1, 3024u32.to_le_bytes().to_vec()),
+            (0x10f, 2, 6, b"Maker\0".to_vec()),
+            (0x112, 3, 1, 6u16.to_le_bytes().to_vec()),
+        ],
+        false,
+    );
+    let exif = [2u32.to_be_bytes().as_slice(), b"--", &exif].concat();
+    for orientation in [None, Some(1), Some(6)] {
+        let bytes = container(&[
+            box_bytes(b"Exif", &exif),
+            box_bytes(b"jxlc", &header(false, 173, 211, 0, 0, orientation)),
+            box_bytes(
+                b"xml ",
+                xmp("<d:description>coast</d:description>").as_bytes(),
+            ),
+        ]);
+        for mode in [Mode::Summary, Mode::Details] {
+            let metadata = read(&bytes, mode);
+            assert!(metadata.issues.is_empty());
+            assert_eq!(metadata.width(), Some(211));
+            assert_eq!(metadata.height(), Some(173));
+            assert_eq!(metadata.orientation(), Some(6));
+            assert_eq!(metadata.camera_make(), Some("Maker"));
+            assert_eq!(metadata.xmp_description(None), Some("coast"));
+            let expected = if orientation == Some(6) {
+                Dimensions {
+                    width: 173,
+                    height: 211,
+                }
+            } else {
+                Dimensions {
+                    width: 211,
+                    height: 173,
+                }
+            };
+            assert_eq!(metadata.display_dimensions(), Some(expected));
+        }
+    }
+}
+
+#[test]
+fn split_headers_can_cross_every_byte_boundary() {
+    let stream = header(false, 400001, 500001, 0, 3, Some(8));
+    for split in 0..=stream.len() {
+        let bytes = container(&[
+            part(0, &stream[..split]),
+            box_bytes(
+                b"xml ",
+                xmp("<d:description>between parts</d:description>").as_bytes(),
+            ),
+            part(1, &[]),
+            part(0x8000_0002, &stream[split..]),
+        ]);
+        let metadata = read(&bytes, Mode::Summary);
+        assert_eq!(
+            metadata.display_dimensions(),
+            Some(Dimensions {
+                width: 400001,
+                height: 500001
+            })
+        );
+        assert_eq!(metadata.xmp_description(None), Some("between parts"));
+    }
+}
+
+#[test]
+fn extended_and_to_eof_boxes_skip_pixel_payloads() {
+    let mut stream = header(false, 71, 113, 0, 0, None);
+    stream.resize(500_000, 0);
+    for size in [0u32, 1] {
+        let mut body = size.to_be_bytes().to_vec();
+        body.extend(b"jxlc");
+        if size == 1u32 {
+            body.extend((16 + stream.len() as u64).to_be_bytes());
+        }
+        body.extend(&stream);
+        let metadata = read(&container(&[body]), Mode::Summary);
+        assert_eq!(
+            metadata.dimensions,
+            Some(Dimensions {
+                width: 113,
+                height: 71
+            })
+        );
+        assert!(metadata.statistics.bytes_read < 80);
+    }
+}
+
+#[test]
+fn invalid_box_sizes_and_codestream_sequences_fail() {
+    let stream = header(true, 24, 40, 0, 0, None);
+    for boxes in [
+        vec![],
+        vec![part(0, &stream)],
+        vec![part(0x8000_0001, &stream)],
+        vec![part(0, &stream), part(0x8000_0000, &[])],
+        vec![part(0x8000_0000, &stream), part(0x8000_0001, &[])],
+        vec![part(0, &stream), box_bytes(b"jxlc", &stream)],
+        vec![box_bytes(b"jxlc", &stream), box_bytes(b"jxlc", &stream)],
+        vec![box_bytes(b"jxlp", &[0, 0, 0])],
+        vec![b"\0\0\0\x07jxlc".to_vec()],
+        vec![b"\0\0\0\x01jxlc\0\0\0\0\0\0\0\x0f".to_vec()],
+        vec![b"\0\0\0\x01jxlc\xff\xff\xff\xff\xff\xff\xff\xff".to_vec()],
+    ] {
+        assert!(matches!(
+            ente_exif::read(
+                &mut Cursor::new(container(&boxes)),
+                Mode::Summary,
+                Limits::default()
+            ),
+            Err(Error::Malformed(_))
+        ));
+    }
+}
+
+#[test]
+fn brotli_metadata_uses_the_same_exif_and_xmp_paths() {
+    let exif = [
+        vec![0; 4],
+        tiff(&[(0x10f, 2, 6, b"Maker\0".to_vec())], true),
+    ]
+    .concat();
+    let xml = xmp("<d:description>星空</d:description>");
+    let bytes = container(&[
+        box_bytes(b"jxlc", &header(true, 24, 40, 0, 0, None)),
+        brob(b"Exif", &stored_brotli(&exif)),
+        brob(b"xml ", &stored_brotli(xml.as_bytes())),
+    ]);
+    for mode in [Mode::Summary, Mode::Details] {
+        let metadata = read(&bytes, mode);
+        assert!(metadata.issues.is_empty(), "{:?}", metadata.issues);
+        assert_eq!(metadata.camera_make(), Some("Maker"));
+        assert_eq!(metadata.xmp_description(None), Some("星空"));
+    }
+}
+
+#[test]
+fn compressed_output_grows_within_an_aggregate_budget() {
+    const COMPRESSED: &[u8] = &[
+        0x42, 0x9e, 0x13, 0x80, 0x9c, 0x5b, 0x4b, 0xf5, 0x25, 0x9f, 0x46, 0x2c, 0x31, 0xd6, 0x09,
+        0xed, 0x35, 0x99, 0xeb, 0xe4, 0x00, 0x0f, 0xe8, 0xb5, 0x24, 0xf0, 0x92, 0x08, 0x03, 0x4a,
+        0x13, 0x0a, 0x00, 0x03, 0x0c, 0xc8, 0x72, 0x1b, 0x7b, 0x6e, 0x47, 0x51, 0x09, 0x42, 0xa7,
+        0xd3, 0xe8, 0x0e, 0x93, 0x63, 0xfa, 0x13, 0xd5, 0x0e, 0x5f, 0x6d, 0x67, 0x32, 0x23, 0x3b,
+        0x10, 0xdc, 0xb3, 0x92, 0x2a, 0x1c, 0xfd, 0x08, 0xe7, 0xbf, 0x5c, 0xcd, 0x07, 0xcb, 0x59,
+        0x57, 0xc1, 0x1d, 0x46, 0xb6, 0x34, 0x42, 0x1f, 0xdb, 0x7d, 0x4c, 0xf0, 0xbe, 0x23, 0x61,
+        0x1b, 0x12, 0x14, 0xaa, 0x82, 0xeb, 0x4d, 0x5f, 0xad, 0xc1, 0x81, 0xe6, 0x74, 0x94, 0xa8,
+        0x8e, 0x46, 0x70, 0xec, 0xf3, 0x27, 0x01, 0x72, 0x4c, 0xa1, 0x20,
+    ];
+    let stream = box_bytes(b"jxlc", &header(true, 24, 40, 0, 0, None));
+    let encoded = brob(b"xml ", COMPRESSED);
+    let plain = br#"<r:RDF xmlns:r="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><r:Description xmlns:d="http://purl.org/dc/elements/1.1/"><d:description>woods</d:description></r:Description></r:RDF>"#;
+    let exact = plain.len() + 40000;
+    let mut limits = Limits {
+        read_bytes: 65536,
+        ..Default::default()
+    };
+    let metadata = ente_exif::read(
+        &mut Cursor::new(container(&[stream.clone(), encoded.clone()])),
+        Mode::Summary,
+        limits,
+    )
+    .unwrap();
+    assert!(metadata.issues.is_empty());
+    assert_eq!(metadata.xmp_description(None), Some("woods"));
+    assert!(metadata.statistics.bytes_read < 300);
+    let repeated = container(&[stream.clone(), encoded.clone(), encoded.clone()]);
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(&repeated), Mode::Summary, limits),
+        Err(Error::Limit("Brotli output"))
+    ));
+    limits.read_bytes = exact * 2;
+    assert!(ente_exif::read(&mut Cursor::new(&repeated), Mode::Summary, limits).is_ok());
+    limits.read_bytes -= 1;
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(&repeated), Mode::Summary, limits),
+        Err(Error::Limit("Brotli output"))
+    ));
+}
+
+#[test]
+fn malformed_compressed_metadata_recovers_but_limits_stop() {
+    let xml = xmp("<d:description>after</d:description>");
+    let compressed = stored_brotli(xml.as_bytes());
+    for bad in [
+        compressed[..compressed.len() - 1].to_vec(),
+        [compressed.clone(), vec![0]].concat(),
+        vec![0x11],
+        vec![],
+    ] {
+        let metadata = read(
+            &container(&[
+                box_bytes(b"jxlc", &header(true, 24, 40, 0, 0, None)),
+                brob(b"xml ", &bad),
+                box_bytes(b"xml ", xml.as_bytes()),
+            ]),
+            Mode::Summary,
+        );
+        assert_eq!(metadata.issues.len(), 1);
+        assert_eq!(metadata.xmp_description(None), Some("after"));
+    }
+    let bytes = container(&[
+        box_bytes(b"jxlc", &header(true, 24, 40, 0, 0, None)),
+        brob(b"xml ", &[0x0f]),
+    ]);
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(bytes), Mode::Summary, Limits::default()),
+        Err(Error::Limit("Brotli window"))
+    ));
+}
+
+#[test]
+fn unknown_boxes_are_skipped_and_brob_cannot_wrap_codestreams() {
+    let metadata = read(
+        &container(&[
+            box_bytes(b"jxlc", &header(true, 24, 40, 0, 0, None)),
+            brob(b"jumb", &[0x11]),
+            brob(b"brob", &[]),
+            brob(b"jxlc", &[]),
+            box_bytes(b"free", &vec![0; 10000]),
+        ]),
+        Mode::Summary,
+    );
+    assert_eq!(metadata.issues.len(), 2);
+    assert!(metadata.statistics.bytes_read < 120);
+}
+
+#[test]
+fn header_truncations_and_mutations_remain_bounded() {
+    let bytes = container(&[
+        part(0, &[0xff]),
+        part(
+            0x8000_0001,
+            &header(false, 400001, 500001, 0, 3, Some(7))[1..],
+        ),
+        brob(
+            b"xml ",
+            &stored_brotli(xmp("<d:description>green</d:description>").as_bytes()),
+        ),
+    ]);
+    for end in 0..bytes.len() {
+        common::exercise(&bytes[..end], Limits::default());
+    }
+    for index in 0..bytes.len() {
+        let mut changed = bytes.clone();
+        changed[index] ^= 0xff;
+        common::exercise(&changed, Limits::default());
+        common::exercise(
+            &changed,
+            Limits {
+                read_bytes: 256,
+                entries: 8,
+                output_bytes: 512,
+                ..Default::default()
+            },
+        );
+    }
+}
+
+fn container(boxes: &[Vec<u8>]) -> Vec<u8> {
+    [
+        b"\0\0\0\x0cJXL \r\n\x87\n".to_vec(),
+        box_bytes(b"ftyp", b"jxl \0\0\0\0jxl "),
+        boxes.concat(),
+    ]
+    .concat()
+}
+
+fn part(index: u32, bytes: &[u8]) -> Vec<u8> {
+    box_bytes(b"jxlp", &[index.to_be_bytes().as_slice(), bytes].concat())
+}
+
+fn brob(kind: &[u8; 4], bytes: &[u8]) -> Vec<u8> {
+    box_bytes(b"brob", &[kind.as_slice(), bytes].concat())
+}
+
+fn header(
+    div8: bool,
+    height: u32,
+    width: u32,
+    ratio: u32,
+    selector: u32,
+    orientation: Option<u8>,
+) -> Vec<u8> {
+    let mut bits = Vec::new();
+    put(&mut bits, 0x0aff, 16);
+    put(&mut bits, u32::from(div8), 1);
+    let dimension = |bits: &mut Vec<bool>, value: u32| {
+        if div8 {
+            put(bits, value / 8 - 1, 5);
+        } else {
+            put(bits, selector, 2);
+            put(bits, value - 1, [9, 13, 18, 30][selector as usize]);
+        }
+    };
+    dimension(&mut bits, height);
+    put(&mut bits, ratio, 3);
+    if ratio == 0 {
+        dimension(&mut bits, width);
+    }
+    put(&mut bits, u32::from(orientation.is_none()), 1);
+    if let Some(value) = orientation {
+        put(&mut bits, u32::from(value != 0), 1);
+        if value != 0 {
+            put(&mut bits, u32::from(value - 1), 3);
+        }
+    }
+    pack(&bits)
+}
+
+// https://www.rfc-editor.org/rfc/rfc7932.html#section-9
+fn stored_brotli(bytes: &[u8]) -> Vec<u8> {
+    assert!(!bytes.is_empty() && bytes.len() <= 65536);
+    let mut bits = Vec::new();
+    put(&mut bits, 0, 1);
+    put(&mut bits, 0, 1);
+    put(&mut bits, 0, 2);
+    put(&mut bits, bytes.len() as u32 - 1, 16);
+    put(&mut bits, 1, 1);
+    let mut output = pack(&bits);
+    output.extend(bytes);
+    output.push(3);
+    output
+}
+
+fn put(bits: &mut Vec<bool>, value: u32, count: usize) {
+    bits.extend((0..count).map(|i| value & (1 << i) != 0));
+}
+
+fn pack(bits: &[bool]) -> Vec<u8> {
+    bits.chunks(8)
+        .map(|chunk| {
+            chunk
+                .iter()
+                .enumerate()
+                .fold(0, |v, (i, b)| v | (u8::from(*b) << i))
+        })
+        .collect()
+}

--- a/rust/crates/exif/tests/integration/limits.rs
+++ b/rust/crates/exif/tests/integration/limits.rs
@@ -1,0 +1,181 @@
+use super::common::*;
+use ente_exif::{Error, Limits, Mode};
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+
+#[test]
+fn io_errors_propagate_and_unknown_formats_only_read_the_header() {
+    struct Failed;
+    impl Read for Failed {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("failed source"))
+        }
+    }
+    impl Seek for Failed {
+        fn seek(&mut self, _: SeekFrom) -> io::Result<u64> {
+            Ok(100)
+        }
+    }
+    let error = ente_exif::read(&mut Failed, Mode::Summary, Limits::default()).unwrap_err();
+    assert!(matches!(error, Error::Io(_)));
+    let source = std::error::Error::source(&error).unwrap();
+    assert!(source.is::<io::Error>());
+    assert_eq!(source.to_string(), "failed source");
+    let mut input = Cursor::new(vec![b'a'; 1_000_000]);
+    assert!(matches!(
+        ente_exif::read(&mut input, Mode::Summary, Limits::default()),
+        Err(Error::Unsupported("format"))
+    ));
+    assert_eq!(input.position(), 16);
+}
+
+#[test]
+fn xml_namespace_expansion_duplicate_attributes_and_multiple_roots() {
+    let declarations: String = (0..65)
+        .map(|i| format!(" xmlns:p{i}=\"urn:{i}\""))
+        .collect();
+    let duplicate = format!(
+        "<r:RDF xmlns:r=\"{}\"><r:Description a=\"1\" a=\"2\"/></r:RDF>",
+        ente_exif::namespace::RDF
+    );
+    for xml in [
+        format!("<root{declarations}/>"),
+        duplicate,
+        xmp("") + "<second/>",
+    ] {
+        assert!(ente_exif::read(&mut Cursor::new(xml), Mode::Details, Limits::default()).is_err());
+    }
+}
+
+#[test]
+fn compressed_png_cannot_expand_beyond_budget() {
+    let text = miniz_oxide::deflate::compress_to_vec_zlib(&vec![b'a'; 100_000], 6);
+    let bytes = [
+        b"\x89PNG\r\n\x1a\n".to_vec(),
+        png_chunk(b"zTXt", &[b"XML:com.adobe.xmp\0\0".to_vec(), text].concat()),
+        png_chunk(b"IEND", &[]),
+    ]
+    .concat();
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(bytes), Mode::Summary, Limits::default()),
+        Err(Error::Limit(_))
+    ));
+
+    let packet = xmp(&" ".repeat(4000));
+    let compressed = miniz_oxide::deflate::compress_to_vec_zlib(packet.as_bytes(), 6);
+    let chunk = png_chunk(
+        b"zTXt",
+        &[b"XML:com.adobe.xmp\0\0".to_vec(), compressed].concat(),
+    );
+    let mut repeated = b"\x89PNG\r\n\x1a\n".to_vec();
+    for _ in 0..8 {
+        repeated.extend(&chunk);
+    }
+    let limits = Limits {
+        read_bytes: 10_000,
+        ..Limits::default()
+    };
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(repeated), Mode::Summary, limits),
+        Err(Error::Limit("expanded bytes"))
+    ));
+}
+
+#[test]
+fn length_fields_and_entry_counts_do_not_drive_allocations() {
+    let cases = [
+        tiff(
+            &[(0x10f, 2, u32::MAX, u32::MAX.to_le_bytes().to_vec())],
+            false,
+        ),
+        [b"\x89PNG\r\n\x1a\n".as_slice(), &[0xff; 4], b"iTXt"].concat(),
+        b"RIFF\xff\xff\xff\xffWEBPEXIF\xff\xff\xff\xff".to_vec(),
+        [
+            1u32.to_be_bytes().to_vec(),
+            b"ftyp".to_vec(),
+            u64::MAX.to_be_bytes().to_vec(),
+        ]
+        .concat(),
+    ];
+    for bytes in cases {
+        assert!(
+            ente_exif::read(&mut Cursor::new(bytes), Mode::Details, Limits::default()).is_err()
+        );
+    }
+    let bytes = tiff(&[(0x10f, 2, 6, b"Canon\0".to_vec())], false);
+    for limits in [
+        Limits {
+            entries: 0,
+            ..Limits::default()
+        },
+        Limits {
+            directories: 0,
+            ..Limits::default()
+        },
+        Limits {
+            read_bytes: 1,
+            ..Limits::default()
+        },
+    ] {
+        assert!(matches!(
+            ente_exif::read(&mut Cursor::new(&bytes), Mode::Summary, limits),
+            Err(Error::Limit(_))
+        ));
+    }
+}
+
+#[test]
+fn oversized_jxrs_footer_does_not_read_its_payload() {
+    let bytes = [
+        jpeg(&[], ""),
+        b"jxrs".to_vec(),
+        u32::MAX.to_le_bytes().to_vec(),
+    ]
+    .concat();
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(bytes), Mode::Summary, Limits::default()),
+        Err(Error::Limit("JXRS index"))
+    ));
+}
+
+#[test]
+fn png_text_limits_apply_to_utf8_output_before_conversion() {
+    let limits = Limits {
+        value_bytes: 4,
+        ..Limits::default()
+    };
+    for (kind, payload, expected) in [
+        (b"tEXt", b"Note\0ABCD".to_vec(), Some("ABCD")),
+        (b"tEXt", b"Note\0ABCDE".to_vec(), None),
+        (b"tEXt", b"Note\0\xe9\xe9".to_vec(), Some("éé")),
+        (b"tEXt", b"Note\0\xe9\xe9\xe9".to_vec(), None),
+        (
+            b"zTXt",
+            [
+                b"Note\0\0".to_vec(),
+                miniz_oxide::deflate::compress_to_vec_zlib(b"\xe9\xe9\xe9", 6),
+            ]
+            .concat(),
+            None,
+        ),
+        (b"iTXt", "Note\0\0\0\0\0éé".as_bytes().to_vec(), Some("éé")),
+        (b"iTXt", "Note\0\0\0\0\0ééé".as_bytes().to_vec(), None),
+    ] {
+        let bytes = [
+            b"\x89PNG\r\n\x1a\n".to_vec(),
+            png_chunk(b"IHDR", &[0, 0, 0, 1, 0, 0, 0, 1, 8, 2, 0, 0, 0]),
+            png_chunk(kind, &payload),
+            png_chunk(b"IEND", &[]),
+        ]
+        .concat();
+        let result = ente_exif::read(&mut Cursor::new(&bytes), Mode::Details, limits);
+        if let Some(expected) = expected {
+            assert_eq!(
+                result.unwrap().property("urn:png:text", "Note"),
+                Some(expected)
+            );
+        } else {
+            assert!(matches!(result, Err(Error::Limit("PNG text"))));
+        }
+        assert!(ente_exif::read(&mut Cursor::new(&bytes), Mode::Summary, limits).is_ok());
+    }
+}

--- a/rust/crates/exif/tests/integration/limits.rs
+++ b/rust/crates/exif/tests/integration/limits.rs
@@ -179,3 +179,49 @@ fn png_text_limits_apply_to_utf8_output_before_conversion() {
         assert!(ente_exif::read(&mut Cursor::new(&bytes), Mode::Summary, limits).is_ok());
     }
 }
+
+#[test]
+fn undersized_jxrs_is_recoverable() {
+    for length in 0u32..8 {
+        let bytes = [
+            jpeg(&[], ""),
+            b"jxrs".to_vec(),
+            length.to_le_bytes().to_vec(),
+        ]
+        .concat();
+        for mode in [Mode::Summary, Mode::Details] {
+            let metadata = read(&bytes, mode);
+            assert_eq!(metadata.width(), Some(30));
+            assert_eq!(metadata.issues.len(), 1);
+            assert_eq!(metadata.issues[0].message, "JXRS length");
+        }
+    }
+}
+
+#[test]
+fn png_language_obeys_value_and_retention_budgets() {
+    let bytes = [
+        b"\x89PNG\r\n\x1a\n".to_vec(),
+        png_chunk(b"iTXt", b"Note\0\0\0en-US\0\0x"),
+    ]
+    .concat();
+    for limits in [
+        Limits {
+            value_bytes: 4,
+            ..Limits::default()
+        },
+        Limits {
+            output_bytes: std::mem::size_of::<ente_exif::Property>()
+                + "urn:png:text".len()
+                + "Note".len()
+                + 1
+                + 4,
+            ..Limits::default()
+        },
+    ] {
+        assert!(matches!(
+            ente_exif::read(&mut Cursor::new(&bytes), Mode::Details, limits),
+            Err(Error::Limit(_))
+        ));
+    }
+}

--- a/rust/crates/exif/tests/integration/main.rs
+++ b/rust/crates/exif/tests/integration/main.rs
@@ -1,0 +1,12 @@
+mod common;
+
+mod capture;
+mod datetime;
+mod dimensions;
+mod formats;
+mod jxl;
+mod limits;
+mod metadata;
+mod png_profiles;
+mod reader;
+mod text;

--- a/rust/crates/exif/tests/integration/metadata.rs
+++ b/rust/crates/exif/tests/integration/metadata.rs
@@ -1,0 +1,435 @@
+use super::common::*;
+use ente_exif::{Error, Ifd, Limits, Location, Mode, namespace};
+use std::io::Cursor;
+
+#[test]
+fn xmp_coordinate_forms_and_invalid_axes() {
+    for (lat, lon, refs, expected) in [
+        ("12.97236N", "77.59457E", "", Some((12.97236, 77.59457))),
+        ("33.8688S", "151.2093W", "", Some((-33.8688, -151.2093))),
+        (
+            "37,46.5N",
+            "122,25W",
+            "",
+            Some((37.775, -(122.0 + 25.0 / 60.0))),
+        ),
+        (
+            "37,46,30N",
+            "122,25,0W",
+            "",
+            Some((37.775, -(122.0 + 25.0 / 60.0))),
+        ),
+        (
+            "8.5",
+            "76.25",
+            "<e:GPSLatitudeRef>n</e:GPSLatitudeRef><e:GPSLongitudeRef> E </e:GPSLongitudeRef>",
+            Some((8.5, 76.25)),
+        ),
+        ("0N", "0E", "", Some((0.0, 0.0))),
+        ("90N", "180E", "", Some((90.0, 180.0))),
+        ("12E", "77N", "", None),
+        ("91N", "181E", "", None),
+        ("12,60N", "77E", "", None),
+        ("NaNN", "77E", "", None),
+        ("infN", "77E", "", None),
+        ("12N", "", "", None),
+        ("12", "77", "", None),
+        ("12,0,0,1N", "77E", "", None),
+    ] {
+        let source = xmp(&format!(
+            "<e:GPSLatitude>{lat}</e:GPSLatitude><e:GPSLongitude>{lon}</e:GPSLongitude>{refs}"
+        ));
+        for mode in [Mode::Summary, Mode::Details] {
+            let metadata = read(source.as_bytes(), mode);
+            assert_eq!(
+                metadata.xmp_location(),
+                expected.map(|(latitude, longitude)| Location {
+                    latitude,
+                    longitude
+                })
+            );
+            assert_eq!(metadata.exif_location(), None);
+        }
+    }
+}
+
+#[test]
+fn descriptions_preserve_alternatives_and_choose_language_on_demand() {
+    let source = xmp(
+        r#"<d:description><r:Alt><r:li xml:lang="fr">Neige</r:li><r:li xml:lang="x-default">Snow</r:li><r:li xml:lang="en">White snow</r:li></r:Alt></d:description>"#,
+    );
+    for mode in [Mode::Summary, Mode::Details] {
+        let metadata = read(source.as_bytes(), mode);
+        assert_eq!(metadata.xmp_description(None), Some("Snow"));
+        assert_eq!(metadata.xmp_description(Some("FR")), Some("Neige"));
+        assert_eq!(metadata.xmp_description(Some("de")), Some("Snow"));
+        assert_eq!(metadata.properties(namespace::DC, "description").count(), 3);
+    }
+}
+
+#[test]
+fn xmp_prefixes_do_not_change_keywords_descriptions_or_attributes() {
+    for (rdf, dc, tiff) in [("rdf", "dc", "tiff"), ("n", "words", "camera")] {
+        let source = format!(
+            r#"<{rdf}:RDF xmlns:{rdf}="{}" xmlns:{dc}="{}" xmlns:{tiff}="{}">
+            <{rdf}:Description {tiff}:Make="Test camera">
+              <{dc}:subject><{rdf}:Bag>
+                <{rdf}:li>forest</{rdf}:li><{rdf}:li>café</{rdf}:li><{rdf}:li>forest</{rdf}:li>
+              </{rdf}:Bag></{dc}:subject>
+              <{dc}:description><{rdf}:Alt>
+                <{rdf}:li xml:lang="x-default">Morning</{rdf}:li>
+                <{rdf}:li xml:lang="fr">Matin</{rdf}:li>
+              </{rdf}:Alt></{dc}:description>
+            </{rdf}:Description></{rdf}:RDF>"#,
+            namespace::RDF,
+            namespace::DC,
+            namespace::TIFF,
+        );
+        for mode in [Mode::Summary, Mode::Details] {
+            let metadata = read(source.as_bytes(), mode);
+            assert_eq!(
+                metadata.property(namespace::TIFF, "Make"),
+                Some("Test camera")
+            );
+            assert_eq!(metadata.xmp_description(None), Some("Morning"));
+            assert_eq!(metadata.xmp_description(Some("fr")), Some("Matin"));
+            let keywords: Vec<_> = metadata
+                .properties(namespace::DC, "subject")
+                .map(|p| p.value.as_str())
+                .collect();
+            if mode == Mode::Details {
+                assert_eq!(keywords, ["forest", "café", "forest"]);
+            } else {
+                assert!(keywords.is_empty());
+            }
+        }
+    }
+}
+
+#[test]
+fn skipped_xmp_values_do_not_consume_retention_budgets() {
+    let source = xmp(&format!(
+        r#"<r:Description xmlns:c="{}" c:HdrPlusMakernote="{}"/><p:ProjectionType>cylindrical</p:ProjectionType>"#,
+        namespace::CAMERA,
+        "x".repeat(Limits::default().value_bytes + 1)
+    ));
+    for mode in [Mode::Summary, Mode::Details] {
+        let metadata = read(source.as_bytes(), mode);
+        assert!(metadata.is_panorama());
+        assert_eq!(
+            metadata.property(namespace::CAMERA, "HdrPlusMakernote"),
+            None
+        );
+    }
+    let source = xmp(&format!(
+        "<d:subject>{}</d:subject><d:description>Kept</d:description>",
+        "x".repeat(Limits::default().value_bytes + 1)
+    ));
+    assert_eq!(
+        read(source.as_bytes(), Mode::Summary).xmp_description(None),
+        Some("Kept")
+    );
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(&source), Mode::Details, Limits::default()),
+        Err(Error::Limit(_))
+    ));
+    let limits = Limits {
+        read_bytes: 100,
+        ..Limits::default()
+    };
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(&source), Mode::Summary, limits),
+        Err(Error::Limit(_))
+    ));
+}
+
+#[test]
+fn structured_read_preserves_region_owners_and_nested_list_identity() {
+    let source = xmp(
+        r#"<m:Regions xmlns:m="urn:regions" xmlns:a="urn:area"><m:RegionList><r:Bag>
+      <r:li r:parseType="Resource"><m:Name>Alice</m:Name><m:Area a:x="0.2" a:y="0.3"/><d:subject><r:Bag><r:li>family</r:li></r:Bag></d:subject></r:li>
+      <r:li r:parseType="Resource"><m:Name>Bob</m:Name><m:Area a:x="0.8" a:y="0.7"/></r:li>
+    </r:Bag></m:RegionList></m:Regions>"#,
+    );
+    let structured =
+        ente_exif::read_structured(&mut Cursor::new(source.as_bytes()), Limits::default()).unwrap();
+    let metadata = &structured.metadata;
+    assert_eq!(metadata, &read(source.as_bytes(), Mode::Details));
+    assert_eq!(structured.xmp.parents.len(), metadata.xmp.len());
+    let owner = |property: &ente_exif::Property| {
+        let index = metadata
+            .xmp
+            .iter()
+            .position(|p| std::ptr::eq(p, property))
+            .unwrap();
+        let mut node = structured.xmp.parents[index];
+        while let Some(index) = node {
+            let n = &structured.xmp.nodes[index as usize];
+            if n.namespace == namespace::RDF && n.name == "li" && n.item == Some(1) {
+                return n.item;
+            }
+            node = n.parent;
+        }
+        None
+    };
+    let alice = metadata
+        .properties("urn:regions", "Name")
+        .find(|p| p.value == "Alice")
+        .unwrap();
+    let family = metadata
+        .properties(namespace::DC, "subject")
+        .next()
+        .unwrap();
+    assert_ne!(alice.item, family.item);
+    assert_eq!(owner(alice), Some(1));
+    assert_eq!(owner(family), Some(1));
+    let coordinates: Vec<_> = metadata.properties("urn:area", "x").collect();
+    assert_eq!(owner(coordinates[0]), Some(1));
+    assert_eq!(owner(coordinates[1]), None);
+    assert_ne!(coordinates[0].item, coordinates[1].item);
+}
+
+#[test]
+fn structured_ancestors_share_the_output_budget() {
+    let source = xmp(
+        "<d:a><d:b><d:c><d:d><d:e><d:f><d:subject><r:Bag><r:li>family</r:li></r:Bag></d:subject></d:f></d:e></d:d></d:c></d:b></d:a>",
+    );
+    let limits = Limits {
+        output_bytes: 512,
+        ..Limits::default()
+    };
+    assert!(ente_exif::read(&mut Cursor::new(&source), Mode::Details, limits).is_ok());
+    assert!(matches!(
+        ente_exif::read_structured(&mut Cursor::new(&source), limits),
+        Err(Error::Limit(_))
+    ));
+}
+
+#[test]
+fn broken_secondary_directory_does_not_hide_primary_exif() {
+    let mut bytes = tiff(&[(0x8769, 4, 1, 26u32.to_le_bytes().to_vec())], false);
+    bytes[22..26].copy_from_slice(&u32::MAX.to_le_bytes());
+    bytes.extend_from_slice(&tiff(&[(0xa401, 3, 1, vec![6, 0])], false)[8..]);
+    for mode in [Mode::Summary, Mode::Details] {
+        let metadata = read(&bytes, mode);
+        assert_eq!(
+            metadata.tag(Ifd::Exif(0), 0xa401).unwrap().value.unsigned(),
+            Some(6)
+        );
+        assert!(metadata.is_panorama());
+        assert_eq!(metadata.issues.len(), usize::from(mode == Mode::Details));
+    }
+}
+
+#[test]
+fn utf16_sidecars_decode_both_orders_and_reject_invalid_surrogates() {
+    let source = xmp("<d:description>Snow ☃</d:description>");
+    for little in [false, true] {
+        let mut bytes = if little {
+            vec![0xff, 0xfe]
+        } else {
+            vec![0xfe, 0xff]
+        };
+        for unit in source.encode_utf16() {
+            bytes.extend(if little {
+                unit.to_le_bytes()
+            } else {
+                unit.to_be_bytes()
+            });
+        }
+        for mode in [Mode::Summary, Mode::Details] {
+            assert_eq!(read(&bytes, mode).xmp_description(None), Some("Snow ☃"));
+        }
+    }
+    assert!(
+        ente_exif::read(
+            &mut Cursor::new([0xff, 0xfe, 0, 0xd8]),
+            Mode::Summary,
+            Limits::default()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn dimensions_keep_stored_size_and_explicit_orientation_separate() {
+    use ente_exif::Dimensions;
+    let stored = Dimensions {
+        width: 640,
+        height: 480,
+    };
+    for orientation in [0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9, u32::MAX] {
+        let bytes = tiff(
+            &[
+                (0x100, 4, 1, 640u32.to_le_bytes().to_vec()),
+                (0x101, 4, 1, 480u32.to_le_bytes().to_vec()),
+                (0x112, 4, 1, orientation.to_le_bytes().to_vec()),
+            ],
+            false,
+        );
+        let expected = if (5..=8).contains(&orientation) {
+            Dimensions {
+                width: 480,
+                height: 640,
+            }
+        } else {
+            stored
+        };
+        for mode in [Mode::Summary, Mode::Details] {
+            let metadata = read(&bytes, mode);
+            assert_eq!(
+                (metadata.width(), metadata.height()),
+                (Some(640), Some(480))
+            );
+            assert_eq!(metadata.display_dimensions(), Some(expected));
+            assert_eq!(stored.with_exif_orientation(orientation), expected);
+        }
+    }
+    let empty = ente_exif::Metadata::default();
+    assert_eq!(empty.width(), None);
+    assert_eq!(empty.height(), None);
+    assert_eq!(empty.display_dimensions(), None);
+    let no_orientation = ente_exif::Metadata {
+        dimensions: Some(stored),
+        ..empty
+    };
+    assert_eq!(no_orientation.display_dimensions(), Some(stored));
+}
+
+#[test]
+fn xmp_dimensions_require_a_complete_positive_integer_pair() {
+    for (fields, expected) in [
+        (
+            "<t:ImageWidth>640</t:ImageWidth><t:ImageLength>480</t:ImageLength>",
+            Some((640, 480)),
+        ),
+        (
+            "<e:PixelXDimension>1280</e:PixelXDimension><e:PixelYDimension>720</e:PixelYDimension>",
+            Some((1280, 720)),
+        ),
+        (
+            "<t:ImageWidth>640</t:ImageWidth><e:PixelYDimension>480</e:PixelYDimension>",
+            None,
+        ),
+        (
+            "<t:ImageWidth>0</t:ImageWidth><t:ImageLength>480</t:ImageLength>",
+            None,
+        ),
+        (
+            "<t:ImageWidth>640px</t:ImageWidth><t:ImageLength>480</t:ImageLength>",
+            None,
+        ),
+        (
+            "<t:ImageWidth>-640</t:ImageWidth><t:ImageLength>480</t:ImageLength>",
+            None,
+        ),
+        (
+            "<t:ImageWidth>4294967296</t:ImageWidth><t:ImageLength>480</t:ImageLength>",
+            None,
+        ),
+    ] {
+        for mode in [Mode::Summary, Mode::Details] {
+            let metadata = read(xmp(fields).as_bytes(), mode);
+            assert_eq!(
+                metadata.xmp_dimensions().map(|d| (d.width, d.height)),
+                expected
+            );
+            assert_eq!(metadata.dimensions, None);
+        }
+    }
+}
+
+#[test]
+fn camera_and_description_helpers_borrow_trimmed_exif_text() {
+    let bytes = tiff(
+        &[
+            (0x10f, 2, 9, b" Camera \0".to_vec()),
+            (0x110, 2, 9, b" Model  \0".to_vec()),
+            (0x10e, 2, 10, b" Caption \0".to_vec()),
+        ],
+        false,
+    );
+    for mode in [Mode::Summary, Mode::Details] {
+        let metadata = read(&bytes, mode);
+        assert_eq!(metadata.camera_make(), Some("Camera"));
+        assert_eq!(metadata.camera_model(), Some("Model"));
+        assert_eq!(metadata.exif_description(), Some("Caption"));
+        let raw = metadata
+            .tag(Ifd::Image(0), 0x10f)
+            .unwrap()
+            .value
+            .text()
+            .unwrap();
+        assert_eq!(raw, " Camera ");
+        assert_eq!(metadata.camera_make().unwrap().as_ptr(), raw[1..].as_ptr());
+    }
+    for entry in [
+        (0x10f, 2, 3, b"  \0".to_vec()),
+        (0x10f, 2, 2, vec![255, 0]),
+        (0x10f, 3, 1, vec![1, 0]),
+    ] {
+        assert_eq!(
+            read(&tiff(&[entry], false), Mode::Summary).camera_make(),
+            None
+        );
+    }
+}
+
+#[test]
+fn photographic_helpers_preserve_exact_exposure_and_legacy_sensitivity() {
+    use ente_exif::Rational;
+    let rational = |n: u32, d: u32| [n.to_le_bytes(), d.to_le_bytes()].concat();
+    let bytes = child_ifd(
+        0x8769,
+        tiff(
+            &[
+                (0xa434, 2, 9, b" Lens   \0".to_vec()),
+                (0x829a, 5, 1, rational(1, 125)),
+                (0x829d, 5, 1, rational(28, 10)),
+                (0x920a, 5, 1, rational(35, 1)),
+                (
+                    0x8827,
+                    3,
+                    2,
+                    [200u16.to_le_bytes(), 65535u16.to_le_bytes()].concat(),
+                ),
+            ],
+            false,
+        ),
+    );
+    for mode in [Mode::Summary, Mode::Details] {
+        let metadata = read(&bytes, mode);
+        assert_eq!(metadata.lens_model(), Some("Lens"));
+        assert_eq!(
+            metadata.exposure_time(),
+            Some(Rational {
+                numerator: 1,
+                denominator: 125
+            })
+        );
+        assert_eq!(metadata.f_number(), Some(2.8));
+        assert_eq!(metadata.focal_length(), Some(35.0));
+        assert_eq!(metadata.iso_speed_ratings(), Some([200, 65535].as_slice()));
+    }
+    for (count, value) in [
+        (1, rational(0, 1)),
+        (1, rational(1, 0)),
+        (2, rational(1, 2).repeat(2)),
+    ] {
+        let bytes = child_ifd(
+            0x8769,
+            tiff(
+                &[
+                    (0x829a, 5, count, value.clone()),
+                    (0x829d, 5, count, value.clone()),
+                    (0x920a, 5, count, value),
+                ],
+                false,
+            ),
+        );
+        let metadata = read(&bytes, Mode::Summary);
+        assert_eq!(metadata.exposure_time(), None);
+        assert_eq!(metadata.f_number(), None);
+        assert_eq!(metadata.focal_length(), None);
+    }
+}

--- a/rust/crates/exif/tests/integration/png_profiles.rs
+++ b/rust/crates/exif/tests/integration/png_profiles.rs
@@ -1,0 +1,171 @@
+use super::common::{png_chunk, read, tiff, xmp};
+use ente_exif::{Error, Limits, Mode, TextEncoding};
+use std::io::Cursor;
+
+#[test]
+fn profiles_use_existing_exif_xmp_and_iptc_readers() {
+    let exif = tiff(
+        &[
+            (0x10f, 2, 6, b"Maker\0".to_vec()),
+            (0x132, 2, 20, b"2024:02:29 12:34:56\0".to_vec()),
+        ],
+        false,
+    );
+    let packet = xmp("<d:description>山</d:description>");
+    let iim = b"\x1c\x01\x5a\0\x03\x1b%G\x1c\x02\x78\0\x03sea";
+    let resource = [
+        b"8BIM\x04\x04\0\0".as_slice(),
+        &(iim.len() as u32).to_be_bytes(),
+        iim,
+    ]
+    .concat();
+    for kind in [b"tEXt", b"zTXt", b"iTXt"] {
+        let bytes = png(&[
+            profile(kind, "exif", &[b"Exif\0\0".as_slice(), &exif].concat()),
+            profile(kind, "iptc", &resource),
+            profile(kind, "xmp", packet.as_bytes()),
+        ]);
+        for mode in [Mode::Summary, Mode::Details] {
+            let metadata = read(&bytes, mode);
+            assert!(metadata.issues.is_empty(), "{:?}", metadata.issues);
+            assert_eq!(metadata.camera_make(), Some("Maker"));
+            assert_eq!(
+                metadata.capture_date_time().unwrap().date_time,
+                "2024-02-29T12:34:56"
+            );
+            assert_eq!(
+                metadata.iptc_caption(TextEncoding::Ascii).as_deref(),
+                Some("sea")
+            );
+            assert_eq!(metadata.xmp_description(None), Some("山"));
+            assert!(!metadata.xmp.iter().any(|p| p.namespace == "urn:png:text"));
+        }
+    }
+}
+
+#[test]
+fn app1_profiles_and_direct_iim_are_supported() {
+    let exif = tiff(&[(0x10f, 2, 6, b"Maker\0".to_vec())], true);
+    let xml = [
+        b"http://ns.adobe.com/xap/1.0/\0".as_slice(),
+        xmp("<d:description>mist</d:description>").as_bytes(),
+    ]
+    .concat();
+    let bytes = png(&[
+        profile(b"zTXt", "APP1", &[b"Exif\0\0".as_slice(), &exif].concat()),
+        profile(b"zTXt", "APP1", &xml),
+        profile(b"tEXt", "iptc", b"\x1c\x02\x78\0\x04dawn"),
+    ]);
+    let metadata = read(&bytes, Mode::Summary);
+    assert!(metadata.issues.is_empty());
+    assert_eq!(metadata.camera_make(), Some("Maker"));
+    assert_eq!(metadata.xmp_description(None), Some("mist"));
+    assert_eq!(
+        metadata.iptc_caption(TextEncoding::Utf8).as_deref(),
+        Some("dawn")
+    );
+}
+
+#[test]
+fn malformed_profiles_do_not_hide_later_metadata() {
+    let good = profile(
+        b"tEXt",
+        "xmp",
+        xmp("<d:description>later</d:description>").as_bytes(),
+    );
+    for text in [
+        "exif\n1\n00",
+        "\nexif\nno\n00",
+        "\nexif\n2\n00",
+        "\nexif\n1\n0z",
+        "\nexif\n1\n000",
+        "\nexif\n184467440737095516160\n00",
+    ] {
+        let bad = png_chunk(
+            b"tEXt",
+            &[b"Raw profile type exif\0".as_slice(), text.as_bytes()].concat(),
+        );
+        let metadata = read(&png(&[bad, good.clone()]), Mode::Summary);
+        assert_eq!(metadata.issues.len(), 1, "{text}");
+        assert_eq!(metadata.xmp_description(None), Some("later"));
+    }
+}
+
+#[test]
+fn decoded_profiles_share_the_expansion_budget() {
+    let exif = tiff(
+        &[
+            (0x10f, 2, 6, b"Maker\0".to_vec()),
+            (0x927c, 7, 1000, vec![0; 1000]),
+        ],
+        false,
+    );
+    let bytes = png(&[profile(b"zTXt", "exif", &exif)]);
+    let limits = Limits {
+        value_bytes: 32,
+        ..Default::default()
+    };
+    let metadata = ente_exif::read(&mut Cursor::new(&bytes), Mode::Summary, limits).unwrap();
+    assert_eq!(metadata.camera_make(), Some("Maker"));
+    let limits = Limits {
+        read_bytes: 2500,
+        ..limits
+    };
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(&bytes), Mode::Summary, limits),
+        Err(Error::Limit(_))
+    ));
+}
+
+#[test]
+fn raw_profiles_tolerate_hex_case_and_ascii_whitespace() {
+    let text = b"Raw profile type iptc\0\ngeneric profile\n  8\n1c 02 78 00 03 73\t65\r\n41\n";
+    let metadata = read(&png(&[png_chunk(b"tEXt", text)]), Mode::Summary);
+    assert!(metadata.issues.is_empty());
+    assert_eq!(
+        metadata.iptc_caption(TextEncoding::Ascii).as_deref(),
+        Some("seA")
+    );
+}
+
+fn profile(kind: &[u8; 4], name: &str, bytes: &[u8]) -> Vec<u8> {
+    use std::fmt::Write;
+    let mut text = format!("\n{name}\n{:8}\n", bytes.len());
+    for (index, byte) in bytes.iter().enumerate() {
+        write!(text, "{byte:02x}").unwrap();
+        if index % 36 == 35 {
+            text.push('\n');
+        }
+    }
+    text.push('\n');
+    let mut data = format!("Raw profile type {name}\0").into_bytes();
+    if kind == b"zTXt" {
+        data.push(0);
+        data.extend(miniz_oxide::deflate::compress_to_vec_zlib(
+            text.as_bytes(),
+            6,
+        ));
+    } else {
+        if kind == b"iTXt" {
+            data.extend([0; 4]);
+        }
+        data.extend(text.as_bytes());
+    }
+    png_chunk(kind, &data)
+}
+
+fn png(chunks: &[Vec<u8>]) -> Vec<u8> {
+    let ihdr = [
+        2u32.to_be_bytes().as_slice(),
+        &3u32.to_be_bytes(),
+        &[8, 2, 0, 0, 0],
+    ]
+    .concat();
+    [
+        b"\x89PNG\r\n\x1a\n".to_vec(),
+        png_chunk(b"IHDR", &ihdr),
+        chunks.concat(),
+        png_chunk(b"IEND", &[]),
+    ]
+    .concat()
+}

--- a/rust/crates/exif/tests/integration/reader.rs
+++ b/rust/crates/exif/tests/integration/reader.rs
@@ -1,0 +1,238 @@
+use super::common::*;
+use ente_exif::{Error, Ifd, Limits, Mode, Rational, Value, namespace};
+use std::io::Cursor;
+
+#[test]
+fn tiff_byte_orders_and_exact_typed_values() {
+    for big in [false, true] {
+        let number = |n: u32| {
+            if big {
+                n.to_be_bytes().to_vec()
+            } else {
+                n.to_le_bytes().to_vec()
+            }
+        };
+        let ratio = [number((-1i32) as u32), number(125)].concat();
+        let data = tiff(
+            &[
+                (0x10f, 2, 6, b"Canon\0".to_vec()),
+                (0x112, 3, 1, if big { vec![0, 6] } else { vec![6, 0] }),
+                (0x829a, 10, 1, ratio),
+                (0x100, 4, 1, number(4032)),
+                (0x101, 4, 1, number(3024)),
+            ],
+            big,
+        );
+        let metadata = read(&data, Mode::Details);
+        assert_eq!(metadata.orientation(), Some(6));
+        assert_eq!(
+            metadata.tag(Ifd::Image(0), 0x10f).unwrap().value.text(),
+            Some("Canon")
+        );
+        assert_eq!(
+            metadata.tag(Ifd::Image(0), 0x829a).unwrap().value,
+            Value::Rational(vec![Rational {
+                numerator: -1,
+                denominator: 125
+            }])
+        );
+        assert_eq!(metadata.dimensions.unwrap().width, 4032);
+    }
+}
+
+#[test]
+fn summary_skips_large_opaque_values_without_fetching_them() {
+    let mut data = tiff(
+        &[(0x927c, 7, 4_000_000, 26u32.to_le_bytes().to_vec())],
+        false,
+    );
+    data.resize(4_000_026, 0xab);
+    let summary = read(&data, Mode::Summary);
+    let details = read(&data, Mode::Details);
+    assert!(summary.tags.is_empty());
+    assert!(summary.statistics.bytes_read < 100);
+    assert!(details.statistics.bytes_read < 100);
+    assert_eq!(details.tags[0].value, Value::Omitted { bytes: 4_000_000 });
+}
+
+#[test]
+fn jpeg_dimensions_override_stale_exif_and_pixels_are_skipped() {
+    let exif = tiff(
+        &[
+            (0x100, 4, 1, 6000u32.to_le_bytes().to_vec()),
+            (0x101, 4, 1, 4000u32.to_le_bytes().to_vec()),
+        ],
+        false,
+    );
+    let mut data = jpeg(&exif, "");
+    let before = read(&data, Mode::Summary);
+    data.resize(20_000_000, 0);
+    let after = read(&data, Mode::Summary);
+    assert_eq!(after.dimensions.unwrap().width, 30);
+    assert_eq!(before.statistics.bytes_read, after.statistics.bytes_read);
+}
+
+#[test]
+fn xmp_namespaces_elements_attributes_arrays_and_entities() {
+    let source = xmp(
+        r#"<p:ProjectionType>equirectangular</p:ProjectionType><e:DateTimeOriginal>2025-01-30T08:59:50.123456+05:30</e:DateTimeOriginal><d:description><r:Alt><r:li xml:lang="x-default">Sun &amp; snow &#x2603;</r:li><r:li xml:lang="fr">Neige</r:li></r:Alt></d:description>"#,
+    );
+    let metadata = read(source.as_bytes(), Mode::Summary);
+    assert!(metadata.is_panorama());
+    assert_eq!(
+        metadata.property(namespace::EXIF, "DateTimeOriginal"),
+        Some("2025-01-30T08:59:50.123456+05:30")
+    );
+    let captions: Vec<_> = metadata
+        .xmp
+        .iter()
+        .filter(|p| p.name == "description")
+        .collect();
+    assert_eq!(captions.len(), 2);
+    assert_eq!(captions[0].value, "Sun & snow ☃");
+    assert_eq!(captions[0].language.as_deref(), Some("x-default"));
+    assert_ne!(captions[0].item, captions[1].item);
+}
+
+#[test]
+fn packetless_utf8_bom_xmp() {
+    let xml = "\u{feff}  <?xml version=\"1.0\" encoding=\"UTF-8\"?><x:xmpmeta xmlns:x=\"adobe:ns:meta/\"><r:RDF xmlns:r=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"><r:Description xmlns:p=\"http://ns.adobe.com/photoshop/1.0/\" p:DateCreated=\"2023-04-27T14:51:16+05:30\"/></r:RDF></x:xmpmeta>";
+    assert_eq!(
+        read(xml.as_bytes(), Mode::Summary).property(namespace::PHOTOSHOP, "DateCreated"),
+        Some("2023-04-27T14:51:16+05:30")
+    );
+}
+
+#[test]
+fn heif_file_and_idat_extents_and_primary_properties() {
+    let exif = tiff(&[(0x112, 3, 1, vec![6, 0])], false);
+    for method in [0, 1] {
+        for split in [false, true] {
+            let metadata = read(&heif(&exif, method, split), Mode::Summary);
+            assert_eq!(metadata.dimensions.unwrap().width, 800);
+            assert_eq!(metadata.transforms.len(), 2);
+            assert_eq!(metadata.transforms[0], ente_exif::Transform::Rotate(1));
+            let ente_exif::Transform::Crop(crop) = metadata.transforms[1] else {
+                panic!("missing crop");
+            };
+            assert_eq!(crop.width.as_f64(), Some(640.0));
+            assert_eq!(crop.horizontal_offset.as_f64(), Some(-0.5));
+            assert_eq!(metadata.orientation(), Some(6));
+            assert!(metadata.issues.is_empty(), "{:?}", metadata.issues);
+        }
+    }
+}
+
+#[test]
+fn png_metadata_after_image_data_and_compressed_xmp() {
+    let source = xmp("<p:ProjectionType>cylindrical</p:ProjectionType>");
+    let compressed = miniz_oxide::deflate::compress_to_vec_zlib(source.as_bytes(), 6);
+    let text = [b"XML:com.adobe.xmp\0\x01\0\0\0".to_vec(), compressed].concat();
+    let mut ihdr = [800u32.to_be_bytes(), 600u32.to_be_bytes()].concat();
+    ihdr.extend([8, 2, 0, 0, 0]);
+    let data = [
+        b"\x89PNG\r\n\x1a\n".to_vec(),
+        png_chunk(b"IHDR", &ihdr),
+        png_chunk(b"IDAT", &vec![0; 1_000_000]),
+        png_chunk(b"iTXt", &text),
+        png_chunk(b"IEND", &[]),
+    ]
+    .concat();
+    let metadata = read(&data, Mode::Summary);
+    assert!(metadata.is_panorama());
+    assert!(metadata.statistics.bytes_read < 2000);
+    assert!(metadata.issues.is_empty());
+}
+
+#[test]
+fn malformed_metadata_does_not_discard_valid_dimensions() {
+    let metadata = read(&jpeg(b"MM\0*\xff\xff\xff\xff", ""), Mode::Summary);
+    assert_eq!(metadata.dimensions.unwrap().width, 30);
+    assert!(!metadata.issues.is_empty());
+}
+
+#[test]
+fn cycles_and_limits_are_explicit() {
+    let mut data = tiff(&[], false);
+    data[10..14].copy_from_slice(&8u32.to_le_bytes());
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(&data), Mode::Details, Limits::default()),
+        Err(Error::Malformed("cyclic IFD"))
+    ));
+    let data = tiff(&[(0x10f, 2, 6, b"Canon\0".to_vec())], false);
+    let limits = Limits {
+        value_bytes: 4,
+        ..Limits::default()
+    };
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(&data), Mode::Summary, limits),
+        Err(Error::Limit(_))
+    ));
+    let limits = Limits {
+        output_bytes: 4,
+        ..Limits::default()
+    };
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(&data), Mode::Summary, limits),
+        Err(Error::Limit(_))
+    ));
+}
+
+#[test]
+fn dtd_and_deep_xml_are_rejected() {
+    let data = b"<!DOCTYPE r [<!ENTITY payload SYSTEM 'file:///etc/passwd'>]><r/>";
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(data), Mode::Summary, Limits::default()),
+        Err(Error::Unsupported("XML DTD"))
+    ));
+    let source = xmp(&format!("{}{}", "<t:n>".repeat(50), "</t:n>".repeat(50)));
+    assert!(matches!(
+        ente_exif::read(&mut Cursor::new(source), Mode::Summary, Limits::default()),
+        Err(Error::Limit("XML depth"))
+    ));
+}
+
+#[test]
+fn truncations_and_header_mutations_never_panic() {
+    let tiff = tiff(&[(0x10f, 2, 6, b"Canon\0".to_vec())], false);
+    let packet = xmp("<d:subject><r:Bag><r:li>café</r:li></r:Bag></d:subject>");
+    let png = [
+        b"\x89PNG\r\n\x1a\n".to_vec(),
+        png_chunk(b"IHDR", &[0, 0, 0, 1, 0, 0, 0, 1, 8, 2, 0, 0, 0]),
+        png_chunk(b"tEXt", b"Caf\xe9\0Caption"),
+        png_chunk(b"IEND", &[]),
+    ]
+    .concat();
+    let seeds = [
+        tiff.clone(),
+        jpeg(&tiff, &packet),
+        heif(&tiff, 0, false),
+        heif(&tiff, 1, true),
+        packet.into_bytes(),
+        png,
+    ];
+    for seed in seeds {
+        for limits in [
+            Limits::default(),
+            Limits {
+                read_bytes: 128,
+                value_bytes: 8,
+                output_bytes: 64,
+                entries: 8,
+                directories: 1,
+                depth: 2,
+            },
+        ] {
+            for len in 0..=seed.len() {
+                exercise(&seed[..len], limits);
+            }
+            for index in 0..seed.len() {
+                for value in [0, 0xff] {
+                    let mut bytes = seed.clone();
+                    bytes[index] = value;
+                    exercise(&bytes, limits);
+                }
+            }
+        }
+    }
+}

--- a/rust/crates/exif/tests/integration/text.rs
+++ b/rust/crates/exif/tests/integration/text.rs
@@ -1,0 +1,124 @@
+use super::common::{jpeg, read, segment, tiff};
+use ente_exif::{Iptc, Metadata, Mode, TextEncoding, Value};
+use std::borrow::Cow;
+
+#[test]
+fn text_decoding_is_explicit_lazy_and_preserves_original_bytes() {
+    let value = Value::Ascii(b"Coffee \xe9\0tail".to_vec());
+    assert_eq!(value.text(), None);
+    assert_eq!(value.text_with(TextEncoding::Utf8), None);
+    assert_eq!(value.text_with(TextEncoding::Ascii), None);
+    assert_eq!(
+        value.text_with(TextEncoding::Latin1).as_deref(),
+        Some("Coffee é")
+    );
+    assert_eq!(value, Value::Ascii(b"Coffee \xe9\0tail".to_vec()));
+
+    let ascii = Value::Ascii(b"camera\0tail".to_vec());
+    for encoding in [
+        TextEncoding::Ascii,
+        TextEncoding::Utf8,
+        TextEncoding::Latin1,
+        TextEncoding::Windows1252,
+    ] {
+        assert!(matches!(
+            ascii.text_with(encoding),
+            Some(Cow::Borrowed("camera"))
+        ));
+    }
+    let utf8 = Value::Ascii("星空\0".as_bytes().to_vec());
+    assert!(matches!(
+        utf8.text_with(TextEncoding::Utf8),
+        Some(Cow::Borrowed("星空"))
+    ));
+    assert_eq!(
+        Value::Bytes(b"text".to_vec()).text_with(TextEncoding::Utf8),
+        None
+    );
+}
+
+#[test]
+fn windows_1252_and_latin1_are_not_interchangeable() {
+    let value = Value::Ascii(b"\x80\x91\x92\x93\x94\x96\x97\x99\xe9".to_vec());
+    assert_eq!(
+        value.text_with(TextEncoding::Windows1252).as_deref(),
+        Some("€‘’“”–—™é")
+    );
+    assert_eq!(
+        value.text_with(TextEncoding::Latin1).as_deref(),
+        Some("\u{80}\u{91}\u{92}\u{93}\u{94}\u{96}\u{97}\u{99}é")
+    );
+}
+
+#[test]
+fn iptc_announcements_override_the_explicit_fallback() {
+    let mut metadata = Metadata {
+        iptc: vec![Iptc {
+            record: 2,
+            dataset: 120,
+            value: b"  coast \x97 caf\xe9  ".to_vec(),
+        }],
+        ..Default::default()
+    };
+    assert_eq!(
+        metadata.iptc_caption(TextEncoding::Windows1252).as_deref(),
+        Some("  coast — café  ")
+    );
+    assert_eq!(metadata.iptc_caption(TextEncoding::Utf8), None);
+    metadata.iptc.push(Iptc {
+        record: 1,
+        dataset: 90,
+        value: b"\x1b%G".to_vec(),
+    });
+    assert_eq!(metadata.iptc_caption(TextEncoding::Windows1252), None);
+    metadata.iptc[0].value = "海辺".as_bytes().to_vec();
+    assert!(matches!(
+        metadata.iptc_caption(TextEncoding::Windows1252),
+        Some(Cow::Borrowed("海辺"))
+    ));
+    metadata.iptc[1].value = b"\x1b-A".to_vec();
+    assert_eq!(metadata.iptc_caption(TextEncoding::Windows1252), None);
+    metadata.iptc.push(Iptc {
+        record: 1,
+        dataset: 5,
+        value: b"\xe9".to_vec(),
+    });
+    assert_eq!(metadata.iptc_text(1, 5, TextEncoding::Latin1), None);
+}
+
+#[test]
+fn jpeg_retains_legacy_text_for_on_demand_decoding_in_both_modes() {
+    let value = b"Woodland \xe9\0";
+    let exif = tiff(&[(0x10e, 2, value.len() as u32, value.to_vec())], false);
+    let caption = b"Trail \x97 river";
+    let iim = [
+        b"\x1c\x02\x78".as_slice(),
+        &(caption.len() as u16).to_be_bytes(),
+        caption,
+    ]
+    .concat();
+    let mut resource = b"8BIM\x04\x04\0\0".to_vec();
+    resource.extend((iim.len() as u32).to_be_bytes());
+    resource.extend(&iim);
+    resource.resize(resource.len() + (iim.len() & 1), 0);
+    let mut bytes = jpeg(&exif, "");
+    bytes.splice(2..2, segment(0xed, &resource));
+    for mode in [Mode::Summary, Mode::Details] {
+        let metadata = read(&bytes, mode);
+        assert!(metadata.issues.is_empty());
+        assert_eq!(metadata.exif_description(), None);
+        assert_eq!(
+            metadata
+                .tag(ente_exif::Ifd::Image(0), 0x10e)
+                .unwrap()
+                .value
+                .text_with(TextEncoding::Latin1)
+                .as_deref(),
+            Some("Woodland é")
+        );
+        assert_eq!(
+            metadata.iptc_caption(TextEncoding::Windows1252).as_deref(),
+            Some("Trail — river")
+        );
+    }
+}

--- a/rust/crates/photos/Cargo.toml
+++ b/rust/crates/photos/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 [dependencies]
 ente-assets.workspace = true
 ente-location.workspace = true
-quick-xml = "0.41.0"
+quick-xml.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
Adds `ente-exif`, a bounded photo metadata reader for EXIF, XMP and IPTC, with helpers for capture dates, display dimensions, GPS, camera fields, panoramas and motion photos.

Includes generated test fixtures and usage examples. Reuses existing dependency versions; uploader integration will follow separately.