### PR TITLE
[mobile] Use Rust metadata for local photos

### DIFF
--- a/mobile/apps/photos/lib/db/files_db.dart
+++ b/mobile/apps/photos/lib/db/files_db.dart
@@ -1199,6 +1199,8 @@ class FilesDB with SqlDbBase {
             jsonEncode({
               widthKey: file.hasDimensions ? file.width : null,
               heightKey: file.hasDimensions ? file.height : null,
+              mediaTypeKey: null,
+              motionVideoIndexKey: null,
             }),
             file.localID,
             file.modificationTime,
@@ -1216,6 +1218,8 @@ class FilesDB with SqlDbBase {
     Location? location,
     int? fileSize,
     ({int width, int height})? dimensions,
+    int? mediaType,
+    int? motionVideoIndex,
   }) async {
     final db = await instance.sqliteAsyncDB;
     final result = await db.execute(
@@ -1236,11 +1240,14 @@ class FilesDB with SqlDbBase {
         location?.latitude,
         location?.longitude,
         fileSize,
-        jsonEncode(
-          dimensions == null
-              ? {}
-              : {widthKey: dimensions.width, heightKey: dimensions.height},
-        ),
+        jsonEncode({
+          if (dimensions != null) ...{
+            widthKey: dimensions.width,
+            heightKey: dimensions.height,
+          },
+          mediaTypeKey: ?mediaType,
+          motionVideoIndexKey: ?motionVideoIndex,
+        }),
         processingVersion,
         localID,
         modificationTime,

--- a/mobile/apps/photos/lib/db/files_db.dart
+++ b/mobile/apps/photos/lib/db/files_db.dart
@@ -1181,7 +1181,7 @@ class FilesDB with SqlDbBase {
     );
   }
 
-  Future<void> refreshLocalDimensions(List<EnteFile> files) async {
+  Future<void> refreshModifiedLocalFiles(List<EnteFile> files) async {
     final db = await instance.sqliteAsyncDB;
     await db.writeTransaction((tx) async {
       for (final file in files) {
@@ -1189,6 +1189,8 @@ class FilesDB with SqlDbBase {
           '''
           UPDATE $filesTable
           SET $columnModificationTime = ?,
+              $columnLatitude = NULL,
+              $columnLongitude = NULL,
               $columnPubMMdEncodedJson = json_patch(COALESCE($columnPubMMdEncodedJson, '{}'), ?),
               $columnMetadataVersion = -1
           WHERE $columnLocalID = ? AND $columnModificationTime != ?

--- a/mobile/apps/photos/lib/db/files_db.dart
+++ b/mobile/apps/photos/lib/db/files_db.dart
@@ -1246,7 +1246,8 @@ class FilesDB with SqlDbBase {
             heightKey: dimensions.height,
           },
           mediaTypeKey: ?mediaType,
-          motionVideoIndexKey: ?motionVideoIndex,
+          if (mediaType != null || motionVideoIndex != null)
+            motionVideoIndexKey: motionVideoIndex,
         }),
         processingVersion,
         localID,

--- a/mobile/apps/photos/lib/db/files_db.dart
+++ b/mobile/apps/photos/lib/db/files_db.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:convert";
 import "dart:io";
 import "dart:math";
 
@@ -16,6 +17,7 @@ import 'package:photos/models/file_load_result.dart';
 import 'package:photos/models/freeable_space_info.dart';
 import 'package:photos/models/location/location.dart';
 import "package:photos/models/metadata/common_keys.dart";
+import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/services/filter/db_filters.dart";
 import 'package:sqlite_async/sqlite_async.dart';
 
@@ -1179,33 +1181,72 @@ class FilesDB with SqlDbBase {
     );
   }
 
-  Future<void> updateOfflineImportMetadataForLocalID(
+  Future<void> refreshLocalDimensions(List<EnteFile> files) async {
+    final db = await instance.sqliteAsyncDB;
+    await db.writeTransaction((tx) async {
+      for (final file in files) {
+        await tx.execute(
+          '''
+          UPDATE $filesTable
+          SET $columnModificationTime = ?,
+              $columnPubMMdEncodedJson = json_patch(COALESCE($columnPubMMdEncodedJson, '{}'), ?),
+              $columnMetadataVersion = -1
+          WHERE $columnLocalID = ? AND $columnModificationTime != ?
+            AND ($columnUploadedFileID IS NULL OR $columnUploadedFileID = -1)
+          ''',
+          [
+            file.modificationTime,
+            jsonEncode({
+              widthKey: file.hasDimensions ? file.width : null,
+              heightKey: file.hasDimensions ? file.height : null,
+            }),
+            file.localID,
+            file.modificationTime,
+          ],
+        );
+      }
+    });
+  }
+
+  Future<bool> updateOfflineImportMetadataForLocalID(
     String localID, {
     required int processingVersion,
+    required int modificationTime,
     int? creationTime,
     Location? location,
     int? fileSize,
+    ({int width, int height})? dimensions,
   }) async {
     final db = await instance.sqliteAsyncDB;
-    await db.execute(
+    final result = await db.execute(
       '''
       UPDATE $filesTable
       SET  $columnCreationTime = COALESCE(?, $columnCreationTime),
             $columnLatitude = COALESCE(?, $columnLatitude),
             $columnLongitude = COALESCE(?, $columnLongitude),
             $columnFileSize = COALESCE(?, $columnFileSize),
+            $columnPubMMdEncodedJson = json_patch(COALESCE($columnPubMMdEncodedJson, '{}'), ?),
             $columnMetadataVersion = ?
-      WHERE $columnLocalID = ? AND ($columnUploadedFileID IS NULL OR $columnUploadedFileID = -1);
+      WHERE $columnLocalID = ? AND $columnModificationTime = ?
+        AND ($columnUploadedFileID IS NULL OR $columnUploadedFileID = -1)
+      RETURNING $columnLocalID;
     ''',
       [
         creationTime,
         location?.latitude,
         location?.longitude,
         fileSize,
+        jsonEncode(
+          dimensions == null
+              ? {}
+              : {widthKey: dimensions.width, heightKey: dimensions.height},
+        ),
         processingVersion,
         localID,
+        modificationTime,
       ],
     );
+    return result.isNotEmpty;
   }
 
   Future<List<EnteFile>> getUnlinkedLocalMatchesForRemoteFile(

--- a/mobile/apps/photos/lib/module/metadata/local_file.dart
+++ b/mobile/apps/photos/lib/module/metadata/local_file.dart
@@ -1,3 +1,4 @@
+import "dart:convert";
 import "dart:io";
 
 import "package:ente_pure_utils/ente_pure_utils.dart";
@@ -5,12 +6,13 @@ import "package:photo_manager/photo_manager.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/location/location.dart";
+import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/module/metadata/asset_date_times.dart";
 import "package:photos/module/metadata/exif.dart";
 
 EnteFile fileFromAsset(String deviceFolder, AssetEntity asset) {
   final resolvedDateTimes = resolveAssetDateTimes(asset);
-  return EnteFile()
+  final file = EnteFile()
     ..localID = asset.id
     ..title = asset.title
     ..deviceFolder = deviceFolder
@@ -20,6 +22,17 @@ EnteFile fileFromAsset(String deviceFolder, AssetEntity asset) {
     ..modificationTime = resolvedDateTimes.modificationTime
     ..fileSubType = asset.subtype
     ..metadataVersion = -1;
+  applyDisplayDimensions(file, asset.orientatedWidth, asset.orientatedHeight);
+  return file;
+}
+
+void applyDisplayDimensions(EnteFile file, int width, int height) {
+  if (width <= 0 || height <= 0) return;
+  file.pubMmdEncodedJson = jsonEncode({
+    ...jsonDecode(file.pubMmdEncodedJson ?? '{}') as Map<String, dynamic>,
+    widthKey: width,
+    heightKey: height,
+  });
 }
 
 void applyCreationTimeMetadata(EnteFile file, ParsedExifDateTime? exifTime) {

--- a/mobile/apps/photos/lib/module/metadata/local_file.dart
+++ b/mobile/apps/photos/lib/module/metadata/local_file.dart
@@ -35,6 +35,19 @@ void applyDisplayDimensions(EnteFile file, int width, int height) {
   });
 }
 
+void applyMediaTypeMetadata(
+  EnteFile file,
+  bool isPanorama,
+  int motionVideoIndex,
+) {
+  file.pubMmdEncodedJson = jsonEncode({
+    ...jsonDecode(file.pubMmdEncodedJson ?? '{}') as Map<String, dynamic>,
+    mediaTypeKey:
+        ((file.pubMagicMetadata?.mediaType ?? 0) & ~1) | (isPanorama ? 1 : 0),
+    motionVideoIndexKey: motionVideoIndex,
+  });
+}
+
 void applyCreationTimeMetadata(EnteFile file, ParsedExifDateTime? exifTime) {
   final hasExifTime = exifTime != null;
   if (exifTime != null) {

--- a/mobile/apps/photos/lib/module/metadata/local_file.dart
+++ b/mobile/apps/photos/lib/module/metadata/local_file.dart
@@ -42,8 +42,7 @@ void applyMediaTypeMetadata(
 ) {
   file.pubMmdEncodedJson = jsonEncode({
     ...jsonDecode(file.pubMmdEncodedJson ?? '{}') as Map<String, dynamic>,
-    mediaTypeKey:
-        ((file.pubMagicMetadata?.mediaType ?? 0) & ~1) | (isPanorama ? 1 : 0),
+    mediaTypeKey: isPanorama ? 1 : 0,
     motionVideoIndexKey: motionVideoIndex,
   });
 }

--- a/mobile/apps/photos/lib/module/metadata/local_file.dart
+++ b/mobile/apps/photos/lib/module/metadata/local_file.dart
@@ -38,7 +38,7 @@ void applyDisplayDimensions(EnteFile file, int width, int height) {
 void applyMediaTypeMetadata(
   EnteFile file,
   bool isPanorama,
-  int motionVideoIndex,
+  int? motionVideoIndex,
 ) {
   file.pubMmdEncodedJson = jsonEncode({
     ...jsonDecode(file.pubMmdEncodedJson ?? '{}') as Map<String, dynamic>,

--- a/mobile/apps/photos/lib/module/metadata/photo.dart
+++ b/mobile/apps/photos/lib/module/metadata/photo.dart
@@ -1,0 +1,39 @@
+import "dart:io";
+
+import "package:logging/logging.dart";
+import "package:photos/models/location/location.dart";
+import "package:photos/module/metadata/exif.dart";
+import "package:photos/src/rust/api/metadata_api.dart";
+
+final _logger = Logger("PhotoMetadata");
+
+Future<PhotoMetadata?> tryReadPhotoMetadata(File file) async {
+  try {
+    return await readPhotoMetadata(filePath: file.path);
+  } catch (e, s) {
+    _logger.warning("Failed to read photo metadata", e, s);
+    return null;
+  }
+}
+
+extension PhotoMetadataValues on PhotoMetadata {
+  ParsedExifDateTime? get creationDateTime {
+    final date = captureDateTime;
+    if (date == null) return null;
+    final timestamp = date.timestampMicros;
+    return ParsedExifDateTime(
+      timestamp == null
+          ? DateTime.parse(date.dateTime)
+          : DateTime.fromMicrosecondsSinceEpoch(timestamp.toInt()),
+      date.dateTime,
+      date.offsetTime,
+    );
+  }
+
+  Location? get embeddedLocation {
+    final value = location;
+    return value == null
+        ? null
+        : Location(latitude: value.latitude, longitude: value.longitude);
+  }
+}

--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -472,7 +472,7 @@ class LocalSyncService {
         "track ${updatedFiles.length}/ $updateCount files due to modification change",
       );
       if (updatedFiles.isNotEmpty) {
-        await _db.refreshLocalDimensions(updatedFiles);
+        await _db.refreshModifiedLocalFiles(updatedFiles);
         await FileUpdationDB.instance.insertMultiple(
           updatedFiles.map((file) => file.localID!).toList(),
           FileUpdationDB.modificationTimeUpdated,

--- a/mobile/apps/photos/lib/services/sync/local_sync_service.dart
+++ b/mobile/apps/photos/lib/services/sync/local_sync_service.dart
@@ -472,6 +472,7 @@ class LocalSyncService {
         "track ${updatedFiles.length}/ $updateCount files due to modification change",
       );
       if (updatedFiles.isNotEmpty) {
+        await _db.refreshLocalDimensions(updatedFiles);
         await FileUpdationDB.instance.insertMultiple(
           updatedFiles.map((file) => file.localID!).toList(),
           FileUpdationDB.modificationTimeUpdated,

--- a/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
+++ b/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
@@ -18,7 +18,7 @@ import "package:photos/service_locator.dart";
 import "package:photos/services/process_activity.dart";
 
 class OfflineImportMetadataService {
-  static const kProcessingVersion = 2;
+  static const kProcessingVersion = 3;
   static const kDefaultBatchSize = 25;
 
   final _logger = Logger("OfflineImportMetadataService");
@@ -121,6 +121,13 @@ class OfflineImportMetadataService {
       );
 
       applyCreationTimeMetadata(file, metadata?.creationDateTime);
+      if (metadata != null) {
+        applyMediaTypeMetadata(
+          file,
+          metadata.isPanorama,
+          metadata.motionVideoStart?.toInt() ?? 0,
+        );
+      }
 
       final updated = await _db.updateOfflineImportMetadataForLocalID(
         file.localID!,
@@ -129,6 +136,8 @@ class OfflineImportMetadataService {
         creationTime: file.creationTime,
         location: file.location,
         fileSize: fileSize,
+        mediaType: metadata == null ? null : file.pubMagicMetadata!.mediaType,
+        motionVideoIndex: metadata == null ? null : file.pubMagicMetadata!.mvi,
         dimensions: file.hasDimensions
             ? (width: file.width, height: file.height)
             : null,

--- a/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
+++ b/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
@@ -125,7 +125,7 @@ class OfflineImportMetadataService {
         applyMediaTypeMetadata(
           file,
           metadata.isPanorama,
-          metadata.motionVideoStart?.toInt() ?? 0,
+          metadata.motionVideoStart?.toInt(),
         );
       }
 

--- a/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
+++ b/mobile/apps/photos/lib/services/sync/offline_import_metadata_service.dart
@@ -1,7 +1,6 @@
 import "dart:async";
 import "dart:io";
 
-import "package:exif_reader/exif_reader.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/db/files_db.dart";
@@ -14,11 +13,12 @@ import "package:photos/module/download/file.dart";
 import "package:photos/module/metadata/exif.dart";
 import "package:photos/module/metadata/local_file.dart";
 import 'package:photos/module/metadata/location.dart';
+import "package:photos/module/metadata/photo.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/services/process_activity.dart";
 
 class OfflineImportMetadataService {
-  static const kProcessingVersion = 1;
+  static const kProcessingVersion = 2;
   static const kDefaultBatchSize = 25;
 
   final _logger = Logger("OfflineImportMetadataService");
@@ -99,32 +99,41 @@ class OfflineImportMetadataService {
   }
 
   Future<bool> _processFile(EnteFile file) async {
-    File? originFile;
     try {
-      originFile = await getFile(file, isOrigin: true);
+      final originFile = await getFile(file, isOrigin: true);
       if (originFile == null || !originFile.existsSync()) {
         return false;
       }
 
       final fileSize = await originFile.length();
-      final exifData = shouldReadExif(file)
-          ? await tryExifFromFile(originFile)
+      final metadata = shouldReadExif(file)
+          ? await tryReadPhotoMetadata(originFile)
           : null;
-      final exifTime = exifData != null
-          ? await tryParseExifDateTime(null, exifData)
-          : null;
+      final dimensions = metadata?.dimensions;
+      if (dimensions != null) {
+        applyDisplayDimensions(file, dimensions.width, dimensions.height);
+      }
 
-      await _updateLocationForOfflineFile(file, originFile, exifData);
+      await _updateLocationAndDimensions(
+        file,
+        originFile,
+        metadata?.embeddedLocation,
+      );
 
-      applyCreationTimeMetadata(file, exifTime);
+      applyCreationTimeMetadata(file, metadata?.creationDateTime);
 
-      await _db.updateOfflineImportMetadataForLocalID(
+      final updated = await _db.updateOfflineImportMetadataForLocalID(
         file.localID!,
         processingVersion: kProcessingVersion,
+        modificationTime: file.modificationTime!,
         creationTime: file.creationTime,
         location: file.location,
         fileSize: fileSize,
+        dimensions: file.hasDimensions
+            ? (width: file.width, height: file.height)
+            : null,
       );
+      if (!updated) return false;
 
       file.fileSize = fileSize;
       file.metadataVersion = kProcessingVersion;
@@ -132,39 +141,40 @@ class OfflineImportMetadataService {
     } catch (e, s) {
       _logger.warning("Failed to process ${file.tag}", e, s);
       return false;
-    } finally {
-      if (Platform.isIOS &&
-          originFile != null &&
-          !file.isSharedMediaToAppSandbox) {
-        try {
-          await originFile.delete();
-        } catch (_) {}
-      }
     }
   }
 
-  Future<void> _updateLocationForOfflineFile(
+  Future<void> _updateLocationAndDimensions(
     EnteFile file,
     File originFile,
-    Map<String, IfdTag>? exifData,
+    Location? embeddedLocation,
   ) async {
-    final shouldFetchAssetLocation =
-        file.location == null ||
-        ((file.location?.latitude ?? 0) == 0 &&
-            (file.location?.longitude ?? 0) == 0);
-    if (shouldFetchAssetLocation) {
+    if (Location.isValidLocation(embeddedLocation)) {
+      file.location = embeddedLocation;
+    }
+    final shouldFetchAssetLocation = !Location.isValidLocation(file.location);
+    if (shouldFetchAssetLocation || !file.hasDimensions) {
       final asset = await file.getAsset;
       if (asset != null) {
-        final latLong = await asset.latlngAsync();
-        if (latLong != null) {
-          file.location = Location(
-            latitude: latLong.latitude,
-            longitude: latLong.longitude,
+        if (!file.hasDimensions) {
+          applyDisplayDimensions(
+            file,
+            asset.orientatedWidth,
+            asset.orientatedHeight,
           );
+        }
+        if (shouldFetchAssetLocation) {
+          final latLong = await asset.latlngAsync();
+          if (latLong != null) {
+            file.location = Location(
+              latitude: latLong.latitude,
+              longitude: latLong.longitude,
+            );
+          }
         }
       }
     }
 
-    await updateLocationFromEmbeddedMetadata(file, originFile, exifData);
+    await updateLocationFromEmbeddedMetadata(file, originFile, null);
   }
 }

--- a/mobile/apps/photos/test/db/offline_metadata_test.dart
+++ b/mobile/apps/photos/test/db/offline_metadata_test.dart
@@ -1,0 +1,129 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:flutter_test/flutter_test.dart";
+import "package:path_provider_platform_interface/path_provider_platform_interface.dart";
+import "package:photos/db/files_db.dart";
+import "package:photos/models/file/file.dart";
+import "package:photos/module/metadata/local_file.dart";
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final files = FilesDB.instance;
+  late Directory directory;
+  late PathProviderPlatform previousPathProvider;
+
+  setUpAll(() async {
+    directory = await Directory.systemTemp.createTemp("offline_metadata_");
+    previousPathProvider = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _PathProvider(directory.path);
+  });
+
+  tearDownAll(() async {
+    await (await files.sqliteAsyncDB).close();
+    PathProviderPlatform.instance = previousPathProvider;
+    await directory.delete(recursive: true);
+  });
+
+  test(
+    "persists dimensions, refreshes edits and rejects stale results only for local rows",
+    () async {
+      final db = await files.sqliteAsyncDB;
+      for (final (uploadedID, collectionID) in [(-1, 1), (-1, 2), (99, 3)]) {
+        await db.execute(
+          '''
+        INSERT INTO ${FilesDB.filesTable}
+          (${FilesDB.columnLocalID}, ${FilesDB.columnUploadedFileID},
+           ${FilesDB.columnCollectionID}, ${FilesDB.columnTitle},
+           ${FilesDB.columnCreationTime}, ${FilesDB.columnModificationTime},
+           ${FilesDB.columnMetadataVersion}, ${FilesDB.columnPubMMdEncodedJson})
+        VALUES ('local', ?, ?, 'photo.jpg', 100, 100, 1, ?)
+      ''',
+          [uploadedID, collectionID, '{"caption":"Keep me","w":4000,"h":3000}'],
+        );
+      }
+
+      expect(
+        await files.updateOfflineImportMetadataForLocalID(
+          "local",
+          processingVersion: 2,
+          modificationTime: 100,
+          dimensions: (width: 3000, height: 4000),
+        ),
+        isTrue,
+      );
+
+      final rows = await db.getAll(
+        'SELECT * FROM ${FilesDB.filesTable} ORDER BY ${FilesDB.columnCollectionID}',
+      );
+      for (final row in rows.take(2)) {
+        final file = EnteFile()
+          ..pubMmdEncodedJson = row[FilesDB.columnPubMMdEncodedJson] as String;
+        expect((file.width, file.height), (3000, 4000));
+        expect(file.pubMagicMetadata!.caption, "Keep me");
+        expect(row[FilesDB.columnMetadataVersion], 2);
+      }
+      expect(
+        jsonDecode(rows.last[FilesDB.columnPubMMdEncodedJson] as String)['w'],
+        4000,
+      );
+      expect(rows.last[FilesDB.columnMetadataVersion], 1);
+
+      final edited = EnteFile()
+        ..localID = "local"
+        ..modificationTime = 200;
+      applyDisplayDimensions(edited, 800, 600);
+      await files.refreshLocalDimensions([edited]);
+      expect(
+        await files.updateOfflineImportMetadataForLocalID(
+          "local",
+          processingVersion: 2,
+          modificationTime: 100,
+          dimensions: (width: 3000, height: 4000),
+        ),
+        isFalse,
+      );
+      final pending = await db.getAll(
+        'SELECT * FROM ${FilesDB.filesTable} WHERE ${FilesDB.columnMetadataVersion} = -1',
+      );
+      expect(pending, hasLength(2));
+      expect(
+        jsonDecode(pending.first[FilesDB.columnPubMMdEncodedJson] as String),
+        {"caption": "Keep me", "w": 800, "h": 600},
+      );
+
+      expect(
+        await files.updateOfflineImportMetadataForLocalID(
+          "local",
+          processingVersion: 2,
+          modificationTime: 200,
+        ),
+        isTrue,
+      );
+      await files.refreshLocalDimensions([edited]);
+      expect(
+        await db.getAll(
+          'SELECT * FROM ${FilesDB.filesTable} WHERE ${FilesDB.columnMetadataVersion} = -1',
+        ),
+        isEmpty,
+      );
+      final refreshed = await db.getAll(
+        'SELECT * FROM ${FilesDB.filesTable} WHERE ${FilesDB.columnUploadedFileID} = -1',
+      );
+      expect(
+        jsonDecode(
+          refreshed.first[FilesDB.columnPubMMdEncodedJson] as String,
+        )['w'],
+        800,
+      );
+    },
+  );
+}
+
+class _PathProvider extends PathProviderPlatform {
+  _PathProvider(this.path);
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}

--- a/mobile/apps/photos/test/db/offline_metadata_test.dart
+++ b/mobile/apps/photos/test/db/offline_metadata_test.dart
@@ -26,7 +26,7 @@ void main() {
   });
 
   test(
-    "persists dimensions, refreshes edits and rejects stale results only for local rows",
+    "persists media metadata, refreshes edits and rejects stale results only for local rows",
     () async {
       final db = await files.sqliteAsyncDB;
       for (final (uploadedID, collectionID) in [(-1, 1), (-1, 2), (99, 3)]) {
@@ -49,6 +49,8 @@ void main() {
           processingVersion: 2,
           modificationTime: 100,
           dimensions: (width: 3000, height: 4000),
+          mediaType: 1,
+          motionVideoIndex: 1234,
         ),
         isTrue,
       );
@@ -61,6 +63,8 @@ void main() {
           ..pubMmdEncodedJson = row[FilesDB.columnPubMMdEncodedJson] as String;
         expect((file.width, file.height), (3000, 4000));
         expect(file.pubMagicMetadata!.caption, "Keep me");
+        expect(file.pubMagicMetadata!.mediaType, 1);
+        expect(file.pubMagicMetadata!.mvi, 1234);
         expect(row[FilesDB.columnMetadataVersion], 2);
       }
       expect(
@@ -80,6 +84,8 @@ void main() {
           processingVersion: 2,
           modificationTime: 100,
           dimensions: (width: 3000, height: 4000),
+          mediaType: 1,
+          motionVideoIndex: 1234,
         ),
         isFalse,
       );

--- a/mobile/apps/photos/test/db/offline_metadata_test.dart
+++ b/mobile/apps/photos/test/db/offline_metadata_test.dart
@@ -5,7 +5,6 @@ import "package:flutter_test/flutter_test.dart";
 import "package:path_provider_platform_interface/path_provider_platform_interface.dart";
 import "package:photos/db/files_db.dart";
 import "package:photos/models/file/file.dart";
-import "package:photos/module/metadata/local_file.dart";
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -25,122 +24,92 @@ void main() {
     await directory.delete(recursive: true);
   });
 
-  test(
-    "persists media metadata, refreshes edits and rejects stale results only for local rows",
-    () async {
-      final db = await files.sqliteAsyncDB;
-      for (final (uploadedID, collectionID) in [(-1, 1), (-1, 2), (99, 3)]) {
-        await db.execute(
-          '''
-        INSERT INTO ${FilesDB.filesTable}
-          (${FilesDB.columnLocalID}, ${FilesDB.columnUploadedFileID},
-           ${FilesDB.columnCollectionID}, ${FilesDB.columnTitle},
-           ${FilesDB.columnCreationTime}, ${FilesDB.columnModificationTime},
-           ${FilesDB.columnMetadataVersion}, ${FilesDB.columnPubMMdEncodedJson})
-        VALUES ('local', ?, ?, 'photo.jpg', 100, 100, 1, ?)
-      ''',
-          [uploadedID, collectionID, '{"caption":"Keep me","w":4000,"h":3000}'],
-        );
-      }
+  test("refreshes only current local rows", () async {
+    final db = await files.sqliteAsyncDB;
+    await db.execute('''
+      INSERT INTO ${FilesDB.filesTable}
+        (${FilesDB.columnLocalID}, ${FilesDB.columnUploadedFileID},
+         ${FilesDB.columnCollectionID}, ${FilesDB.columnTitle},
+         ${FilesDB.columnCreationTime}, ${FilesDB.columnModificationTime},
+         ${FilesDB.columnLatitude}, ${FilesDB.columnLongitude},
+         ${FilesDB.columnMetadataVersion}, ${FilesDB.columnPubMMdEncodedJson})
+      VALUES
+        ('local', -1, 1, 'photo.jpg', 100, 100, 12.3, 45.6, 3,
+         '{"caption":"Keep me","w":4000,"h":3000,"mediaType":1,"mvi":42}'),
+        ('local', 99, 2, 'photo.jpg', 100, 100, 12.3, 45.6, 1,
+         '{"caption":"Keep me","w":4000,"h":3000}')
+    ''');
 
-      expect(
-        await files.updateOfflineImportMetadataForLocalID(
-          "local",
-          processingVersion: 2,
-          modificationTime: 100,
-          dimensions: (width: 3000, height: 4000),
-          mediaType: 1,
-          motionVideoIndex: 1234,
-        ),
-        isTrue,
-      );
-
-      final rows = await db.getAll(
-        'SELECT * FROM ${FilesDB.filesTable} ORDER BY ${FilesDB.columnCollectionID}',
-      );
-      for (final row in rows.take(2)) {
-        final file = EnteFile()
-          ..pubMmdEncodedJson = row[FilesDB.columnPubMMdEncodedJson] as String;
-        expect((file.width, file.height), (3000, 4000));
-        expect(file.pubMagicMetadata!.caption, "Keep me");
-        expect(file.pubMagicMetadata!.mediaType, 1);
-        expect(file.pubMagicMetadata!.mvi, 1234);
-        expect(row[FilesDB.columnMetadataVersion], 2);
-      }
-      expect(
-        jsonDecode(rows.last[FilesDB.columnPubMMdEncodedJson] as String)['w'],
-        4000,
-      );
-      expect(rows.last[FilesDB.columnMetadataVersion], 1);
-
+    final edited = EnteFile()
+      ..localID = "local"
+      ..modificationTime = 200
+      ..pubMmdEncodedJson = '{"w":800,"h":600}';
+    await files.refreshModifiedLocalFiles([edited]);
+    expect(
       await files.updateOfflineImportMetadataForLocalID(
         "local",
-        processingVersion: 3,
+        processingVersion: 2,
         modificationTime: 100,
+      ),
+      isFalse,
+    );
+
+    final rows = await db.getAll('SELECT * FROM ${FilesDB.filesTable}');
+    var local = rows.first;
+    expect(
+      (
+        local[FilesDB.columnModificationTime],
+        local[FilesDB.columnMetadataVersion],
+        local[FilesDB.columnLatitude],
+        local[FilesDB.columnLongitude],
+      ),
+      (200, -1, null, null),
+    );
+    expect(jsonDecode(local[FilesDB.columnPubMMdEncodedJson] as String), {
+      "caption": "Keep me",
+      "w": 800,
+      "h": 600,
+    });
+    final uploaded = rows.last;
+    expect(
+      (
+        uploaded[FilesDB.columnModificationTime],
+        uploaded[FilesDB.columnMetadataVersion],
+        uploaded[FilesDB.columnLatitude],
+        uploaded[FilesDB.columnLongitude],
+      ),
+      (100, 1, 12.3, 45.6),
+    );
+
+    expect(
+      await files.updateOfflineImportMetadataForLocalID(
+        "local",
+        processingVersion: 2,
+        modificationTime: 200,
+        dimensions: (width: 600, height: 800),
         mediaType: 0,
-      );
-      final unknown = await db.getAll(
-        'SELECT * FROM ${FilesDB.filesTable} WHERE ${FilesDB.columnUploadedFileID} = -1',
-      );
-      for (final row in unknown) {
-        final metadata = jsonDecode(
-          row[FilesDB.columnPubMMdEncodedJson] as String,
-        );
-        expect(metadata.containsKey('mvi'), isFalse);
-        expect(metadata['mediaType'], 0);
-      }
-
-      final edited = EnteFile()
-        ..localID = "local"
-        ..modificationTime = 200;
-      applyDisplayDimensions(edited, 800, 600);
-      await files.refreshLocalDimensions([edited]);
-      expect(
-        await files.updateOfflineImportMetadataForLocalID(
-          "local",
-          processingVersion: 2,
-          modificationTime: 100,
-          dimensions: (width: 3000, height: 4000),
-          mediaType: 1,
-          motionVideoIndex: 1234,
-        ),
-        isFalse,
-      );
-      final pending = await db.getAll(
-        'SELECT * FROM ${FilesDB.filesTable} WHERE ${FilesDB.columnMetadataVersion} = -1',
-      );
-      expect(pending, hasLength(2));
-      expect(
-        jsonDecode(pending.first[FilesDB.columnPubMMdEncodedJson] as String),
-        {"caption": "Keep me", "w": 800, "h": 600},
-      );
-
-      expect(
-        await files.updateOfflineImportMetadataForLocalID(
-          "local",
-          processingVersion: 2,
-          modificationTime: 200,
-        ),
-        isTrue,
-      );
-      await files.refreshLocalDimensions([edited]);
-      expect(
-        await db.getAll(
-          'SELECT * FROM ${FilesDB.filesTable} WHERE ${FilesDB.columnMetadataVersion} = -1',
-        ),
-        isEmpty,
-      );
-      final refreshed = await db.getAll(
-        'SELECT * FROM ${FilesDB.filesTable} WHERE ${FilesDB.columnUploadedFileID} = -1',
-      );
-      expect(
-        jsonDecode(
-          refreshed.first[FilesDB.columnPubMMdEncodedJson] as String,
-        )['w'],
-        800,
-      );
-    },
-  );
+      ),
+      isTrue,
+    );
+    await files.refreshModifiedLocalFiles([edited]);
+    local = (await db.getAll(
+      'SELECT * FROM ${FilesDB.filesTable} WHERE ${FilesDB.columnUploadedFileID} = -1',
+    )).single;
+    final metadata = jsonDecode(
+      local[FilesDB.columnPubMMdEncodedJson] as String,
+    );
+    expect(
+      (
+        metadata['caption'],
+        metadata['w'],
+        metadata['h'],
+        metadata['mediaType'],
+        metadata.containsKey('mvi'),
+        local[FilesDB.columnMetadataVersion],
+      ),
+      ("Keep me", 600, 800, 0, false, 2),
+    );
+  });
 }
 
 class _PathProvider extends PathProviderPlatform {

--- a/mobile/apps/photos/test/db/offline_metadata_test.dart
+++ b/mobile/apps/photos/test/db/offline_metadata_test.dart
@@ -73,6 +73,23 @@ void main() {
       );
       expect(rows.last[FilesDB.columnMetadataVersion], 1);
 
+      await files.updateOfflineImportMetadataForLocalID(
+        "local",
+        processingVersion: 3,
+        modificationTime: 100,
+        mediaType: 0,
+      );
+      final unknown = await db.getAll(
+        'SELECT * FROM ${FilesDB.filesTable} WHERE ${FilesDB.columnUploadedFileID} = -1',
+      );
+      for (final row in unknown) {
+        final metadata = jsonDecode(
+          row[FilesDB.columnPubMMdEncodedJson] as String,
+        );
+        expect(metadata.containsKey('mvi'), isFalse);
+        expect(metadata['mediaType'], 0);
+      }
+
       final edited = EnteFile()
         ..localID = "local"
         ..modificationTime = 200;

--- a/mobile/apps/photos/test/module/metadata/photo_test.dart
+++ b/mobile/apps/photos/test/module/metadata/photo_test.dart
@@ -35,6 +35,31 @@ void main() {
     expect(file.metadataVersion, -1);
   });
 
+  test("keeps an earlier MediaStore modification time without EXIF", () {
+    final file = fileFromAsset(
+      "EnteThumbnailBench",
+      AssetEntity(
+        id: "bench",
+        typeInt: 1,
+        width: 4032,
+        height: 3024,
+        title: "bench-IMG_8606_rotate_90_cw_contains_text.HEIC",
+        createDateSecond: 1786506608,
+        modifiedDateSecond: 1786450130,
+      ),
+    );
+
+    expect(
+      file.creationTime,
+      1786450130 * Duration.microsecondsPerSecond,
+    );
+    applyCreationTimeMetadata(file, null);
+    expect(
+      file.creationTime,
+      1786450130 * Duration.microsecondsPerSecond,
+    );
+  });
+
   test(
     "refined dimensions invalidate the model cache and preserve other fields",
     () {

--- a/mobile/apps/photos/test/module/metadata/photo_test.dart
+++ b/mobile/apps/photos/test/module/metadata/photo_test.dart
@@ -6,16 +6,16 @@ import "package:photos/module/metadata/photo.dart";
 import "package:photos/src/rust/api/metadata_api.dart";
 
 void main() {
-  test("media detection preserves other bits and clears stale detections", () {
+  test("media detection replaces prior state and preserves other metadata", () {
     final file = EnteFile()
-      ..pubMmdEncodedJson = '{"mediaType":2,"caption":"Keep me"}';
-    applyMediaTypeMetadata(file, true, 1234);
-    expect(file.pubMagicMetadata!.mediaType, 3);
-    expect(file.pubMagicMetadata!.mvi, 1234);
+      ..pubMmdEncodedJson = '{"mediaType":1,"mvi":42,"caption":"Keep me"}';
     applyMediaTypeMetadata(file, false, null);
-    expect(file.pubMagicMetadata!.mediaType, 2);
+    expect(file.pubMagicMetadata!.mediaType, 0);
     expect(file.pubMagicMetadata!.mvi, isNull);
     expect(file.pubMagicMetadata!.caption, "Keep me");
+    applyMediaTypeMetadata(file, true, 1234);
+    expect(file.pubMagicMetadata!.mediaType, 1);
+    expect(file.pubMagicMetadata!.mvi, 1234);
   });
 
   test("local discovery supplies oriented mosaic dimensions", () {

--- a/mobile/apps/photos/test/module/metadata/photo_test.dart
+++ b/mobile/apps/photos/test/module/metadata/photo_test.dart
@@ -6,6 +6,18 @@ import "package:photos/module/metadata/photo.dart";
 import "package:photos/src/rust/api/metadata_api.dart";
 
 void main() {
+  test("media detection preserves other bits and clears stale detections", () {
+    final file = EnteFile()
+      ..pubMmdEncodedJson = '{"mediaType":2,"caption":"Keep me"}';
+    applyMediaTypeMetadata(file, true, 1234);
+    expect(file.pubMagicMetadata!.mediaType, 3);
+    expect(file.pubMagicMetadata!.mvi, 1234);
+    applyMediaTypeMetadata(file, false, 0);
+    expect(file.pubMagicMetadata!.mediaType, 2);
+    expect(file.pubMagicMetadata!.mvi, 0);
+    expect(file.pubMagicMetadata!.caption, "Keep me");
+  });
+
   test("local discovery supplies oriented mosaic dimensions", () {
     final file = fileFromAsset(
       "Camera",
@@ -41,6 +53,8 @@ void main() {
   test("uses the parsed instant without applying the offset twice", () {
     const metadata = PhotoMetadata(
       dimensions: null,
+      isPanorama: false,
+      motionVideoStart: null,
       location: null,
       captureDateTime: CaptureDateTime(
         dateTime: "2024-01-01T12:00:00.123456",
@@ -57,6 +71,8 @@ void main() {
   test("resolves an offset-free time locally without inventing an offset", () {
     const metadata = PhotoMetadata(
       dimensions: null,
+      isPanorama: false,
+      motionVideoStart: null,
       location: null,
       captureDateTime: CaptureDateTime(
         dateTime: "2024-01-01T12:00:00",

--- a/mobile/apps/photos/test/module/metadata/photo_test.dart
+++ b/mobile/apps/photos/test/module/metadata/photo_test.dart
@@ -49,15 +49,9 @@ void main() {
       ),
     );
 
-    expect(
-      file.creationTime,
-      1786450130 * Duration.microsecondsPerSecond,
-    );
+    expect(file.creationTime, 1786450130 * Duration.microsecondsPerSecond);
     applyCreationTimeMetadata(file, null);
-    expect(
-      file.creationTime,
-      1786450130 * Duration.microsecondsPerSecond,
-    );
+    expect(file.creationTime, 1786450130 * Duration.microsecondsPerSecond);
   });
 
   test(

--- a/mobile/apps/photos/test/module/metadata/photo_test.dart
+++ b/mobile/apps/photos/test/module/metadata/photo_test.dart
@@ -12,9 +12,9 @@ void main() {
     applyMediaTypeMetadata(file, true, 1234);
     expect(file.pubMagicMetadata!.mediaType, 3);
     expect(file.pubMagicMetadata!.mvi, 1234);
-    applyMediaTypeMetadata(file, false, 0);
+    applyMediaTypeMetadata(file, false, null);
     expect(file.pubMagicMetadata!.mediaType, 2);
-    expect(file.pubMagicMetadata!.mvi, 0);
+    expect(file.pubMagicMetadata!.mvi, isNull);
     expect(file.pubMagicMetadata!.caption, "Keep me");
   });
 

--- a/mobile/apps/photos/test/module/metadata/photo_test.dart
+++ b/mobile/apps/photos/test/module/metadata/photo_test.dart
@@ -1,0 +1,71 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:photo_manager/photo_manager.dart";
+import "package:photos/models/file/file.dart";
+import "package:photos/module/metadata/local_file.dart";
+import "package:photos/module/metadata/photo.dart";
+import "package:photos/src/rust/api/metadata_api.dart";
+
+void main() {
+  test("local discovery supplies oriented mosaic dimensions", () {
+    final file = fileFromAsset(
+      "Camera",
+      AssetEntity(
+        id: "rotated",
+        typeInt: 1,
+        width: 4000,
+        height: 3000,
+        orientation: 90,
+        createDateSecond: 1704110400,
+        modifiedDateSecond: 1704110400,
+      ),
+    );
+    expect((file.width, file.height), (3000, 4000));
+    expect(file.metadataVersion, -1);
+  });
+
+  test(
+    "refined dimensions invalidate the model cache and preserve other fields",
+    () {
+      final file = EnteFile()
+        ..pubMmdEncodedJson = '{"w":4000,"h":3000,"caption":"Keep me"}';
+      expect(file.width, 4000);
+      expect(file.pubMagicMetadata!.caption, "Keep me");
+      applyDisplayDimensions(file, 1200, 1600);
+      expect((file.width, file.height), (1200, 1600));
+      expect(file.pubMagicMetadata!.caption, "Keep me");
+      applyDisplayDimensions(file, 0, 100);
+      expect((file.width, file.height), (1200, 1600));
+    },
+  );
+
+  test("uses the parsed instant without applying the offset twice", () {
+    const metadata = PhotoMetadata(
+      dimensions: null,
+      location: null,
+      captureDateTime: CaptureDateTime(
+        dateTime: "2024-01-01T12:00:00.123456",
+        offsetTime: "-00:30",
+        timestampMicros: 1704112200123456,
+      ),
+    );
+    final date = metadata.creationDateTime!;
+    expect(date.time.toUtc(), DateTime.utc(2024, 1, 1, 12, 30, 0, 123, 456));
+    expect(date.dateTime, "2024-01-01T12:00:00.123456");
+    expect(date.offsetTime, "-00:30");
+  });
+
+  test("resolves an offset-free time locally without inventing an offset", () {
+    const metadata = PhotoMetadata(
+      dimensions: null,
+      location: null,
+      captureDateTime: CaptureDateTime(
+        dateTime: "2024-01-01T12:00:00",
+        offsetTime: null,
+        timestampMicros: null,
+      ),
+    );
+    final date = metadata.creationDateTime!;
+    expect(date.time, DateTime(2024, 1, 1, 12));
+    expect(date.offsetTime, isNull);
+  });
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2732,6 +2732,7 @@ name = "ente-photos"
 version = "0.0.0"
 dependencies = [
  "ente-assets",
+ "ente-exif",
  "ente-location",
  "quick-xml",
  "rusqlite",

--- a/rust/bindings/frb/photos/src/api/metadata_api.rs
+++ b/rust/bindings/frb/photos/src/api/metadata_api.rs
@@ -1,0 +1,41 @@
+use super::location_api::LocationCoordinate;
+
+#[derive(Clone, Debug)]
+pub struct PhotoMetadata {
+    pub dimensions: Option<Dimensions>,
+    pub capture_date_time: Option<CaptureDateTime>,
+    pub location: Option<LocationCoordinate>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Dimensions {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct CaptureDateTime {
+    pub date_time: String,
+    pub offset_time: Option<String>,
+    pub timestamp_micros: Option<i64>,
+}
+
+pub fn read_photo_metadata(file_path: String) -> Result<PhotoMetadata, String> {
+    let metadata =
+        ente_photos::metadata::read_photo_metadata(file_path).map_err(|error| error.to_string())?;
+    Ok(PhotoMetadata {
+        dimensions: metadata.dimensions.map(|dimensions| Dimensions {
+            width: dimensions.width,
+            height: dimensions.height,
+        }),
+        capture_date_time: metadata.capture_date_time.map(|date| CaptureDateTime {
+            date_time: date.date_time,
+            offset_time: date.offset_time,
+            timestamp_micros: date.timestamp_micros,
+        }),
+        location: metadata.location.map(|location| LocationCoordinate {
+            latitude: location.latitude,
+            longitude: location.longitude,
+        }),
+    })
+}

--- a/rust/bindings/frb/photos/src/api/metadata_api.rs
+++ b/rust/bindings/frb/photos/src/api/metadata_api.rs
@@ -5,6 +5,8 @@ pub struct PhotoMetadata {
     pub dimensions: Option<Dimensions>,
     pub capture_date_time: Option<CaptureDateTime>,
     pub location: Option<LocationCoordinate>,
+    pub motion_video_start: Option<u64>,
+    pub is_panorama: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -24,6 +26,8 @@ pub fn read_photo_metadata(file_path: String) -> Result<PhotoMetadata, String> {
     let metadata =
         ente_photos::metadata::read_photo_metadata(file_path).map_err(|error| error.to_string())?;
     Ok(PhotoMetadata {
+        motion_video_start: metadata.motion_video.map(|video| video.start),
+        is_panorama: metadata.is_panorama,
         dimensions: metadata.dimensions.map(|dimensions| Dimensions {
             width: dimensions.width,
             height: dimensions.height,

--- a/rust/bindings/frb/photos/src/api/mod.rs
+++ b/rust/bindings/frb/photos/src/api/mod.rs
@@ -5,6 +5,7 @@ pub mod location_api;
 #[cfg(any(feature = "flutter", frb_expand))]
 pub mod log;
 pub mod map_cluster_api;
+pub mod metadata_api;
 pub mod ml_db_api;
 pub mod ml_indexing_api;
 pub mod motion_photo_api;

--- a/rust/crates/exif/src/photo.rs
+++ b/rust/crates/exif/src/photo.rs
@@ -8,6 +8,7 @@ pub struct CaptureDateTime {
     pub date_time: String,
     pub offset_time: Option<String>,
     pub timestamp_micros: Option<i64>,
+    pub precision: DateTimePrecision,
     pub source: DateTimeSource,
 }
 pub fn capture_date_time(metadata: &Metadata) -> Option<CaptureDateTime> {
@@ -64,6 +65,7 @@ pub fn capture_date_time_with(
                 )
             }),
             timestamp_micros: absolute.unix_micros(),
+            precision: value.precision,
             source,
         };
         accept(&mut result).then_some(result)

--- a/rust/crates/exif/tests/integration/capture.rs
+++ b/rust/crates/exif/tests/integration/capture.rs
@@ -239,15 +239,32 @@ fn host_policy_can_resolve_local_time_and_reject_candidates_before_fallback() {
 
 #[test]
 fn reduced_xmp_dates_use_period_start_without_inventing_an_embedded_offset() {
-    for (value, expected, timestamp) in [
-        ("1971", "1971-01-01T00:00:00", Some(31_536_000_000_000)),
-        ("1970-02", "1970-02-01T00:00:00", Some(2_678_400_000_000)),
-        ("1970-01-02", "1970-01-02T00:00:00", Some(86_400_000_000)),
-        ("1970-01-02T00:15", "1970-01-02T00:15:00", None),
+    use DateTimePrecision::{Day, Minute, Month, Year};
+    for (value, expected, timestamp, precision) in [
+        (
+            "1971",
+            "1971-01-01T00:00:00",
+            Some(31_536_000_000_000),
+            Year,
+        ),
+        (
+            "1970-02",
+            "1970-02-01T00:00:00",
+            Some(2_678_400_000_000),
+            Month,
+        ),
+        (
+            "1970-01-02",
+            "1970-01-02T00:00:00",
+            Some(86_400_000_000),
+            Day,
+        ),
+        ("1970-01-02T00:15", "1970-01-02T00:15:00", None, Minute),
         (
             "1970-01-02T00:15+00:30",
             "1970-01-02T00:15:00",
             Some(85_500_000_000),
+            Minute,
         ),
     ] {
         assert_eq!(DateTime::parse(value), None);
@@ -260,6 +277,7 @@ fn reduced_xmp_dates_use_period_start_without_inventing_an_embedded_offset() {
             .unwrap();
             assert_eq!(capture.date_time, expected);
             assert_eq!(capture.timestamp_micros, timestamp);
+            assert_eq!(capture.precision, precision);
             if value.len() <= 10 {
                 assert_eq!(capture.offset_time, None);
             }
@@ -308,6 +326,14 @@ fn generated_iptc_dates_pair_only_their_own_time_dataset() {
             let metadata = read(&iptc_tiff(&fields), mode);
             let capture = metadata.capture_date_time().unwrap();
             assert_eq!(capture.source, DateTimeSource::Iptc(55, 60));
+            assert_eq!(
+                capture.precision,
+                if time.is_some() {
+                    DateTimePrecision::Second
+                } else {
+                    DateTimePrecision::Day
+                }
+            );
             assert_eq!(capture.offset_time.as_deref(), offset);
             assert_eq!(capture.timestamp_micros, timestamp);
         }

--- a/rust/crates/photos/Cargo.toml
+++ b/rust/crates/photos/Cargo.toml
@@ -4,6 +4,7 @@ edition.workspace = true
 
 [dependencies]
 ente-assets.workspace = true
+ente-exif.workspace = true
 ente-location.workspace = true
 quick-xml.workspace = true
 rusqlite = { workspace = true, default-features = true }

--- a/rust/crates/photos/src/lib.rs
+++ b/rust/crates/photos/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod db;
 pub mod location;
+pub mod metadata;
 pub mod ml_db;
 pub mod motion_photo;
 

--- a/rust/crates/photos/src/metadata.rs
+++ b/rust/crates/photos/src/metadata.rs
@@ -22,6 +22,7 @@ pub fn read_photo_metadata(path: impl AsRef<Path>) -> Result<PhotoMetadata, Erro
         capture_date_time: metadata.capture_date_time_with(|date| {
             date.precision == DateTimePrecision::Second
                 && date.timestamp_micros != Some(0)
+                && !(date.offset_time.is_none() && date.date_time == "1970-01-01T00:00:00")
                 && date.date_time != "4501-01-01T00:00:00"
         }),
         location: metadata.exif_location().or_else(|| metadata.xmp_location()),

--- a/rust/crates/photos/src/metadata.rs
+++ b/rust/crates/photos/src/metadata.rs
@@ -1,0 +1,19 @@
+use std::{fs::File, path::Path};
+
+use ente_exif::{CaptureDateTime, Dimensions, Error, Limits, Location, Mode};
+
+#[derive(Debug)]
+pub struct PhotoMetadata {
+    pub dimensions: Option<Dimensions>,
+    pub capture_date_time: Option<CaptureDateTime>,
+    pub location: Option<Location>,
+}
+
+pub fn read_photo_metadata(path: impl AsRef<Path>) -> Result<PhotoMetadata, Error> {
+    let metadata = ente_exif::read(&mut File::open(path)?, Mode::Summary, Limits::default())?;
+    Ok(PhotoMetadata {
+        dimensions: metadata.display_dimensions(),
+        capture_date_time: metadata.capture_date_time(),
+        location: metadata.exif_location().or_else(|| metadata.xmp_location()),
+    })
+}

--- a/rust/crates/photos/src/metadata.rs
+++ b/rust/crates/photos/src/metadata.rs
@@ -1,18 +1,24 @@
 use std::{fs::File, path::Path};
 
-use ente_exif::{CaptureDateTime, DateTimePrecision, Dimensions, Error, Limits, Location, Mode};
+use ente_exif::{
+    CaptureDateTime, DateTimePrecision, Dimensions, Error, Limits, Location, Mode, VideoRange,
+};
 
 #[derive(Debug)]
 pub struct PhotoMetadata {
     pub dimensions: Option<Dimensions>,
     pub capture_date_time: Option<CaptureDateTime>,
     pub location: Option<Location>,
+    pub motion_video: Option<VideoRange>,
+    pub is_panorama: bool,
 }
 
 pub fn read_photo_metadata(path: impl AsRef<Path>) -> Result<PhotoMetadata, Error> {
     let metadata = ente_exif::read(&mut File::open(path)?, Mode::Summary, Limits::default())?;
     Ok(PhotoMetadata {
         dimensions: metadata.display_dimensions(),
+        motion_video: metadata.motion_video,
+        is_panorama: metadata.is_panorama(),
         capture_date_time: metadata.capture_date_time_with(|date| {
             date.precision == DateTimePrecision::Second
                 && date.timestamp_micros != Some(0)

--- a/rust/crates/photos/src/metadata.rs
+++ b/rust/crates/photos/src/metadata.rs
@@ -25,6 +25,9 @@ pub fn read_photo_metadata(path: impl AsRef<Path>) -> Result<PhotoMetadata, Erro
                 && !(date.offset_time.is_none() && date.date_time == "1970-01-01T00:00:00")
                 && date.date_time != "4501-01-01T00:00:00"
         }),
-        location: metadata.exif_location().or_else(|| metadata.xmp_location()),
+        location: metadata
+            .exif_location()
+            .filter(|location| location.latitude != 0.0 || location.longitude != 0.0)
+            .or_else(|| metadata.xmp_location()),
     })
 }

--- a/rust/crates/photos/src/metadata.rs
+++ b/rust/crates/photos/src/metadata.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, path::Path};
 
-use ente_exif::{CaptureDateTime, Dimensions, Error, Limits, Location, Mode};
+use ente_exif::{CaptureDateTime, DateTimePrecision, Dimensions, Error, Limits, Location, Mode};
 
 #[derive(Debug)]
 pub struct PhotoMetadata {
@@ -13,7 +13,11 @@ pub fn read_photo_metadata(path: impl AsRef<Path>) -> Result<PhotoMetadata, Erro
     let metadata = ente_exif::read(&mut File::open(path)?, Mode::Summary, Limits::default())?;
     Ok(PhotoMetadata {
         dimensions: metadata.display_dimensions(),
-        capture_date_time: metadata.capture_date_time(),
+        capture_date_time: metadata.capture_date_time_with(|date| {
+            date.precision == DateTimePrecision::Second
+                && date.timestamp_micros != Some(0)
+                && date.date_time != "4501-01-01T00:00:00"
+        }),
         location: metadata.exif_location().or_else(|| metadata.xmp_location()),
     })
 }

--- a/rust/crates/photos/tests/metadata_test.rs
+++ b/rust/crates/photos/tests/metadata_test.rs
@@ -1,0 +1,41 @@
+use std::io::Write;
+
+use ente_exif::{Dimensions, Location};
+use ente_photos::metadata::read_photo_metadata;
+
+#[test]
+fn reads_display_dimensions_capture_time_and_xmp_location() {
+    let properties = r#"tiff:Orientation="6" exif:DateTimeOriginal="2024-01-01T12:00:00.123456-00:30"
+        exif:GPSLatitude="40,30N" exif:GPSLongitude="74,15W""#;
+    let xmp = format!(
+        "http://ns.adobe.com/xap/1.0/\0<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"><rdf:Description xmlns:exif=\"http://ns.adobe.com/exif/1.0/\" xmlns:tiff=\"http://ns.adobe.com/tiff/1.0/\" {properties}/></rdf:RDF>"
+    );
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(&[0xff, 0xd8, 0xff, 0xe1]).unwrap();
+    file.write_all(&u16::try_from(xmp.len() + 2).unwrap().to_be_bytes())
+        .unwrap();
+    file.write_all(xmp.as_bytes()).unwrap();
+    file.write_all(&[
+        0xff, 0xc0, 0, 11, 8, 0, 48, 0, 64, 1, 1, 0x11, 0, 0xff, 0xd9,
+    ])
+    .unwrap();
+    let metadata = read_photo_metadata(file.path()).unwrap();
+    assert_eq!(
+        metadata.dimensions,
+        Some(Dimensions {
+            width: 48,
+            height: 64
+        })
+    );
+    let date = metadata.capture_date_time.unwrap();
+    assert_eq!(date.date_time, "2024-01-01T12:00:00.123456000");
+    assert_eq!(date.offset_time.as_deref(), Some("-00:30"));
+    assert_eq!(date.timestamp_micros, Some(1_704_112_200_123_456));
+    assert_eq!(
+        metadata.location,
+        Some(Location {
+            latitude: 40.5,
+            longitude: -74.25
+        })
+    );
+}

--- a/rust/crates/photos/tests/metadata_test.rs
+++ b/rust/crates/photos/tests/metadata_test.rs
@@ -36,6 +36,8 @@ fn skips_partial_and_sentinel_capture_dates_and_continues_to_fallbacks() {
         ("2004-06-15", true),
         ("2004-06-15T12:30Z", true),
         ("1970-01-01T00:00:00Z", true),
+        ("1970-01-01T00:00:00", true),
+        ("1970-01-01T00:00:01", false),
         ("1970-01-01T05:30:00+05:30", true),
         ("4501-01-01T00:00:00.000Z", true),
         ("4501-01-01T00:00:00+05:30", true),

--- a/rust/crates/photos/tests/metadata_test.rs
+++ b/rust/crates/photos/tests/metadata_test.rs
@@ -3,11 +3,13 @@ use std::io::Write;
 use ente_exif::{DateTimeSource, Dimensions, Location, namespace};
 use ente_photos::metadata::{PhotoMetadata, read_photo_metadata};
 
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
 #[test]
-fn reads_display_dimensions_capture_time_and_xmp_location() {
+fn reads_display_dimensions_capture_time_and_xmp_location() -> TestResult {
     let properties = r#"tiff:Orientation="6" exif:DateTimeOriginal="2024-01-01T12:00:00.123456-00:30"
         exif:GPSLatitude="40,30N" exif:GPSLongitude="74,15W""#;
-    let metadata = read(properties);
+    let metadata = read(properties)?;
     assert_eq!(
         metadata.dimensions,
         Some(Dimensions {
@@ -15,10 +17,18 @@ fn reads_display_dimensions_capture_time_and_xmp_location() {
             height: 64
         })
     );
-    let date = metadata.capture_date_time.unwrap();
-    assert_eq!(date.date_time, "2024-01-01T12:00:00.123456000");
-    assert_eq!(date.offset_time.as_deref(), Some("-00:30"));
-    assert_eq!(date.timestamp_micros, Some(1_704_112_200_123_456));
+    assert_eq!(
+        metadata.capture_date_time.as_ref().map(|date| (
+            date.date_time.as_str(),
+            date.offset_time.as_deref(),
+            date.timestamp_micros,
+        )),
+        Some((
+            "2024-01-01T12:00:00.123456000",
+            Some("-00:30"),
+            Some(1_704_112_200_123_456),
+        ))
+    );
     assert_eq!(
         metadata.location,
         Some(Location {
@@ -26,10 +36,11 @@ fn reads_display_dimensions_capture_time_and_xmp_location() {
             longitude: -74.25
         })
     );
+    Ok(())
 }
 
 #[test]
-fn skips_partial_and_sentinel_capture_dates_and_continues_to_fallbacks() {
+fn skips_partial_and_sentinel_capture_dates_and_continues_to_fallbacks() -> TestResult {
     for (original, rejected) in [
         ("2004", true),
         ("2004-06", true),
@@ -49,35 +60,36 @@ fn skips_partial_and_sentinel_capture_dates_and_continues_to_fallbacks() {
     ] {
         let metadata = read(&format!(
             r#"exif:DateTimeOriginal="{original}" xmp:CreateDate="2024-01-02T12:00:00Z""#
-        ));
+        ))?;
         let expected = if rejected {
             DateTimeSource::Xmp(namespace::XMP, "CreateDate")
         } else {
             DateTimeSource::Xmp(namespace::EXIF, "DateTimeOriginal")
         };
         assert_eq!(
-            metadata.capture_date_time.unwrap().source,
-            expected,
+            metadata.capture_date_time.as_ref().map(|d| d.source),
+            Some(expected),
             "{original}"
         );
     }
     assert!(
-        read(r#"exif:DateTimeOriginal="2004" xmp:CreateDate="2004-06-15""#)
+        read(r#"exif:DateTimeOriginal="2004" xmp:CreateDate="2004-06-15""#)?
             .capture_date_time
             .is_none()
     );
     assert!(
         read(
             r#"exif:DateTimeOriginal="4501-01-01T00:00:00Z" xmp:CreateDate="1970-01-01T00:00:00Z""#
-        )
+        )?
         .capture_date_time
         .is_none()
     );
+    Ok(())
 }
 
 #[test]
-fn reads_panorama_and_motion_video() {
-    let plain = read("");
+fn reads_panorama_and_motion_video() -> TestResult {
+    let plain = read("")?;
     assert!(!plain.is_panorama);
     assert_eq!(plain.motion_video, None);
     let video = b"\0\0\0\x10ftypisom\0\0\0\0\0\0\0\x08moov\0\0\0\x08mdat";
@@ -87,30 +99,31 @@ fn reads_panorama_and_motion_video() {
             xmlns:GCamera="http://ns.google.com/photos/1.0/camera/"
             GCamera:MicroVideoOffset="32""#,
         video,
-    );
+    )?;
     assert!(metadata.is_panorama);
-    let range = metadata.motion_video.unwrap();
-    assert!(range.start > 0);
-    assert_eq!(range.end - range.start, video.len() as u64);
+    assert!(
+        metadata.motion_video.as_ref().is_some_and(|range| {
+            range.start > 0 && range.end - range.start == video.len() as u64
+        })
+    );
+    Ok(())
 }
 
-fn read(properties: &str) -> PhotoMetadata {
+fn read(properties: &str) -> TestResult<PhotoMetadata> {
     read_with_tail(properties, &[])
 }
 
-fn read_with_tail(properties: &str, tail: &[u8]) -> PhotoMetadata {
+fn read_with_tail(properties: &str, tail: &[u8]) -> TestResult<PhotoMetadata> {
     let xmp = format!(
         "http://ns.adobe.com/xap/1.0/\0<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"><rdf:Description xmlns:exif=\"http://ns.adobe.com/exif/1.0/\" xmlns:tiff=\"http://ns.adobe.com/tiff/1.0/\" xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\" {properties}/></rdf:RDF>"
     );
-    let mut file = tempfile::NamedTempFile::new().unwrap();
-    file.write_all(&[0xff, 0xd8, 0xff, 0xe1]).unwrap();
-    file.write_all(&u16::try_from(xmp.len() + 2).unwrap().to_be_bytes())
-        .unwrap();
-    file.write_all(xmp.as_bytes()).unwrap();
+    let mut file = tempfile::NamedTempFile::new()?;
+    file.write_all(&[0xff, 0xd8, 0xff, 0xe1])?;
+    file.write_all(&u16::try_from(xmp.len() + 2)?.to_be_bytes())?;
+    file.write_all(xmp.as_bytes())?;
     file.write_all(&[
         0xff, 0xc0, 0, 11, 8, 0, 48, 0, 64, 1, 1, 0x11, 0, 0xff, 0xd9,
-    ])
-    .unwrap();
-    file.write_all(tail).unwrap();
-    read_photo_metadata(file.path()).unwrap()
+    ])?;
+    file.write_all(tail)?;
+    Ok(read_photo_metadata(file.path())?)
 }

--- a/rust/crates/photos/tests/metadata_test.rs
+++ b/rust/crates/photos/tests/metadata_test.rs
@@ -73,7 +73,30 @@ fn skips_partial_and_sentinel_capture_dates_and_continues_to_fallbacks() {
     );
 }
 
+#[test]
+fn reads_panorama_and_motion_video() {
+    let plain = read("");
+    assert!(!plain.is_panorama);
+    assert_eq!(plain.motion_video, None);
+    let video = b"\0\0\0\x10ftypisom\0\0\0\0\0\0\0\x08moov\0\0\0\x08mdat";
+    let metadata = read_with_tail(
+        r#"xmlns:GPano="http://ns.google.com/photos/1.0/panorama/"
+            GPano:ProjectionType="equirectangular"
+            xmlns:GCamera="http://ns.google.com/photos/1.0/camera/"
+            GCamera:MicroVideoOffset="32""#,
+        video,
+    );
+    assert!(metadata.is_panorama);
+    let range = metadata.motion_video.unwrap();
+    assert!(range.start > 0);
+    assert_eq!(range.end - range.start, video.len() as u64);
+}
+
 fn read(properties: &str) -> PhotoMetadata {
+    read_with_tail(properties, &[])
+}
+
+fn read_with_tail(properties: &str, tail: &[u8]) -> PhotoMetadata {
     let xmp = format!(
         "http://ns.adobe.com/xap/1.0/\0<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"><rdf:Description xmlns:exif=\"http://ns.adobe.com/exif/1.0/\" xmlns:tiff=\"http://ns.adobe.com/tiff/1.0/\" xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\" {properties}/></rdf:RDF>"
     );
@@ -86,5 +109,6 @@ fn read(properties: &str) -> PhotoMetadata {
         0xff, 0xc0, 0, 11, 8, 0, 48, 0, 64, 1, 1, 0x11, 0, 0xff, 0xd9,
     ])
     .unwrap();
+    file.write_all(tail).unwrap();
     read_photo_metadata(file.path()).unwrap()
 }

--- a/rust/crates/photos/tests/metadata_test.rs
+++ b/rust/crates/photos/tests/metadata_test.rs
@@ -1,25 +1,13 @@
 use std::io::Write;
 
-use ente_exif::{Dimensions, Location};
-use ente_photos::metadata::read_photo_metadata;
+use ente_exif::{DateTimeSource, Dimensions, Location, namespace};
+use ente_photos::metadata::{PhotoMetadata, read_photo_metadata};
 
 #[test]
 fn reads_display_dimensions_capture_time_and_xmp_location() {
     let properties = r#"tiff:Orientation="6" exif:DateTimeOriginal="2024-01-01T12:00:00.123456-00:30"
         exif:GPSLatitude="40,30N" exif:GPSLongitude="74,15W""#;
-    let xmp = format!(
-        "http://ns.adobe.com/xap/1.0/\0<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"><rdf:Description xmlns:exif=\"http://ns.adobe.com/exif/1.0/\" xmlns:tiff=\"http://ns.adobe.com/tiff/1.0/\" {properties}/></rdf:RDF>"
-    );
-    let mut file = tempfile::NamedTempFile::new().unwrap();
-    file.write_all(&[0xff, 0xd8, 0xff, 0xe1]).unwrap();
-    file.write_all(&u16::try_from(xmp.len() + 2).unwrap().to_be_bytes())
-        .unwrap();
-    file.write_all(xmp.as_bytes()).unwrap();
-    file.write_all(&[
-        0xff, 0xc0, 0, 11, 8, 0, 48, 0, 64, 1, 1, 0x11, 0, 0xff, 0xd9,
-    ])
-    .unwrap();
-    let metadata = read_photo_metadata(file.path()).unwrap();
+    let metadata = read(properties);
     assert_eq!(
         metadata.dimensions,
         Some(Dimensions {
@@ -38,4 +26,65 @@ fn reads_display_dimensions_capture_time_and_xmp_location() {
             longitude: -74.25
         })
     );
+}
+
+#[test]
+fn skips_partial_and_sentinel_capture_dates_and_continues_to_fallbacks() {
+    for (original, rejected) in [
+        ("2004", true),
+        ("2004-06", true),
+        ("2004-06-15", true),
+        ("2004-06-15T12:30Z", true),
+        ("1970-01-01T00:00:00Z", true),
+        ("1970-01-01T05:30:00+05:30", true),
+        ("4501-01-01T00:00:00.000Z", true),
+        ("4501-01-01T00:00:00+05:30", true),
+        ("1970-01-01T00:00:00+05:30", false),
+        ("1969-12-31T23:59:59Z", false),
+        ("2024-01-01T12:00:00", false),
+        ("2024-01-01T00:00:00Z", false),
+        ("4501-01-02T00:00:00Z", false),
+    ] {
+        let metadata = read(&format!(
+            r#"exif:DateTimeOriginal="{original}" xmp:CreateDate="2024-01-02T12:00:00Z""#
+        ));
+        let expected = if rejected {
+            DateTimeSource::Xmp(namespace::XMP, "CreateDate")
+        } else {
+            DateTimeSource::Xmp(namespace::EXIF, "DateTimeOriginal")
+        };
+        assert_eq!(
+            metadata.capture_date_time.unwrap().source,
+            expected,
+            "{original}"
+        );
+    }
+    assert!(
+        read(r#"exif:DateTimeOriginal="2004" xmp:CreateDate="2004-06-15""#)
+            .capture_date_time
+            .is_none()
+    );
+    assert!(
+        read(
+            r#"exif:DateTimeOriginal="4501-01-01T00:00:00Z" xmp:CreateDate="1970-01-01T00:00:00Z""#
+        )
+        .capture_date_time
+        .is_none()
+    );
+}
+
+fn read(properties: &str) -> PhotoMetadata {
+    let xmp = format!(
+        "http://ns.adobe.com/xap/1.0/\0<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"><rdf:Description xmlns:exif=\"http://ns.adobe.com/exif/1.0/\" xmlns:tiff=\"http://ns.adobe.com/tiff/1.0/\" xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\" {properties}/></rdf:RDF>"
+    );
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(&[0xff, 0xd8, 0xff, 0xe1]).unwrap();
+    file.write_all(&u16::try_from(xmp.len() + 2).unwrap().to_be_bytes())
+        .unwrap();
+    file.write_all(xmp.as_bytes()).unwrap();
+    file.write_all(&[
+        0xff, 0xc0, 0, 11, 8, 0, 48, 0, 64, 1, 1, 0x11, 0, 0xff, 0xd9,
+    ])
+    .unwrap();
+    read_photo_metadata(file.path()).unwrap()
 }


### PR DESCRIPTION
Use Rust metadata for Android local-gallery processing: display dimensions for mosaic layout, capture time with existing fallbacks, location, and motion-photo/panorama detection. Reject partial and sentinel capture dates.

Persist results in existing local metadata fields, reprocess previously scanned files, and invalidate cached detections after edits. Motion-video extraction remains on demand.
