### PR TITLE
[server] Invalidate file counts during stale cleanup

### DIFF
--- a/server/pkg/repo/collection.go
+++ b/server/pkg/repo/collection.go
@@ -815,7 +815,10 @@ func (repo *CollectionRepository) RestoreFiles(ctx context.Context, userID int64
 		if !ok {
 			return stacktrace.Propagate(ente.ErrInvalidApp, "unsupported collection app %s", app)
 		}
-		if _, err := applyUsageDelta(ctx, tx, userID, 0, photosFileDelta, lockerFileDelta, false); err != nil {
+		if _, err := applyUsageChange(ctx, tx, userID, usageChange{
+			PhotosFileDelta: photosFileDelta,
+			LockerFileDelta: lockerFileDelta,
+		}); err != nil {
 			return stacktrace.Propagate(err, "failed to update file counts")
 		}
 	}

--- a/server/pkg/repo/file.go
+++ b/server/pkg/repo/file.go
@@ -313,7 +313,7 @@ func (repo *FileRepository) Update(file ente.File, fileSize int64, thumbnailSize
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	_, err = repo.updateUsage(ctx, tx, file.OwnerID, usageDiff, 0, 0)
+	_, err = applyUsageChange(ctx, tx, file.OwnerID, usageChange{StorageDelta: usageDiff})
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
@@ -450,7 +450,7 @@ func (repo *FileRepository) UpdateThumbnail(ctx context.Context, fileID int64, u
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	_, err = repo.updateUsage(ctx, tx, userID, usageDiff, 0, 0)
+	_, err = applyUsageChange(ctx, tx, userID, usageChange{StorageDelta: usageDiff})
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
@@ -775,7 +775,7 @@ func (repo *FileRepository) scheduleDeletion(ctx context.Context, tx *sql.Tx, fi
 		totalObjectSize += object.FileSize
 	}
 	diff = diff - (totalObjectSize)
-	_, err = repo.updateUsage(ctx, tx, userID, diff, 0, 0)
+	_, err = applyUsageChange(ctx, tx, userID, usageChange{StorageDelta: diff})
 	return stacktrace.Propagate(err, "")
 }
 
@@ -784,9 +784,9 @@ func (repo *FileRepository) updateUsageForFileCreation(ctx context.Context, tx *
 	if !ok {
 		return -1, stacktrace.Propagate(ente.ErrInvalidApp, "")
 	}
-	return repo.updateUsage(ctx, tx, userID, storageDiff, photosFileCountDiff, lockerFileCountDiff)
-}
-
-func (repo *FileRepository) updateUsage(ctx context.Context, tx *sql.Tx, userID, storageDiff, photosFileCountDiff, lockerFileCountDiff int64) (int64, error) {
-	return applyUsageDelta(ctx, tx, userID, storageDiff, photosFileCountDiff, lockerFileCountDiff, false)
+	return applyUsageChange(ctx, tx, userID, usageChange{
+		StorageDelta:    storageDiff,
+		PhotosFileDelta: photosFileCountDiff,
+		LockerFileDelta: lockerFileCountDiff,
+	})
 }

--- a/server/pkg/repo/file_usage_test.go
+++ b/server/pkg/repo/file_usage_test.go
@@ -71,7 +71,7 @@ func TestUpdateUsageForFileCreationMaintainsCounterState(t *testing.T) {
 	}
 }
 
-func TestUpdateUsageRequiresUsageRow(t *testing.T) {
+func TestApplyUsageChangeRequiresUsageRow(t *testing.T) {
 	db := setupFileUsageTest(t)
 	userID := testutil.InsertUser(t, db, testutil.UserFixture{
 		UserID:       1,
@@ -84,12 +84,12 @@ func TestUpdateUsageRequiresUsageRow(t *testing.T) {
 	}
 	defer tx.Rollback()
 
-	_, err = (&FileRepository{}).updateUsage(t.Context(), tx, userID, 5, 1, 0)
+	_, err = applyUsageChange(t.Context(), tx, userID, usageChange{StorageDelta: 5, PhotosFileDelta: 1})
 	if err == nil {
-		t.Fatal("updateUsage() created a missing usage row")
+		t.Fatal("applyUsageChange() created a missing usage row")
 	}
 	if errors.Is(err, sql.ErrNoRows) {
-		t.Fatal("updateUsage() exposed missing usage row as not found")
+		t.Fatal("applyUsageChange() exposed missing usage row as not found")
 	}
 
 	var count int

--- a/server/pkg/repo/trash.go
+++ b/server/pkg/repo/trash.go
@@ -188,25 +188,29 @@ func (t *TrashRepository) CleanUpDeletedFilesFromCollection(ctx context.Context,
 		return stacktrace.Propagate(err, "")
 	}
 	defer tx.Rollback()
-	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT collection_id FROM 
-		collection_files WHERE file_id = ANY($1) AND is_deleted = $2`, pq.Array(fileIDs), false)
+	updationTime := time.Microseconds()
+	rows, err := tx.QueryContext(ctx, `UPDATE collection_files AS cf
+		SET is_deleted = TRUE, updation_time = $2
+		FROM collections AS c
+		WHERE cf.file_id = ANY($1) AND cf.is_deleted = FALSE
+			AND c.collection_id = cf.collection_id
+		RETURNING cf.collection_id, c.owner_id = $3`, pq.Array(fileIDs), updationTime, userID)
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
 	defer rows.Close()
 	cIDs := make([]int64, 0)
+	removedOwnedMembership := false
 	for rows.Next() {
 		var cID int64
-		if err := rows.Scan(&cID); err != nil {
+		var owned bool
+		if err := rows.Scan(&cID, &owned); err != nil {
 			return stacktrace.Propagate(err, "")
 		}
 		cIDs = append(cIDs, cID)
+		removedOwnedMembership = removedOwnedMembership || owned
 	}
-	updationTime := time.Microseconds()
-	_, err = tx.ExecContext(ctx, `UPDATE collection_files 
-		SET is_deleted = $1, updation_time = $2 WHERE file_id = ANY($3)`,
-		true, updationTime, pq.Array(fileIDs))
-	if err != nil {
+	if err := rows.Err(); err != nil {
 		return stacktrace.Propagate(err, "")
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE collections SET updation_time = $1
@@ -214,8 +218,21 @@ func (t *TrashRepository) CleanUpDeletedFilesFromCollection(ctx context.Context,
 	if err != nil {
 		return stacktrace.Propagate(err, "")
 	}
-	err = tx.Commit()
-	return stacktrace.Propagate(err, "")
+	if removedOwnedMembership {
+		if _, err := applyUsageDelta(ctx, tx, userID, 0, 0, 0, true); err != nil {
+			return stacktrace.Propagate(err, "failed to invalidate file counts")
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	if removedOwnedMembership {
+		logrus.WithFields(logrus.Fields{
+			"user_id":  userID,
+			"file_ids": fileIDs,
+		}).Info("cleaned stale owned file memberships")
+	}
+	return nil
 }
 
 func (t *TrashRepository) Delete(ctx context.Context, userID int64, fileIDs []int64) error {

--- a/server/pkg/repo/trash.go
+++ b/server/pkg/repo/trash.go
@@ -171,7 +171,11 @@ func (t *TrashRepository) TrashFiles(ctx context.Context, userID int64, trash en
 		return stacktrace.Propagate(err, "failed to disable file links for files being trashed")
 	}
 	if photosFileDelta != 0 || lockerFileDelta != 0 || ambiguousFileApp {
-		if _, err := applyUsageDelta(ctx, tx, userID, 0, photosFileDelta, lockerFileDelta, ambiguousFileApp); err != nil {
+		if _, err := applyUsageChange(ctx, tx, userID, usageChange{
+			PhotosFileDelta:      photosFileDelta,
+			LockerFileDelta:      lockerFileDelta,
+			InvalidateFileCounts: ambiguousFileApp,
+		}); err != nil {
 			return stacktrace.Propagate(err, "failed to update file counts")
 		}
 	}
@@ -219,7 +223,7 @@ func (t *TrashRepository) CleanUpDeletedFilesFromCollection(ctx context.Context,
 		return stacktrace.Propagate(err, "")
 	}
 	if removedOwnedMembership {
-		if _, err := applyUsageDelta(ctx, tx, userID, 0, 0, 0, true); err != nil {
+		if _, err := applyUsageChange(ctx, tx, userID, usageChange{InvalidateFileCounts: true}); err != nil {
 			return stacktrace.Propagate(err, "failed to invalidate file counts")
 		}
 	}

--- a/server/pkg/repo/trash_test.go
+++ b/server/pkg/repo/trash_test.go
@@ -144,6 +144,66 @@ func TestTrashFilesRollsBackWhenFileLinkCleanupFails(t *testing.T) {
 	}
 }
 
+func TestStaleCleanupInvalidatesOnlyRemovedOwnedMemberships(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		collectionOwner int64
+		ready           bool
+		wantVersion     int64
+	}{
+		{"ready owned", 1, true, 1},
+		{"legacy owned", 1, false, 1},
+		{"shared only", 2, true, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repository, db, userID := setupCollectionMembershipTest(t)
+			if tc.collectionOwner != userID {
+				testutil.InsertUser(t, db, testutil.UserFixture{UserID: tc.collectionOwner, Email: "collection-owner@ente.com", CreationTime: 1})
+			}
+			if tc.ready {
+				setReadyFileCounts(t, db, userID, 1, 1)
+			}
+			if _, err := db.Exec(`UPDATE usage SET storage_consumed = 123 WHERE user_id = $1`, userID); err != nil {
+				t.Fatal(err)
+			}
+			collectionID := insertObjectTestCollection(t, db, tc.collectionOwner)
+			fileID := insertObjectTestFile(t, db, userID)
+			linkObjectTestFileToCollection(t, db, collectionID, fileID, userID)
+			// Legacy owner columns can be NULL, and soft-deleted collections still count.
+			if _, err := db.Exec(`UPDATE collection_files SET c_owner_id = NULL, f_owner_id = NULL;
+				UPDATE collections SET is_deleted = TRUE`); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.Exec(`INSERT INTO trash(file_id, collection_id, user_id, delete_by, updated_at, is_deleted)
+				VALUES ($1, $2, $3, 1, 1, TRUE)`, fileID, collectionID, userID); err != nil {
+				t.Fatal(err)
+			}
+
+			for attempt := 0; attempt < 2; attempt++ {
+				if err := repository.TrashRepo.CleanUpDeletedFilesFromCollection(t.Context(), []int64{fileID}, userID); err != nil {
+					t.Fatal(err)
+				}
+				photos, locker, version := readFileCountState(t, db, userID)
+				if tc.wantVersion == 0 {
+					assertReadyFileCounts(t, db, userID, 1, 1, 0)
+				} else if photos.Valid || locker.Valid || version != tc.wantVersion {
+					t.Fatalf("attempt %d: counts = (%v, %v, %d), want (NULL, NULL, %d)", attempt, photos, locker, version, tc.wantVersion)
+				}
+			}
+			var deleted bool
+			var storage int64
+			if err := db.QueryRow(`SELECT cf.is_deleted, u.storage_consumed
+				FROM collection_files cf JOIN usage u ON u.user_id = $1
+				WHERE cf.file_id = $2`, userID, fileID).Scan(&deleted, &storage); err != nil {
+				t.Fatal(err)
+			}
+			if !deleted || storage != 123 {
+				t.Fatalf("deleted = %t, storage = %d, want true, 123", deleted, storage)
+			}
+		})
+	}
+}
+
 func setupTrashTest(t *testing.T) (*TrashRepository, *sql.DB) {
 	t.Helper()
 

--- a/server/pkg/repo/usage_file_count.go
+++ b/server/pkg/repo/usage_file_count.go
@@ -11,15 +11,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func applyUsageDelta(
-	ctx context.Context,
-	tx *sql.Tx,
-	userID int64,
-	storageDelta int64,
-	photosFileDelta int64,
-	lockerFileDelta int64,
-	invalidateFileCounts bool,
-) (int64, error) {
+type usageChange struct {
+	StorageDelta         int64
+	PhotosFileDelta      int64
+	LockerFileDelta      int64
+	InvalidateFileCounts bool
+}
+
+func applyUsageChange(ctx context.Context, tx *sql.Tx, userID int64, change usageChange) (int64, error) {
 	row := tx.QueryRowContext(ctx, `WITH current_usage AS (
 			SELECT user_id, storage_consumed, photos_file_count, locker_file_count, file_count_source_version
 			FROM usage
@@ -55,10 +54,10 @@ func applyUsageDelta(
 			AND current_usage.locker_file_count IS NOT NULL
 			AND ($5 OR current_usage.photos_file_count + $3 < 0 OR current_usage.locker_file_count + $4 < 0)`,
 		userID,
-		storageDelta,
-		photosFileDelta,
-		lockerFileDelta,
-		invalidateFileCounts,
+		change.StorageDelta,
+		change.PhotosFileDelta,
+		change.LockerFileDelta,
+		change.InvalidateFileCounts,
 	)
 	var storageConsumed int64
 	var fileCountsInvalidated bool
@@ -71,8 +70,8 @@ func applyUsageDelta(
 	if fileCountsInvalidated {
 		logrus.WithFields(logrus.Fields{
 			"user_id":           userID,
-			"photos_file_delta": photosFileDelta,
-			"locker_file_delta": lockerFileDelta,
+			"photos_file_delta": change.PhotosFileDelta,
+			"locker_file_delta": change.LockerFileDelta,
 		}).Error("invalidated file counts")
 	}
 	return storageConsumed, nil


### PR DESCRIPTION
Historical stale memberships can still be removed by cleanup after permanent deletion. Invalidate both file counters and advance the source version in the same transaction when cleanup removes an active owned membership, so a concurrent initialization cannot publish stale counts.

Use the memberships actually changed by the update: retries and shared-only cleanup leave counts alone. Log successful repairs after commit as `cleaned stale owned file memberships`.

Storage usage and count reads are unchanged. Counter activation remains a separate rollout step.