### PR TITLE
[mob][photos] Add Flex justified layout option

### DIFF
--- a/mobile/apps/photos/lib/models/gallery/flex_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/flex_layout.dart
@@ -4,12 +4,12 @@ import "dart:typed_data";
 
 import "package:photos/models/gallery/justified_layout.dart";
 
-/// Experimental whole-group row breaking inspired by Google Photos' FlexLayout:
-/// https://medium.com/google-design/google-photos-45b714dfbed1
-///
-/// Each possible row is an edge between two file indices. A backward dynamic
-/// programming pass chooses the least expensive path through the entire group.
-/// Density is a sizing preference rather than Comfort's hard 3/4/5 item cap.
+// Experimental whole-group row breaking inspired by Google Photos' FlexLayout:
+// https://medium.com/google-design/google-photos-45b714dfbed1
+//
+// Each possible row is an edge between two file indices. A backward dynamic
+// programming pass chooses the least expensive path through the entire group.
+// Density is a sizing preference rather than Comfort's hard 3/4/5 item cap.
 class FlexLayoutCalculator {
   static const double _minimumTappableExtent = 48;
   static const double _maximumRowHeightFactor = 1.6;

--- a/mobile/apps/photos/lib/models/gallery/flex_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/flex_layout.dart
@@ -1,0 +1,161 @@
+import "dart:collection";
+import "dart:math" as math;
+import "dart:typed_data";
+
+import "package:photos/models/gallery/justified_layout.dart";
+
+/// Experimental whole-group row breaking inspired by Google Photos' FlexLayout:
+/// https://medium.com/google-design/google-photos-45b714dfbed1
+///
+/// Each possible row is an edge between two file indices. A backward dynamic
+/// programming pass chooses the least expensive path through the entire group.
+/// Density is a sizing preference rather than Comfort's hard 3/4/5 item cap.
+class FlexLayoutCalculator {
+  static const double _minimumTappableExtent = 48;
+  static const double _maximumRowHeightFactor = 1.6;
+  static const double _preferredTileWidthFactor = 0.6;
+
+  const FlexLayoutCalculator._();
+
+  static List<JustifiedRowLayout> computeRows({
+    required Iterable<double> aspectRatios,
+    required double availableWidth,
+    required double targetRowHeight,
+    required double spacing,
+  }) {
+    if (!availableWidth.isFinite || availableWidth <= 0) {
+      throw ArgumentError.value(availableWidth, "availableWidth");
+    }
+    if (!targetRowHeight.isFinite || targetRowHeight <= 0) {
+      throw ArgumentError.value(targetRowHeight, "targetRowHeight");
+    }
+    if (!spacing.isFinite || spacing < 0) {
+      throw ArgumentError.value(spacing, "spacing");
+    }
+
+    final ratios = Float64List.fromList(aspectRatios.toList(growable: false));
+    if (ratios.isEmpty) return const [];
+    for (var i = 0; i < ratios.length; i++) {
+      final ratio = ratios[i];
+      ratios[i] = ratio.isFinite && ratio > 0
+          ? ratio.clamp(1 / 3, 4).toDouble()
+          : 1;
+    }
+
+    final count = ratios.length;
+    final costs = Float64List(count + 1)..fillRange(0, count, double.infinity);
+    final nextBreak = Uint32List(count);
+    final maximumHeight = targetRowHeight * _maximumRowHeightFactor;
+    final preferredTileWidth = targetRowHeight * _preferredTileWidthFactor;
+
+    double rowHeight(double fittedHeight, double minimumRatio, bool isTail) {
+      if (!isTail && fittedHeight <= maximumHeight) return fittedHeight;
+      // Sparse tails and unavoidable standalone portraits can leave a gap.
+      // Accessibility takes precedence when a narrow portrait needs more height.
+      return math.min(
+        fittedHeight,
+        math.max(
+          targetRowHeight,
+          math.max(
+            _minimumTappableExtent,
+            _minimumTappableExtent / minimumRatio,
+          ),
+        ),
+      );
+    }
+
+    for (var start = count - 1; start >= 0; start--) {
+      var ratioSum = 0.0;
+      var minimumRatio = double.infinity;
+      for (var end = start; end < count; end++) {
+        ratioSum += ratios[end];
+        minimumRatio = math.min(minimumRatio, ratios[end]);
+        final itemCount = end - start + 1;
+        final contentWidth = availableWidth - spacing * (itemCount - 1);
+        if (contentWidth <= 0) break;
+        final fittedHeight = contentWidth / ratioSum;
+        // Adding more items only makes these extents smaller. This bounds the
+        // search by the viewport's tap capacity, not the number of files.
+        if (itemCount > 1 &&
+            (fittedHeight < _minimumTappableExtent ||
+                fittedHeight * minimumRatio < _minimumTappableExtent)) {
+          break;
+        }
+        final isTail = end == count - 1;
+        if (!isTail && itemCount > 1 && fittedHeight > maximumHeight) continue;
+
+        final height = rowHeight(fittedHeight, minimumRatio, isTail);
+        final heightDeviation = math.log(height / targetRowHeight);
+        final narrowness = math.max(
+          0.0,
+          preferredTileWidth / (height * minimumRatio) - 1,
+        );
+        final unusedWidthFraction = math.max(
+          0.0,
+          1 - height * ratioSum / contentWidth,
+        );
+        // Logarithmic error treats stretching and shrinking symmetrically.
+        // Weight by file count so adding more rows cannot dilute the cost.
+        // A small break cost avoids fragmenting ordinary photos into many
+        // standalone rows. Panoramas can still stand alone without this bias.
+        final singletonPenalty = itemCount == 1 && count > 1
+            ? isTail
+                  ? 0.15
+                  : ratios[start] < 2
+                  ? 0.2
+                  : 0.0
+            : 0.0;
+        final rowCost =
+            itemCount *
+                (heightDeviation * heightDeviation +
+                    2 * narrowness * narrowness) +
+            unusedWidthFraction * unusedWidthFraction +
+            0.08 +
+            singletonPenalty;
+        final cost = rowCost + costs[end + 1];
+        if (cost < costs[start] - 1e-9) {
+          costs[start] = cost;
+          nextBreak[start] = end + 1;
+        }
+      }
+    }
+
+    final rows = <JustifiedRowLayout>[];
+    var offset = 0.0;
+    for (var start = 0; start < count;) {
+      final end = nextBreak[start];
+      var ratioSum = 0.0;
+      var minimumRatio = double.infinity;
+      for (var i = start; i < end; i++) {
+        ratioSum += ratios[i];
+        minimumRatio = math.min(minimumRatio, ratios[i]);
+      }
+      final contentWidth = availableWidth - spacing * (end - start - 1);
+      final fittedHeight = contentWidth / ratioSum;
+      final height = rowHeight(fittedHeight, minimumRatio, end == count);
+      final widths = List<double>.generate(
+        end - start,
+        (i) => ratios[start + i] * height,
+        growable: false,
+      );
+      if (height == fittedHeight) {
+        final precedingWidth = widths
+            .take(widths.length - 1)
+            .fold<double>(0, (a, b) => a + b);
+        widths[widths.length - 1] = math.max(0, contentWidth - precedingWidth);
+      }
+      rows.add(
+        JustifiedRowLayout(
+          firstIndex: start,
+          lastIndex: end - 1,
+          minOffset: offset,
+          height: height,
+          itemWidths: UnmodifiableListView(widths),
+        ),
+      );
+      offset += height + spacing;
+      start = end;
+    }
+    return UnmodifiableListView(rows);
+  }
+}

--- a/mobile/apps/photos/lib/models/gallery/flex_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/flex_layout.dart
@@ -4,12 +4,7 @@ import "dart:typed_data";
 
 import "package:photos/models/gallery/justified_layout.dart";
 
-// Experimental whole-group row breaking inspired by Google Photos' FlexLayout:
-// https://medium.com/google-design/google-photos-45b714dfbed1
-//
-// Each possible row is an edge between two file indices. A backward dynamic
-// programming pass chooses the least expensive path through the entire group.
-// Density is a sizing preference rather than Comfort's hard 3/4/5 item cap.
+// Selects the minimum-cost sequence from candidate row breaks across the group.
 class FlexLayoutCalculator {
   static const double _minimumTappableExtent = 48;
   static const double _maximumRowHeightFactor = 1.6;
@@ -50,8 +45,7 @@ class FlexLayoutCalculator {
 
     double rowHeight(double fittedHeight, double minimumRatio, bool isTail) {
       if (!isTail && fittedHeight <= maximumHeight) return fittedHeight;
-      // Sparse tails and unavoidable standalone portraits can leave a gap.
-      // Accessibility takes precedence when a narrow portrait needs more height.
+      // Allow sparse tails to leave unused width while preserving tap extents.
       return math.min(
         fittedHeight,
         math.max(
@@ -74,8 +68,8 @@ class FlexLayoutCalculator {
         final contentWidth = availableWidth - spacing * (itemCount - 1);
         if (contentWidth <= 0) break;
         final fittedHeight = contentWidth / ratioSum;
-        // Adding more items only makes these extents smaller. This bounds the
-        // search by the viewport's tap capacity, not the number of files.
+        // Adding items only shrinks these extents, so no later candidate can
+        // restore the minimum tap target.
         if (itemCount > 1 &&
             (fittedHeight < _minimumTappableExtent ||
                 fittedHeight * minimumRatio < _minimumTappableExtent)) {
@@ -94,10 +88,9 @@ class FlexLayoutCalculator {
           0.0,
           1 - height * ratioSum / contentWidth,
         );
-        // Logarithmic error treats stretching and shrinking symmetrically.
-        // Weight by file count so adding more rows cannot dilute the cost.
-        // A small break cost avoids fragmenting ordinary photos into many
-        // standalone rows. Panoramas can still stand alone without this bias.
+        // Log error treats shrinking and stretching symmetrically. Weighting by
+        // item count prevents extra rows from diluting the cost; the small
+        // per-row cost discourages fragmentation without excluding panoramas.
         final singletonPenalty = itemCount == 1 && count > 1
             ? isTail
                   ? 0.15

--- a/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
+++ b/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
@@ -9,9 +9,11 @@ import "package:photos/models/file/dummy_file.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/gallery/fixed_extent_grid_row.dart";
 import "package:photos/models/gallery/fixed_extent_section_layout.dart";
+import "package:photos/models/gallery/flex_layout.dart";
 import "package:photos/models/gallery/gallery_layout_config.dart";
 import "package:photos/models/gallery/justified_grid_row.dart";
 import "package:photos/models/gallery/justified_layout.dart";
+import "package:photos/models/gallery/justified_layout_strategy.dart";
 import "package:photos/models/gallery/section_layout.dart";
 import "package:photos/models/selected_files.dart";
 import "package:photos/service_locator.dart";
@@ -449,13 +451,17 @@ class GalleryGroups {
     final targetRowHeight = gridTargetRowHeight.isFinite
         ? math.min(gridTargetRowHeight, _maximumJustifiedTargetRowHeight)
         : gridTargetRowHeight;
+    final computeRows = switch (localSettings.getJustifiedLayoutStrategy()) {
+      JustifiedLayoutStrategy.comfort => JustifiedLayoutCalculator.computeRows,
+      JustifiedLayoutStrategy.flex => FlexLayoutCalculator.computeRows,
+    };
     final groupLayouts = <SectionLayout>[];
     var currentIndex = 0;
     var currentOffset = 0.0;
 
     for (final groupID in _groupIdToFilesMap.keys) {
       final filesInGroup = _groupIdToFilesMap[groupID]!;
-      final rows = JustifiedLayoutCalculator.computeRows(
+      final rows = computeRows(
         aspectRatios: filesInGroup.map(
           (file) => JustifiedLayoutCalculator.aspectRatioForDimensions(
             file.width,

--- a/mobile/apps/photos/lib/models/gallery/justified_layout_strategy.dart
+++ b/mobile/apps/photos/lib/models/gallery/justified_layout_strategy.dart
@@ -1,0 +1,1 @@
+enum JustifiedLayoutStrategy { comfort, flex }

--- a/mobile/apps/photos/lib/settings/local_settings.dart
+++ b/mobile/apps/photos/lib/settings/local_settings.dart
@@ -3,6 +3,7 @@ import "dart:io";
 import 'package:home_widget/home_widget.dart' as hw;
 import 'package:photos/app_mode.dart';
 import 'package:photos/core/constants.dart';
+import 'package:photos/models/gallery/justified_layout_strategy.dart';
 import 'package:photos/ui/viewer/gallery/component/group/type.dart';
 import "package:photos/utils/ram_check_util.dart";
 import 'package:shared_preferences/shared_preferences.dart';
@@ -57,6 +58,7 @@ class LocalSettings {
   static const kCollectionSortPref = "collection_sort_pref";
   static const kGalleryGroupType = "gallery_group_type";
   static const kGalleryLayoutType = "gallery_layout_type";
+  static const kJustifiedLayoutStrategy = "justified_layout_strategy";
   static const kPhotoGridSize = "photo_grid_size";
   static const _kisMLLocalIndexingEnabled = "ls.ml_local_indexing";
   static const _kLocalGalleryMLLocalIndexingEnabled =
@@ -277,6 +279,19 @@ class LocalSettings {
 
   Future<void> setGalleryLayoutType(GalleryLayoutType layoutType) async {
     await _prefs.setString(kGalleryLayoutType, layoutType.name);
+  }
+
+  JustifiedLayoutStrategy getJustifiedLayoutStrategy() {
+    return switch (_prefs.getString(kJustifiedLayoutStrategy)) {
+      "flex" => JustifiedLayoutStrategy.flex,
+      _ => JustifiedLayoutStrategy.comfort,
+    };
+  }
+
+  Future<void> setJustifiedLayoutStrategy(
+    JustifiedLayoutStrategy strategy,
+  ) async {
+    await _prefs.setString(kJustifiedLayoutStrategy, strategy.name);
   }
 
   int getPhotoGridSize() {

--- a/mobile/apps/photos/lib/ui/settings/gallery_settings_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/gallery_settings_screen.dart
@@ -6,9 +6,11 @@ import "package:photos/core/event_bus.dart";
 import "package:photos/events/gallery_layout_changed_event.dart";
 import "package:photos/events/hide_shared_items_from_home_gallery_event.dart";
 import "package:photos/models/gallery/gallery_layout_config.dart";
+import "package:photos/models/gallery/justified_layout_strategy.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/settings/local_settings.dart";
 import "package:photos/ui/viewer/gallery/component/group/type.dart";
+import "package:photos/ui/viewer/gallery/justified_layout_strategy_label.dart";
 
 class GallerySettingsScreen extends StatefulWidget {
   final bool fromGalleryLayoutSettingsCTA;
@@ -23,6 +25,7 @@ class GallerySettingsScreen extends StatefulWidget {
 
 class _GallerySettingsScreenState extends State<GallerySettingsScreen> {
   late GalleryLayoutType _layoutType;
+  late JustifiedLayoutStrategy _justifiedStrategy;
   late int _photoGridSize;
   late GroupType _groupType;
 
@@ -33,6 +36,7 @@ class _GallerySettingsScreenState extends State<GallerySettingsScreen> {
       localSettings.getGalleryLayoutType(),
     );
     _photoGridSize = localSettings.getPhotoGridSize();
+    _justifiedStrategy = localSettings.getJustifiedLayoutStrategy();
     _groupType = localSettings.getGalleryGroupType();
   }
 
@@ -48,7 +52,7 @@ class _GallerySettingsScreenState extends State<GallerySettingsScreen> {
             title: l10n.layout,
             trailing: _trailingLabel(
               context,
-              _layoutTypeLabel(context, _layoutType),
+              _layoutTypeLabel(context, _layoutType, _justifiedStrategy),
             ),
             onTap: () async => _showLayoutTypeSheet(context),
           ),
@@ -101,10 +105,14 @@ class _GallerySettingsScreenState extends State<GallerySettingsScreen> {
     );
   }
 
-  String _layoutTypeLabel(BuildContext context, GalleryLayoutType layoutType) {
+  String _layoutTypeLabel(
+    BuildContext context,
+    GalleryLayoutType layoutType,
+    JustifiedLayoutStrategy? strategy,
+  ) {
     return switch (layoutType) {
       GalleryLayoutType.grid => context.strings.grid,
-      GalleryLayoutType.justified => context.strings.layoutJustified,
+      GalleryLayoutType.justified => strategy!.label(context),
     };
   }
 
@@ -117,18 +125,24 @@ class _GallerySettingsScreenState extends State<GallerySettingsScreen> {
         title: l10n.layout,
         content: MenuGroupComponent(
           items: [
-            for (final layoutType in GalleryLayoutType.values)
+            for (final (layoutType, strategy) in [
+              (GalleryLayoutType.grid, null),
+              for (final strategy in JustifiedLayoutStrategy.values)
+                (GalleryLayoutType.justified, strategy),
+            ])
               MenuComponent(
-                key: ValueKey(layoutType),
-                title: _layoutTypeLabel(sheetContext, layoutType),
-                trailing: _layoutType == layoutType
+                key: ValueKey((layoutType, strategy)),
+                title: _layoutTypeLabel(sheetContext, layoutType, strategy),
+                trailing:
+                    _layoutType == layoutType &&
+                        (strategy == null || _justifiedStrategy == strategy)
                     ? Icon(
                         Icons.check,
                         color: sheetContext.componentColors.primary,
                       )
                     : null,
                 onTap: () async {
-                  await _setLayoutType(layoutType);
+                  await _setLayoutType(layoutType, strategy);
                   if (sheetContext.mounted) {
                     Navigator.of(sheetContext).pop();
                   }
@@ -140,16 +154,27 @@ class _GallerySettingsScreenState extends State<GallerySettingsScreen> {
     );
   }
 
-  Future<void> _setLayoutType(GalleryLayoutType layoutType) async {
+  Future<void> _setLayoutType(
+    GalleryLayoutType layoutType,
+    JustifiedLayoutStrategy? strategy,
+  ) async {
     if (layoutType == GalleryLayoutType.justified &&
         !isJustifiedLayoutAvailable) {
       return;
     }
-    if (localSettings.getGalleryLayoutType() == layoutType) return;
-    await localSettings.setGalleryLayoutType(layoutType);
+    if (localSettings.getGalleryLayoutType() == layoutType &&
+        (strategy == null ||
+            localSettings.getJustifiedLayoutStrategy() == strategy)) {
+      return;
+    }
+    await Future.wait([
+      localSettings.setGalleryLayoutType(layoutType),
+      if (strategy != null) localSettings.setJustifiedLayoutStrategy(strategy),
+    ]);
     if (mounted) {
       setState(() {
         _layoutType = layoutType;
+        if (strategy != null) _justifiedStrategy = strategy;
       });
     }
     Bus.instance.fire(GalleryLayoutChangedEvent());

--- a/mobile/apps/photos/lib/ui/viewer/gallery/justified_layout_strategy_label.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/justified_layout_strategy_label.dart
@@ -1,0 +1,10 @@
+import "package:ente_strings/ente_strings.dart";
+import "package:flutter/widgets.dart";
+import "package:photos/models/gallery/justified_layout_strategy.dart";
+
+extension JustifiedLayoutStrategyLabel on JustifiedLayoutStrategy {
+  String label(BuildContext context) => switch (this) {
+    JustifiedLayoutStrategy.comfort => context.strings.layoutJustifiedComfort,
+    JustifiedLayoutStrategy.flex => context.strings.layoutJustifiedFlex,
+  };
+}

--- a/mobile/apps/photos/lib/ui/viewer/gallery/layout_settings.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/layout_settings.dart
@@ -7,10 +7,12 @@ import "package:flutter/material.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/events/gallery_layout_changed_event.dart";
 import "package:photos/models/gallery/gallery_layout_config.dart";
+import "package:photos/models/gallery/justified_layout_strategy.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/settings/local_settings.dart";
 import "package:photos/ui/settings/gallery_settings_screen.dart";
 import "package:photos/ui/viewer/gallery/component/group/type.dart";
+import "package:photos/ui/viewer/gallery/justified_layout_strategy_label.dart";
 
 class GalleryLayoutSettings extends StatefulWidget {
   const GalleryLayoutSettings({super.key});
@@ -23,6 +25,7 @@ class _GalleryLayoutSettingsState extends State<GalleryLayoutSettings> {
   late bool isDayLayout;
   late bool isMonthLayout;
   late bool isJustifiedLayout;
+  late JustifiedLayoutStrategy justifiedStrategy;
 
   @override
   void initState() {
@@ -43,6 +46,7 @@ class _GalleryLayoutSettingsState extends State<GalleryLayoutSettings> {
         localSettings.getGalleryGroupType() == GroupType.month &&
         localSettings.getPhotoGridSize() == 5;
     isJustifiedLayout = layoutType == GalleryLayoutType.justified;
+    justifiedStrategy = localSettings.getJustifiedLayoutStrategy();
   }
 
   void _reloadWithLatestSetting() {
@@ -78,15 +82,17 @@ class _GalleryLayoutSettingsState extends State<GalleryLayoutSettings> {
             onTap: () => _applyLayout(GroupType.month, 5),
           ),
           if (isJustifiedLayoutAvailable)
-            MenuComponent(
-              title: context.strings.layoutJustified,
-              leading: const Icon(Icons.view_quilt_outlined),
-              trailing: isJustifiedLayout
-                  ? Icon(Icons.check, color: colors.primary)
-                  : null,
-              showOnlyLoadingState: true,
-              onTap: _applyJustifiedLayout,
-            ),
+            for (final strategy in JustifiedLayoutStrategy.values)
+              MenuComponent(
+                key: ValueKey(strategy),
+                title: strategy.label(context),
+                leading: const Icon(Icons.view_quilt_outlined),
+                trailing: isJustifiedLayout && justifiedStrategy == strategy
+                    ? Icon(Icons.check, color: colors.primary)
+                    : null,
+                showOnlyLoadingState: true,
+                onTap: () => _applyJustifiedLayout(strategy),
+              ),
           MenuComponent(
             title: context.strings.custom,
             trailing: Row(
@@ -132,10 +138,14 @@ class _GalleryLayoutSettingsState extends State<GalleryLayoutSettings> {
     Navigator.pop(context);
   }
 
-  Future<void> _applyJustifiedLayout() async {
+  Future<void> _applyJustifiedLayout(JustifiedLayoutStrategy strategy) async {
     if (!isJustifiedLayoutAvailable) return;
-    if (localSettings.getGalleryLayoutType() != GalleryLayoutType.justified) {
-      await localSettings.setGalleryLayoutType(GalleryLayoutType.justified);
+    if (localSettings.getGalleryLayoutType() != GalleryLayoutType.justified ||
+        localSettings.getJustifiedLayoutStrategy() != strategy) {
+      await Future.wait([
+        localSettings.setGalleryLayoutType(GalleryLayoutType.justified),
+        localSettings.setJustifiedLayoutStrategy(strategy),
+      ]);
       Bus.instance.fire(GalleryLayoutChangedEvent());
     }
 

--- a/mobile/apps/photos/test/models/flex_layout_test.dart
+++ b/mobile/apps/photos/test/models/flex_layout_test.dart
@@ -1,0 +1,105 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/models/gallery/flex_layout.dart";
+
+void main() {
+  test("considers later photos when choosing an earlier row break", () {
+    List<int> rowCounts(List<double> ratios) =>
+        FlexLayoutCalculator.computeRows(
+          aspectRatios: ratios,
+          availableWidth: 402,
+          targetRowHeight: 200,
+          spacing: 2,
+        ).map((row) => row.itemWidths.length).toList();
+
+    expect(rowCounts([1.5, 0.5, 0.5]), [1, 2]);
+    expect(rowCounts([1.5, 0.5, 0.5, 0.5, 0.5]), [2, 3]);
+  });
+
+  test("can exceed Comfort's item cap to avoid a portrait orphan", () {
+    final rows = FlexLayoutCalculator.computeRows(
+      aspectRatios: List.filled(4, 9 / 16),
+      availableWidth: 402,
+      targetRowHeight: 200,
+      spacing: 2,
+    );
+    expect(rows, hasLength(1));
+    expect(rows.single.itemWidths, hasLength(4));
+    expect(
+      rows.single.itemWidths.reduce((a, b) => a + b) + 6,
+      closeTo(402, 1e-9),
+    );
+  });
+
+  test("keeps dense portraits balanced and sparse tablet tails restrained", () {
+    final portraits = FlexLayoutCalculator.computeRows(
+      aspectRatios: List.filled(9, 9 / 16),
+      availableWidth: 402,
+      targetRowHeight: 200,
+      spacing: 2,
+    );
+    expect(portraits.map((row) => row.itemWidths.length), [3, 3, 3]);
+    final tail = FlexLayoutCalculator.computeRows(
+      aspectRatios: const [0.75, 0.75],
+      availableWidth: 1024,
+      targetRowHeight: 320,
+      spacing: 2,
+    ).single;
+    expect(tail.height, 320);
+    expect(tail.itemWidths.reduce((a, b) => a + b) + 2, lessThan(1024));
+  });
+
+  test("preserves file order, ratios and tap extents across screen sizes", () {
+    const ratios = [1 / 3, 4.0, 0.85, 4.0, 1.0, 0.75, 1.5, 0.5, 1.0];
+    for (final width in [393.0, 744.0, 1024.0, 1366.0]) {
+      final rows = FlexLayoutCalculator.computeRows(
+        aspectRatios: ratios,
+        availableWidth: width,
+        targetRowHeight: width < 600 ? 195.5 : 320,
+        spacing: 2,
+      );
+      var fileIndex = 0;
+      var offset = 0.0;
+      for (final row in rows) {
+        expect(row.firstIndex, fileIndex);
+        expect(row.minOffset, closeTo(offset, 1e-9));
+        expect(row.height, greaterThanOrEqualTo(48));
+        expect(row.itemWidths, everyElement(greaterThanOrEqualTo(48 - 1e-9)));
+        for (final tileWidth in row.itemWidths) {
+          expect(tileWidth / row.height, closeTo(ratios[fileIndex++], 1e-9));
+        }
+        expect(row.lastIndex, fileIndex - 1);
+        expect(
+          row.itemWidths.reduce((a, b) => a + b) +
+              2 * (row.itemWidths.length - 1),
+          lessThanOrEqualTo(width + 1e-9),
+        );
+        offset = row.maxOffset + 2;
+      }
+      expect(fileIndex, ratios.length);
+    }
+  });
+
+  test("normalizes missing and extreme ratios and handles empty groups", () {
+    final rows = FlexLayoutCalculator.computeRows(
+      aspectRatios: [0, double.nan, double.infinity, 0.01, 100],
+      availableWidth: 744,
+      targetRowHeight: 320,
+      spacing: 2,
+    );
+    expect(
+      rows.expand((row) => row.itemWidths.map((width) => width / row.height)),
+      orderedEquals(
+        [1.0, 1.0, 1.0, 1 / 3, 4.0].map((ratio) => closeTo(ratio, 1e-9)),
+      ),
+    );
+    expect(
+      FlexLayoutCalculator.computeRows(
+        aspectRatios: [],
+        availableWidth: 402,
+        targetRowHeight: 200,
+        spacing: 2,
+      ),
+      isEmpty,
+    );
+  });
+}

--- a/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
+++ b/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
@@ -12,6 +12,7 @@ import "package:photos/models/gallery/fixed_extent_section_layout.dart";
 import "package:photos/models/gallery/gallery_groups.dart";
 import "package:photos/models/gallery/justified_grid_row.dart";
 import "package:photos/models/gallery/justified_layout.dart";
+import "package:photos/models/gallery/justified_layout_strategy.dart";
 import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/settings/local_settings.dart";
@@ -47,6 +48,9 @@ void main() {
 
   setUp(() async {
     await localSettings.setGalleryLayoutType(GalleryLayoutType.justified);
+    await localSettings.setJustifiedLayoutStrategy(
+      JustifiedLayoutStrategy.comfort,
+    );
     await localSettings.setPhotoGridSize(4);
   });
 
@@ -127,6 +131,32 @@ void main() {
         expectedSectionOffset = justifiedSection.maxOffset;
       }
     }
+  });
+
+  test("routes justified galleries through the selected strategy", () async {
+    final files = List.generate(
+      4,
+      (index) => _file(
+        index: index,
+        creationTime: DateTime(2026, 8, 19).microsecondsSinceEpoch,
+        width: 9,
+        height: 16,
+      ),
+    );
+    await localSettings.setPhotoGridSize(2);
+    GalleryGroups groups() => _galleryGroups(
+      files: files,
+      groupType: GroupType.none,
+      groupHeaderExtent: GalleryGroups.spacing,
+      widthAvailable: 402,
+    );
+    final comfort = groups().groupLayouts.single as JustifiedSectionLayout;
+    expect(comfort.rows.map((row) => row.itemWidths.length), [2, 2]);
+    await localSettings.setJustifiedLayoutStrategy(
+      JustifiedLayoutStrategy.flex,
+    );
+    final flex = groups().groupLayouts.single as JustifiedSectionLayout;
+    expect(flex.rows.single.itemWidths, hasLength(4));
   });
 
   test(
@@ -313,28 +343,37 @@ void main() {
     expect(groups.getOffsetOfFile(replacement), originalGeometry?.rowOffset);
   });
 
-  test("a layout override keeps an embedded gallery on the fixed grid", () {
-    final files = List<EnteFile>.generate(
-      12,
-      (index) => _file(
-        index: index,
-        creationTime: DateTime(2026, 8, 19).microsecondsSinceEpoch,
-        width: 400,
-        height: 100,
-      ),
-      growable: false,
-    );
+  test(
+    "a layout override keeps an embedded gallery on the fixed grid",
+    () async {
+      await localSettings.setJustifiedLayoutStrategy(
+        JustifiedLayoutStrategy.flex,
+      );
+      final files = List<EnteFile>.generate(
+        12,
+        (index) => _file(
+          index: index,
+          creationTime: DateTime(2026, 8, 19).microsecondsSinceEpoch,
+          width: 400,
+          height: 100,
+        ),
+        growable: false,
+      );
 
-    final groups = _galleryGroups(
-      files: files,
-      groupType: GroupType.none,
-      groupHeaderExtent: GalleryGroups.spacing,
-      layoutTypeOverride: GalleryLayoutType.grid,
-    );
+      final groups = _galleryGroups(
+        files: files,
+        groupType: GroupType.none,
+        groupHeaderExtent: GalleryGroups.spacing,
+        layoutTypeOverride: GalleryLayoutType.grid,
+      );
 
-    expect(groups.layoutType, GalleryLayoutType.grid);
-    expect(groups.groupLayouts, everyElement(isA<FixedExtentSectionLayout>()));
-  });
+      expect(groups.layoutType, GalleryLayoutType.grid);
+      expect(
+        groups.groupLayouts,
+        everyElement(isA<FixedExtentSectionLayout>()),
+      );
+    },
+  );
 }
 
 GalleryGroups _galleryGroups({

--- a/mobile/apps/photos/test/settings/local_settings_gallery_layout_test.dart
+++ b/mobile/apps/photos/test/settings/local_settings_gallery_layout_test.dart
@@ -1,4 +1,5 @@
 import "package:flutter_test/flutter_test.dart";
+import "package:photos/models/gallery/justified_layout_strategy.dart";
 import "package:photos/settings/local_settings.dart";
 import "package:shared_preferences/shared_preferences.dart";
 
@@ -23,6 +24,21 @@ void main() {
     expect(
       preferences.getString(LocalSettings.kGalleryLayoutType),
       "justified",
+    );
+  });
+
+  test("justified strategy defaults to Comfort and persists Flex", () async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    final settings = LocalSettings(preferences);
+    expect(
+      settings.getJustifiedLayoutStrategy(),
+      JustifiedLayoutStrategy.comfort,
+    );
+    await settings.setJustifiedLayoutStrategy(JustifiedLayoutStrategy.flex);
+    expect(
+      LocalSettings(preferences).getJustifiedLayoutStrategy(),
+      JustifiedLayoutStrategy.flex,
     );
   });
 }

--- a/mobile/apps/photos/test/ui/viewer/gallery/gallery_layout_changed_event_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/gallery/gallery_layout_changed_event_test.dart
@@ -12,13 +12,16 @@ import "package:photos/models/file/dummy_file.dart";
 import "package:photos/models/file/file.dart";
 import "package:photos/models/file/file_type.dart";
 import "package:photos/models/file_load_result.dart";
+import "package:photos/models/gallery/justified_layout_strategy.dart";
 import "package:photos/models/metadata/file_magic.dart";
 import "package:photos/service_locator.dart";
 import "package:photos/settings/local_settings.dart";
+import "package:photos/ui/settings/gallery_settings_screen.dart";
 import "package:photos/ui/viewer/gallery/component/group/group_header_widget.dart";
 import "package:photos/ui/viewer/gallery/component/group/type.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
 import "package:photos/ui/viewer/gallery/gallery_app_bar_config.dart";
+import "package:photos/ui/viewer/gallery/layout_settings.dart";
 import "package:photos/ui/viewer/gallery/state/gallery_boundaries_provider.dart";
 import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
 import "package:shared_preferences/shared_preferences.dart";
@@ -54,11 +57,75 @@ void main() {
 
   setUp(() async {
     await localSettings.setInternalUserDisabled(false);
+    await localSettings.setGalleryLayoutType(GalleryLayoutType.grid);
+    await localSettings.setJustifiedLayoutStrategy(
+      JustifiedLayoutStrategy.comfort,
+    );
   });
 
   tearDown(() async {
     await localSettings.setInternalUserDisabled(false);
   });
+
+  testWidgets(
+    "both layout menus notify galleries when only the strategy changes",
+    (tester) async {
+      var events = 0;
+      final subscription = Bus.instance.on<GalleryLayoutChangedEvent>().listen(
+        (_) => events++,
+      );
+      addTearDown(subscription.cancel);
+      for (final quickMenu in [true, false]) {
+        await localSettings.setGalleryLayoutType(GalleryLayoutType.justified);
+        await localSettings.setJustifiedLayoutStrategy(
+          JustifiedLayoutStrategy.comfort,
+        );
+        events = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: lightThemeData,
+            localizationsDelegates: StringsLocalizations.localizationsDelegates,
+            supportedLocales: StringsLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => quickMenu
+                          ? const Scaffold(body: GalleryLayoutSettings())
+                          : const GallerySettingsScreen(
+                              fromGalleryLayoutSettingsCTA: true,
+                            ),
+                    ),
+                  ),
+                  child: const Text("Open settings"),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.tap(find.text("Open settings"));
+        await tester.pumpAndSettle();
+        if (!quickMenu) {
+          await tester.tap(find.text("Layout"));
+          await tester.pumpAndSettle();
+        }
+        await tester.tap(find.text("Justified · Flex"));
+        await tester.pumpAndSettle();
+        expect(
+          localSettings.getGalleryLayoutType(),
+          GalleryLayoutType.justified,
+        );
+        expect(
+          localSettings.getJustifiedLayoutStrategy(),
+          JustifiedLayoutStrategy.flex,
+        );
+        expect(events, 1);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+      }
+    },
+  );
 
   testWidgets(
     "layout changes rebuild every mounted gallery without loading files",

--- a/mobile/packages/strings/lib/l10n/arb/strings_en.arb
+++ b/mobile/packages/strings/lib/l10n/arb/strings_en.arb
@@ -2105,6 +2105,8 @@
   "layout": "Layout",
   "layoutGrouped": "Grouped",
   "layoutJustified": "Justified",
+  "layoutJustifiedComfort": "Justified · Comfort",
+  "layoutJustifiedFlex": "Justified · Flex",
   "layoutMasonry": "Masonry",
   "layoutTrip": "Trip",
   "leave": "Leave",


### PR DESCRIPTION
## Description

Adds an experimental Flex row-breaking strategy alongside the existing Comfort justified layout. Both are selectable from gallery settings for internal visual comparison, with Comfort remaining the default.

Flex uses whole-group dynamic programming to balance row height, tile width, unused space, and standalone rows. The selected strategy is persisted, strategy-only changes rebuild mounted galleries, and the existing internal-user feature gate remains unchanged.