### PR TITLE
[mob][photos] Use CPU for Rust OCR inference

### DIFF
--- a/rust/crates/ml/src/ocr/classify.rs
+++ b/rust/crates/ml/src/ocr/classify.rs
@@ -38,10 +38,11 @@ pub(crate) struct AngleClassifier {
 impl AngleClassifier {
     pub(crate) fn new(model_path: &str) -> Self {
         Self {
-            session: Mutex::new(
-                OnnxSession::new(model_path, MODEL_NAMESPACE, ExecutionMode::CpuAccelerated)
-                    .with_unvalidated_acceleration(),
-            ),
+            session: Mutex::new(OnnxSession::new(
+                model_path,
+                MODEL_NAMESPACE,
+                ExecutionMode::CpuOnly,
+            )),
         }
     }
 

--- a/rust/crates/ml/src/ocr/detect.rs
+++ b/rust/crates/ml/src/ocr/detect.rs
@@ -46,10 +46,11 @@ pub(crate) struct TextDetector {
 impl TextDetector {
     pub(crate) fn new(model_path: &str) -> Self {
         Self {
-            session: Mutex::new(
-                OnnxSession::new(model_path, MODEL_NAMESPACE, ExecutionMode::CpuAccelerated)
-                    .with_unvalidated_acceleration(),
-            ),
+            session: Mutex::new(OnnxSession::new(
+                model_path,
+                MODEL_NAMESPACE,
+                ExecutionMode::CpuOnly,
+            )),
         }
     }
 

--- a/rust/crates/ml/src/ocr/recognize.rs
+++ b/rust/crates/ml/src/ocr/recognize.rs
@@ -63,10 +63,11 @@ pub(crate) struct TextRecognizer {
 impl TextRecognizer {
     pub(crate) fn new(model_path: &str, dictionary_path: &str) -> Self {
         Self {
-            session: Mutex::new(
-                OnnxSession::new(model_path, MODEL_NAMESPACE, ExecutionMode::CpuAccelerated)
-                    .with_unvalidated_acceleration(),
-            ),
+            session: Mutex::new(OnnxSession::new(
+                model_path,
+                MODEL_NAMESPACE,
+                ExecutionMode::CpuOnly,
+            )),
             dictionary: LazyDictionary::new(dictionary_path),
         }
     }

--- a/rust/crates/ml/src/onnx/providers.rs
+++ b/rust/crates/ml/src/onnx/providers.rs
@@ -48,7 +48,6 @@ const ENABLE_PERSISTENT_COREML_CACHE: bool = true;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ExecutionMode {
     PlatformDefault,
-    CpuAccelerated,
     CpuOnly,
 }
 
@@ -78,7 +77,6 @@ impl ProviderPlan {
     ) -> Self {
         let providers = match mode {
             ExecutionMode::PlatformDefault => platform_default_providers(model_path, validation),
-            ExecutionMode::CpuAccelerated => cpu_accelerated_providers(),
             ExecutionMode::CpuOnly => vec![ExecutionProvider::Cpu],
         };
         Self::from_providers(providers)
@@ -270,16 +268,6 @@ fn platform_default_providers(
     _model_path: &str,
     _validation: AccelerationValidation,
 ) -> Vec<ExecutionProvider> {
-    vec![ExecutionProvider::Cpu]
-}
-
-#[cfg(target_os = "android")]
-fn cpu_accelerated_providers() -> Vec<ExecutionProvider> {
-    vec![ExecutionProvider::Xnnpack, ExecutionProvider::Cpu]
-}
-
-#[cfg(not(target_os = "android"))]
-fn cpu_accelerated_providers() -> Vec<ExecutionProvider> {
     vec![ExecutionProvider::Cpu]
 }
 
@@ -488,21 +476,6 @@ mod tests {
         assert_eq!(attempts, 2);
         assert_eq!(plan.selected_provider(), Some(ExecutionProvider::Cpu));
         assert!(!plan.has_fallback());
-    }
-
-    #[test]
-    fn cpu_accelerated_plan_ends_with_cpu_and_never_uses_gpu_providers() {
-        let plan = ProviderPlan::new(
-            ExecutionMode::CpuAccelerated,
-            "model.onnx",
-            AccelerationValidation::Unvalidated,
-        );
-
-        assert_eq!(plan.providers.last(), Some(&ExecutionProvider::Cpu));
-        assert!(!plan.providers.iter().any(|provider| matches!(
-            provider,
-            ExecutionProvider::WebGpu | ExecutionProvider::CoreMl
-        )));
     }
 
     fn accelerated_provider_plan() -> ProviderPlan {


### PR DESCRIPTION
## Description

With Rust OCR from #12616 enabled on Android, some images fail because the XNNPACK angle classifier returns `[1, 2]` for a batch requiring `[N, 2]`. The resulting terminal shape error skips CPU fallback and prevents any recognized text from being returned.

Temporarily use the ONNX Runtime CPU provider for all three OCR models: detection, angle classification, and recognition. Remove the now-unused `CpuAccelerated` mode.

## Tests

- Reproduced the classifier failure on a Pixel 8 using ONNX Runtime 1.28.1 extracted from its installed Play Store APK. XNNPACK returned the wrong shape for batches of 2, 4, and 6; CPU returned the correct shapes.
- Ran all 21 album entries (17 unique originals) through the edited Rust pipeline on an Android 17 arm64 emulator with that same runtime. All 21 returned text, compared with 13 before the fix. Every transcript matched the earlier classifier-only CPU comparison.
- The standalone runner still aborts during native runtime teardown after writing every result, as it did before this change. Validation inside an installed app on the Pixel, including performance, remains pending because the phone disconnected.
