### PR TITLE
[mobile][locker] Enable document scanner for all users

### DIFF
--- a/mobile/apps/locker/changes/document-scanner.md
+++ b/mobile/apps/locker/changes/document-scanner.md
@@ -1,1 +1,1 @@
-- Document scanner (behind internal flag)
+- Document scanner enabled for all users

--- a/mobile/apps/locker/lib/services/feature_flag_service.dart
+++ b/mobile/apps/locker/lib/services/feature_flag_service.dart
@@ -16,7 +16,7 @@ class FeatureFlagService {
   late FlagService _flagService;
 
   bool get internalUser => _flagService.internalUser;
-  bool get documentScanner => internalUser;
+  bool get documentScanner => true;
 
   void init(SharedPreferences preferences) {
     _preferences = preferences;


### PR DESCRIPTION
Enable the document scanner for all Locker users by setting `documentScanner` to `true`. Update the release note to reflect general availability.
