### PR TITLE
[mobile][locker] Make scanner button more prominent

### DIFF
--- a/mobile/apps/locker/changes/scanner-button-visibility.md
+++ b/mobile/apps/locker/changes/scanner-button-visibility.md
@@ -1,0 +1,1 @@
+- Made the document scanner button more prominent with a blue border.

--- a/mobile/apps/locker/lib/ui/pages/home_page.dart
+++ b/mobile/apps/locker/lib/ui/pages/home_page.dart
@@ -864,7 +864,7 @@ class _HomePageState extends UploaderPageState<HomePage>
           button: true,
           label: context.strings.scanDocumentTitle,
           child: FABComponent(
-            variant: FABComponentVariant.secondary,
+            variant: FABComponentVariant.outlined,
             icon: HugeIcon(
               icon: HugeIcons.strokeRoundedCamera01,
               color: colors.primary,

--- a/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
+++ b/mobile/packages/ente_components/lib/components/buttons/fab_component.dart
@@ -5,7 +5,7 @@ import "package:ente_components/theme/text_styles.dart";
 import "package:ente_components/theme/theme.dart";
 import "package:flutter/material.dart";
 
-enum FABComponentVariant { primary, secondary, destructive }
+enum FABComponentVariant { primary, secondary, outlined, destructive }
 
 // Figma: https://www.figma.com/design/BuBNPPytxlVnqfmCUW0mgz/Ente-Visual-Design?node-id=21843-6537&m=dev
 class FABComponent extends StatefulWidget {
@@ -57,13 +57,16 @@ class _FABComponentState extends State<FABComponent> {
         _isPressed ? colors.primaryDark : colors.primary,
       FABComponentVariant.secondary =>
         _isPressed ? colors.fillDarker : colors.fillDark,
+      FABComponentVariant.outlined =>
+        _isPressed ? colors.primaryLightPressed : colors.primaryLight,
       FABComponentVariant.destructive =>
         _isPressed ? colors.warningDark : colors.warning,
     };
     final foregroundColor = switch (widget.variant) {
       FABComponentVariant.primary ||
       FABComponentVariant.destructive => colors.specialWhite,
-      FABComponentVariant.secondary => colors.primary,
+      FABComponentVariant.secondary ||
+      FABComponentVariant.outlined => colors.primary,
     };
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -82,6 +85,12 @@ class _FABComponentState extends State<FABComponent> {
             color: backgroundColor,
             borderRadius: BorderRadius.circular(9999),
           ),
+          foregroundDecoration: widget.variant == FABComponentVariant.outlined
+              ? BoxDecoration(
+                  border: Border.all(color: colors.primaryDark, width: 1),
+                  borderRadius: BorderRadius.circular(9999),
+                )
+              : null,
           child: ConstrainedBox(
             constraints: const BoxConstraints(minWidth: 52, minHeight: 52),
             child: Padding(


### PR DESCRIPTION
## Description

Make Locker's scanner button easier to see with a `primaryLight` background and a 1-point `primaryDark` border. Add an outlined FAB variant that preserves the 52-point button size and uses `primaryLightPressed` for touch feedback, and apply it to the scanner button.

## Tests

Visually checked resting and pressed states in light and dark mode on an iPhone 17 Pro simulator running iOS 26.
