### PR TITLE
[mobile] Keep Auth selection actions visible with notes

### DIFF
--- a/mobile/apps/auth/lib/ui/home_page.dart
+++ b/mobile/apps/auth/lib/ui/home_page.dart
@@ -840,7 +840,7 @@ class _HomePageState extends State<HomePage> {
       identifier: 'auth_selection_action_bar',
       child: ConstrainedBox(
         constraints: BoxConstraints(
-          maxHeight: MediaQuery.of(context).size.height * 0.4,
+          maxHeight: MediaQuery.of(context).size.height * 0.4 + bottomPadding,
         ),
         child: Card(
           margin: EdgeInsets.zero,


### PR DESCRIPTION
## Before

<img width="1080" height="2340" alt="Before" src="https://github.com/user-attachments/assets/e863975e-4405-4f9f-ab23-0b0f60bd5d3d" />

## After

<img width="1080" height="2340" alt="After" src="https://github.com/user-attachments/assets/095fa637-cbd7-4498-922b-60419feaf4ce" />