### PR TITLE
[photos] Add Android ADB log export for internal users

### DIFF
--- a/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/AdbDiagnostics.kt
+++ b/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/AdbDiagnostics.kt
@@ -1,0 +1,76 @@
+package io.ente.photos
+
+import android.app.KeyguardManager
+import android.content.Context
+import java.io.File
+import java.io.IOException
+import java.io.PrintWriter
+import java.io.RandomAccessFile
+import org.json.JSONObject
+
+internal object AdbDiagnostics {
+    fun dumpLogs(context: Context, writer: PrintWriter) {
+        if (!canReadLogs(context, writer)) return
+        try {
+            val directory = File(context.filesDir, "logs").canonicalFile
+            val files = directory.listFiles()
+            if (files == null) {
+                writer.println("Ente log directory is unavailable.")
+                return
+            }
+            var remaining = 40 * 1024 * 1024
+            for (file in
+                files
+                    .filter {
+                        it.isFile &&
+                            it.extension == "log" &&
+                            it.canonicalFile.parentFile == directory
+                    }
+                    .sortedByDescending { it.lastModified() }) {
+                if (remaining == 0) {
+                    writer.println("[Older logs omitted: 40 MiB limit reached]")
+                    break
+                }
+                RandomAccessFile(file, "r").use { input ->
+                    val size = input.length()
+                    val start = maxOf(0, size - remaining)
+                    val bytes = ByteArray((size - start).toInt())
+                    input.seek(start)
+                    input.readFully(bytes)
+                    if (!canReadLogs(context, writer)) return
+                    writer.println("=== ${file.name} ===")
+                    if (start > 0) writer.println("[First $start bytes omitted]")
+                    writer.println(bytes.toString(Charsets.UTF_8))
+                    remaining -= bytes.size
+                }
+            }
+            writer.println("=== End of Ente logs ===")
+        } catch (error: IOException) {
+            writer.println("Could not read Ente logs: ${error.message}")
+        }
+    }
+
+    private fun canReadLogs(context: Context, writer: PrintWriter): Boolean {
+        val prefs =
+            context.getSharedPreferences(
+                EnteApplication.FLUTTER_SHARED_PREFERENCES,
+                Context.MODE_PRIVATE,
+            )
+        val internalUser = runCatching {
+            !prefs.getBoolean(EnteApplication.INTERNAL_USER_DISABLED_KEY, false) &&
+                JSONObject(prefs.getString(EnteApplication.REMOTE_FLAGS_KEY, null) ?: "{}")
+                    .opt("internalUser") == true
+        }
+            .getOrDefault(false)
+        if (!internalUser) {
+            writer.println("Ente logs are only available to internal users.")
+            return false
+        }
+        val keyguard = context.getSystemService(KeyguardManager::class.java)
+        if (keyguard == null || keyguard.isDeviceLocked || keyguard.isKeyguardLocked) {
+            writer.println("Unlock the device to read Ente logs.")
+            return false
+        }
+        return true
+    }
+}

--- a/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/MainActivity.kt
+++ b/mobile/apps/photos/android/app/src/main/kotlin/io/ente/photos/MainActivity.kt
@@ -2,10 +2,25 @@ package io.ente.photos
 
 import android.content.Intent
 import io.flutter.embedding.android.FlutterFragmentActivity
+import java.io.FileDescriptor
+import java.io.PrintWriter
 
 class MainActivity : FlutterFragmentActivity() {
     override fun onNewIntent(intent: Intent) {
         setIntent(intent)
         super.onNewIntent(intent)
+    }
+
+    override fun dump(
+        prefix: String,
+        fd: FileDescriptor?,
+        writer: PrintWriter,
+        args: Array<out String>?,
+    ) {
+        if (args?.singleOrNull() == "--ente-logs") {
+            AdbDiagnostics.dumpLogs(this, writer)
+        } else {
+            super.dump(prefix, fd, writer, args)
+        }
     }
 }

--- a/mobile/apps/photos/docs/android-cli.md
+++ b/mobile/apps/photos/docs/android-cli.md
@@ -26,3 +26,13 @@ flutter run --flavor independent -d sdk
 ```
 
 The above is macOS-specific, but swap `brew` for your package manager (unless `brew` is your package manager) and skip the JDK symlink step and it should work on Linux too.
+
+## App logs
+
+With ADB authorized, open the app with `internalUser` enabled and unlock the device. Export up to 40 MiB of saved logs, newest files first:
+
+```sh
+adb shell dumpsys activity io.ente.photos/io.ente.photos.MainActivity --ente-logs > ente-logs.txt
+```
+
+For independent builds, change the package before `/` to `io.ente.photos.independent`. For Android logs, use `adb logcat -d`.


### PR DESCRIPTION
## Description

Allow internal users to retrieve Ente Photos' saved Android logs through ADB, including in non-debuggable release builds. Install a build containing this change and open Ente, then run:

```sh
adb shell dumpsys activity io.ente.photos/.MainActivity --ente-logs
```

When you run the command:

1. **MainActivity receives the request** and forwards `--ente-logs` to AdbDiagnostics.
2. **It checks the account is an internal user.** Missing or invalid flags, `internalUser: false`, or “Disable internal user features” cause it to refuse.
3. **It checks the phone is unlocked.** Otherwise, it prints an instruction to unlock and stops.
4. **It finds Ente's saved `.log` files**, rejecting files that resolve outside the private log directory.
5. **It reads the newest files first**, up to 40 MiB total. If necessary, it reads only the end of a file and reports what was omitted.
6. **Before printing each file, it rechecks internal-user eligibility and phone unlock**, then sends the filename and log text back to the terminal.

Missing directories and read failures produce an error message. Access uses the cached account flag and Android diagnostic permissions; Ente's separate app lock is not checked.

## Tests

Validated the native helper in a non-debuggable Android emulator probe: internal users allowed; missing, malformed, non-internal, or disabled flags and locked devices denied. Full Ente release installation remains unverified.
