### PR TITLE
docs: cover Photos 1.3.63 features

### DIFF
--- a/docs/docs/photos/faq/metadata-and-editing.md
+++ b/docs/docs/photos/faq/metadata-and-editing.md
@@ -89,7 +89,9 @@ To fix this:
 
 ### What metadata is preserved when I edit a photo? {#metadata-preserved-after-edit}
 
-When Ente creates an edited copy, some metadata such as location, date, and time may be preserved. Other metadata may not be retained in the edited copy.
+When Ente creates an edited copy on mobile, it preserves key camera information along with the photo's date, time, and location metadata. Other metadata may not be retained in the edited copy.
+
+For JPEG photos, an edit that only rotates or flips the image is applied without re-encoding it, preserving the original image quality. Other image edits may re-encode the photo.
 
 The original photo remains untouched.
 

--- a/docs/docs/photos/features/albums-and-organization/deleting.md
+++ b/docs/docs/photos/features/albums-and-organization/deleting.md
@@ -85,9 +85,25 @@ Trash is a special folder where deleted photos are held temporarily before perma
 1. Open the sidebar menu
 2. Click on "Trash"
 
+### Android device trash
+
+On Android 11 and newer, device photos deleted through Ente Photos move to Android's system trash instead of being permanently removed immediately. To review or recover them in Ente:
+
+1. Open the **Albums** tab
+2. Tap the down-arrow icon on the right
+3. Open **Trash**
+4. Select **On device** at the top
+5. Select the photos you want to restore, then tap **Restore**
+
+The **Ente** tab contains files deleted from your Ente account, while **On device** contains device copies in Android's system trash. Emptying either trash permanently deletes the items shown in that tab.
+
+> [!NOTE]
+>
+> The **On device** tab is available on Android 11 and newer.
+
 ### Storage considerations
 
-Items in Trash are included in your storage quota calculation. If you need to free up storage space immediately, you have two options:
+Items in Ente Trash are included in your storage quota calculation. If you need to free up storage space immediately, you have two options:
 
 1. **Empty trash completely** - Permanently deletes all items in trash
 2. **Delete specific items** - Permanently delete only selected items

--- a/docs/docs/photos/features/utilities/video-streaming.md
+++ b/docs/docs/photos/features/utilities/video-streaming.md
@@ -45,6 +45,15 @@ The generated stream is a single encrypted blob (AES encryption) while the playl
 
 Open the specific video, tap the overflow menu (⋮) in the top-right corner, and select **Create stream**
 
+### Mobile playback controls
+
+While viewing a video on mobile:
+
+- Double-tap the left or right half of the video to seek backward or forward by five seconds. Repeated double-taps continue seeking in the same direction.
+- Open the overflow menu (three dots), select **Playback speed**, then choose `0.25x`, `0.5x`, `1x`, `1.5x`, or `2x`.
+
+These controls are available whether Ente plays the original video or a streamable version.
+
 ### On desktop
 
 1. Open `Settings > Preferences > Streamable videos`


### PR DESCRIPTION
## Summary

- document Android 11+ device trash and restoration in Ente Photos
- document mobile five-second double-tap seeking and playback speed options
- clarify metadata and quality preservation for mobile photo edits

## Checks

- `npm ci`
- `npx prettier --check docs/photos/features/albums-and-organization/deleting.md docs/photos/features/utilities/video-streaming.md docs/photos/faq/metadata-and-editing.md`
- `npm run build`
- `git diff --check origin/main...HEAD`
