### PR TITLE
[infra] Show file counts in staff dashboard

### DIFF
--- a/infra/staff/src/App.tsx
+++ b/infra/staff/src/App.tsx
@@ -23,6 +23,7 @@ import duckieimage from "./components/duckie.png";
 import {
     getScheduledDeletions,
     getUser,
+    initializeFileCounts,
     type ScheduledDeletion,
     type UserResponse,
 } from "./services/admin-user";
@@ -55,6 +56,7 @@ export const App: React.FC = () => {
         useState(false);
     const [scheduledDeletionsLoaded, setScheduledDeletionsLoaded] =
         useState(false);
+    const [fileCountInitPending, setFileCountInitPending] = useState(false);
     const searchRequestID = useRef(0);
 
     useEffect(() => {
@@ -173,6 +175,30 @@ export const App: React.FC = () => {
         [authToken, selectedUserEmail],
     );
     const displayedRequestID = searchRequestID.current;
+    const initializeDisplayedFileCounts = async (
+        userID: number,
+        requestID: number,
+    ) => {
+        setFileCountInitPending(true);
+        try {
+            const result = await initializeFileCounts(
+                { token: authToken },
+                userID,
+            );
+            if (result.reason) alert(result.reason);
+            if (result.initialized && requestID === searchRequestID.current) {
+                await fetchData(`${userID}`, authToken);
+            }
+        } catch (error) {
+            alert(
+                error instanceof Error
+                    ? error.message
+                    : "Failed to initialize file counts",
+            );
+        } finally {
+            setFileCountInitPending(false);
+        }
+    };
 
     return (
         <StaffSessionProvider session={session}>
@@ -287,14 +313,14 @@ export const App: React.FC = () => {
                                     {tabValue === 0 && (
                                         <UserDetails
                                             userData={userData}
-                                            onFileCountsInitialized={() =>
-                                                displayedRequestID ===
-                                                searchRequestID.current
-                                                    ? fetchData(
-                                                          selectedUserEmail,
-                                                          authToken,
-                                                      )
-                                                    : Promise.resolve()
+                                            fileCountInitPending={
+                                                fileCountInitPending
+                                            }
+                                            onInitializeFileCounts={() =>
+                                                initializeDisplayedFileCounts(
+                                                    userData.userID,
+                                                    displayedRequestID,
+                                                )
                                             }
                                         />
                                     )}

--- a/infra/staff/src/App.tsx
+++ b/infra/staff/src/App.tsx
@@ -172,6 +172,7 @@ export const App: React.FC = () => {
         () => ({ email: selectedUserEmail, token: authToken }),
         [authToken, selectedUserEmail],
     );
+    const displayedRequestID = searchRequestID.current;
 
     return (
         <StaffSessionProvider session={session}>
@@ -287,10 +288,13 @@ export const App: React.FC = () => {
                                         <UserDetails
                                             userData={userData}
                                             onFileCountsInitialized={() =>
-                                                fetchData(
-                                                    selectedUserEmail,
-                                                    authToken,
-                                                )
+                                                displayedRequestID ===
+                                                searchRequestID.current
+                                                    ? fetchData(
+                                                          selectedUserEmail,
+                                                          authToken,
+                                                      )
+                                                    : Promise.resolve()
                                             }
                                         />
                                     )}

--- a/infra/staff/src/App.tsx
+++ b/infra/staff/src/App.tsx
@@ -48,7 +48,6 @@ export const App: React.FC = () => {
     const [fetchSuccess, setFetchSuccess] = useState(false);
     const [tabValue, setTabValue] = useState(0);
     const [userData, setUserData] = useState<UserDetailsData | null>(null);
-    const [activeUserID, setActiveUserID] = useState<number>();
     const [scheduledDeletions, setScheduledDeletions] = useState<
         ScheduledDeletion[]
     >([]);
@@ -58,6 +57,7 @@ export const App: React.FC = () => {
         useState(false);
     const [fileCountInitPending, setFileCountInitPending] = useState(false);
     const searchRequestID = useRef(0);
+    const activeUserIDRef = useRef<number | undefined>(undefined);
 
     useEffect(() => {
         if (authToken) {
@@ -73,7 +73,7 @@ export const App: React.FC = () => {
         setError("");
         setFetchSuccess(false);
         setUserData(null);
-        setActiveUserID(undefined);
+        activeUserIDRef.current = undefined;
         setScheduledDeletions([]);
         setScheduledDeletionsLoading(false);
         setScheduledDeletionsLoaded(false);
@@ -91,7 +91,7 @@ export const App: React.FC = () => {
                 );
                 setSelectedUserEmail(userDetailsData.email);
                 setUserData(userDetailsData);
-                setActiveUserID(userResult.user.ID);
+                activeUserIDRef.current = userResult.user.ID;
             } else {
                 if (!userSearchInput.includes("@")) {
                     throw new Error("User not found");
@@ -174,11 +174,7 @@ export const App: React.FC = () => {
         () => ({ email: selectedUserEmail, token: authToken }),
         [authToken, selectedUserEmail],
     );
-    const displayedRequestID = searchRequestID.current;
-    const initializeDisplayedFileCounts = async (
-        userID: number,
-        requestID: number,
-    ) => {
+    const initializeDisplayedFileCounts = async (userID: number) => {
         setFileCountInitPending(true);
         try {
             const result = await initializeFileCounts(
@@ -186,7 +182,7 @@ export const App: React.FC = () => {
                 userID,
             );
             if (result.reason) alert(result.reason);
-            if (result.initialized && requestID === searchRequestID.current) {
+            if (result.initialized && userID === activeUserIDRef.current) {
                 await fetchData(`${userID}`, authToken);
             }
         } catch (error) {
@@ -234,7 +230,7 @@ export const App: React.FC = () => {
                             </Button>
                             <AdHocActions
                                 email={selectedUserEmail}
-                                activeUserID={activeUserID}
+                                activeUserID={userData?.userID}
                                 scheduledDeletions={scheduledDeletions}
                                 scheduledDeletionsLoading={
                                     scheduledDeletionsLoading
@@ -319,7 +315,6 @@ export const App: React.FC = () => {
                                             onInitializeFileCounts={() =>
                                                 initializeDisplayedFileCounts(
                                                     userData.userID,
-                                                    displayedRequestID,
                                                 )
                                             }
                                         />

--- a/infra/staff/src/App.tsx
+++ b/infra/staff/src/App.tsx
@@ -284,7 +284,15 @@ export const App: React.FC = () => {
                                     }}
                                 >
                                     {tabValue === 0 && (
-                                        <UserDetails userData={userData} />
+                                        <UserDetails
+                                            userData={userData}
+                                            onFileCountsInitialized={() =>
+                                                fetchData(
+                                                    selectedUserEmail,
+                                                    authToken,
+                                                )
+                                            }
+                                        />
                                     )}
                                     {tabValue === 1 && <FamilyTable />}
                                     {tabValue === 2 && (
@@ -337,9 +345,15 @@ const buildUserDetailsData = (
         (userResponse.details?.profileData?.passkeyCount ?? 0) > 0;
     const canDisableEmailMFA =
         userResponse.details?.profileData?.canDisableEmailMFA ?? false;
+    const { photosFileCount, lockerFileCount } = userResponse;
+    const fileCountsAvailable =
+        photosFileCount !== undefined && lockerFileCount !== undefined;
 
     return {
         email: userResponse.user.email || userSearchInput,
+        userID: userResponse.user.ID,
+        showFileCountInitializer:
+            photosFileCount === -1 && lockerFileCount === -1,
         user: [
             {
                 kind: "text",
@@ -408,11 +422,21 @@ const buildUserDetailsData = (
                 enabled: twoFactorEnabled,
             },
             { kind: "passkeys", label: "Passkeys", enabled: passkeysEnabled },
-            {
-                kind: "text",
-                label: "AuthCodes",
-                value: `${userResponse.authCodes}`,
-            },
+            { kind: "text", label: "Auth", value: `${userResponse.authCodes}` },
+            ...(fileCountsAvailable
+                ? [
+                      {
+                          kind: "text" as const,
+                          label: "Photos",
+                          value: fileCountLabel(photosFileCount),
+                      },
+                      {
+                          kind: "text" as const,
+                          label: "Locker",
+                          value: fileCountLabel(lockerFileCount),
+                      },
+                  ]
+                : []),
         ],
         securityState: {
             emailMFAEnabled,
@@ -421,3 +445,6 @@ const buildUserDetailsData = (
         },
     };
 };
+
+const fileCountLabel = (count: number) =>
+    count === -1 ? "Uninitialized" : `${count}`;

--- a/infra/staff/src/components/UserDetails.tsx
+++ b/infra/staff/src/components/UserDetails.tsx
@@ -15,8 +15,6 @@ import {
     Typography,
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
-import { initializeFileCounts } from "../services/admin-user";
-import { useStaffSession } from "../services/session";
 import { SUCCESS_COLOR } from "../utils";
 import { AddOTT } from "./AddOTT";
 import { ChangeEmail } from "./ChangeEmail";
@@ -53,14 +51,15 @@ type UserSectionKey = "user" | "storage" | "subscription" | "security";
 
 interface UserDetailsProps {
     userData: UserDetailsData;
-    onFileCountsInitialized: () => Promise<void>;
+    fileCountInitPending: boolean;
+    onInitializeFileCounts: () => Promise<void>;
 }
 
 export const UserDetails: React.FC<UserDetailsProps> = ({
     userData,
-    onFileCountsInitialized,
+    fileCountInitPending,
+    onInitializeFileCounts,
 }) => {
-    const session = useStaffSession();
     const [deleteAccountOpen, setDeleteAccountOpen] = useState(false);
     const [emailMFAEnabled, setEmailMFAEnabled] = useState(
         userData.securityState.emailMFAEnabled,
@@ -74,7 +73,6 @@ export const UserDetails: React.FC<UserDetailsProps> = ({
     const [changeEmailOpen, setChangeEmailOpen] = useState(false);
     const [disablePasskeysOpen, setDisablePasskeysOpen] = useState(false);
     const [addOTTOpen, setAddOTTOpen] = useState(false);
-    const [fileCountInitDisabled, setFileCountInitDisabled] = useState(false);
     const { canDisableEmailMFA } = userData.securityState;
 
     useEffect(() => {
@@ -97,22 +95,6 @@ export const UserDetails: React.FC<UserDetailsProps> = ({
             setDisable2FAOpen(true);
         }
     };
-    const handleInitializeFileCounts = async () => {
-        setFileCountInitDisabled(true);
-        window.setTimeout(() => setFileCountInitDisabled(false), 30_000);
-        try {
-            const result = await initializeFileCounts(session, userData.userID);
-            if (result.reason) alert(result.reason);
-            if (result.initialized) await onFileCountsInitialized();
-        } catch (error) {
-            alert(
-                error instanceof Error
-                    ? error.message
-                    : "Failed to initialize file counts",
-            );
-        }
-    };
-
     const sections: {
         key: UserSectionKey;
         title: string;
@@ -158,11 +140,13 @@ export const UserDetails: React.FC<UserDetailsProps> = ({
             {userData.showFileCountInitializer && (
                 <Button
                     variant="contained"
-                    disabled={fileCountInitDisabled}
-                    onClick={() => handleInitializeFileCounts()}
+                    disabled={fileCountInitPending}
+                    onClick={onInitializeFileCounts}
                     sx={{ textTransform: "none" }}
                 >
-                    Initialize file counts
+                    {fileCountInitPending
+                        ? "Initializing..."
+                        : "Initialize file counts"}
                 </Button>
             )}
 

--- a/infra/staff/src/components/UserDetails.tsx
+++ b/infra/staff/src/components/UserDetails.tsx
@@ -15,6 +15,8 @@ import {
     Typography,
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
+import { initializeFileCounts } from "../services/admin-user";
+import { useStaffSession } from "../services/session";
 import { SUCCESS_COLOR } from "../utils";
 import { AddOTT } from "./AddOTT";
 import { ChangeEmail } from "./ChangeEmail";
@@ -26,6 +28,8 @@ import { UpdateSubscription } from "./UpdateSubscription";
 
 export interface UserDetailsData {
     email: string;
+    userID: number;
+    showFileCountInitializer: boolean;
     user: UserTableRow[];
     storage: UserTableRow[];
     subscription: UserTableRow[];
@@ -49,9 +53,14 @@ type UserSectionKey = "user" | "storage" | "subscription" | "security";
 
 interface UserDetailsProps {
     userData: UserDetailsData;
+    onFileCountsInitialized: () => Promise<void>;
 }
 
-export const UserDetails: React.FC<UserDetailsProps> = ({ userData }) => {
+export const UserDetails: React.FC<UserDetailsProps> = ({
+    userData,
+    onFileCountsInitialized,
+}) => {
+    const session = useStaffSession();
     const [deleteAccountOpen, setDeleteAccountOpen] = useState(false);
     const [emailMFAEnabled, setEmailMFAEnabled] = useState(
         userData.securityState.emailMFAEnabled,
@@ -65,6 +74,7 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userData }) => {
     const [changeEmailOpen, setChangeEmailOpen] = useState(false);
     const [disablePasskeysOpen, setDisablePasskeysOpen] = useState(false);
     const [addOTTOpen, setAddOTTOpen] = useState(false);
+    const [fileCountInitDisabled, setFileCountInitDisabled] = useState(false);
     const { canDisableEmailMFA } = userData.securityState;
 
     useEffect(() => {
@@ -85,6 +95,21 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userData }) => {
     const handleTwoFactorChange = (enabled: boolean) => {
         if (!enabled) {
             setDisable2FAOpen(true);
+        }
+    };
+    const handleInitializeFileCounts = async () => {
+        setFileCountInitDisabled(true);
+        window.setTimeout(() => setFileCountInitDisabled(false), 30_000);
+        try {
+            const result = await initializeFileCounts(session, userData.userID);
+            if (result.reason) alert(result.reason);
+            if (result.initialized) await onFileCountsInitialized();
+        } catch (error) {
+            alert(
+                error instanceof Error
+                    ? error.message
+                    : "Failed to initialize file counts",
+            );
         }
     };
 
@@ -130,6 +155,16 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userData }) => {
                     />
                 </Grid>
             ))}
+            {userData.showFileCountInitializer && (
+                <Button
+                    variant="contained"
+                    disabled={fileCountInitDisabled}
+                    onClick={() => handleInitializeFileCounts()}
+                    sx={{ textTransform: "none" }}
+                >
+                    Initialize file counts
+                </Button>
+            )}
 
             <DeleteAccount
                 open={deleteAccountOpen}

--- a/infra/staff/src/services/admin-user.ts
+++ b/infra/staff/src/services/admin-user.ts
@@ -102,11 +102,18 @@ const UserResponse = z.object({
     }),
     subscription: Subscription.nullish().transform(nullToUndefined),
     authCodes: z.number().nullish().transform(nullishToZero),
+    photosFileCount: z.number().nullish().transform(nullToUndefined),
+    lockerFileCount: z.number().nullish().transform(nullToUndefined),
     tokens: z.array(TokenData).nullish().transform(nullishToEmpty),
     details: UserDetails,
 });
 
 export type UserResponse = z.infer<typeof UserResponse>;
+
+const InitializeFileCountsResponse = z.object({
+    initialized: z.boolean(),
+    reason: z.string().optional(),
+});
 
 const ScheduledDeletionResponse = z.object({
     scheduledDeletions: z.array(
@@ -172,6 +179,19 @@ export const getUser = async (
 
     await ensureOk(response, "Network response was not ok");
     return UserResponse.parse(await response.json());
+};
+
+export const initializeFileCounts = async (
+    session: Pick<StaffSession, "token">,
+    userID: number,
+) => {
+    const response = await fetch(apiURL("/admin/user/init-file-counts"), {
+        method: "POST",
+        headers: staffJSONRequestHeaders(session),
+        body: JSON.stringify({ userID }),
+    });
+    await ensureOk(response, "Failed to initialize file counts");
+    return InitializeFileCountsResponse.parse(await response.json());
 };
 
 export const getScheduledDeletions = async (


### PR DESCRIPTION
Depends on #12680.

Show Auth, Photos and Locker counts in the staff dashboard. File-count initialization is disabled while a request is in flight. Missing server fields keep the count rows and action hidden, so either deployment order is safe.