### PR TITLE
[space][server] Link notifications to the new post

### DIFF
--- a/server/space/controller/notifications.go
+++ b/server/space/controller/notifications.go
@@ -55,7 +55,7 @@ func spaceActivityActor(space *repo.SpaceRecord) SpaceActivityActor {
 }
 
 type SpaceActivityNotifier interface {
-	OnSpacePostCreated(actor SpaceActivityActor)
+	OnSpacePostCreated(actor SpaceActivityActor, postID int64)
 	OnSpacePostLiked(actor SpaceActivityActor, recipientUserID int64)
 	OnSpacePostReplied(actor SpaceActivityActor, recipientUserID int64)
 	OnSpaceMessageSent(actor SpaceActivityActor, recipientUserID int64)
@@ -103,7 +103,7 @@ func NewSpaceWebPushSender(
 	return sender
 }
 
-func (n *SpaceWebPushSender) OnSpacePostCreated(actor SpaceActivityActor) {
+func (n *SpaceWebPushSender) OnSpacePostCreated(actor SpaceActivityActor, postID int64) {
 	if !n.available() {
 		return
 	}
@@ -121,7 +121,7 @@ func (n *SpaceWebPushSender) OnSpacePostCreated(actor SpaceActivityActor) {
 		"posted a new photo",
 		"Check it out",
 		spaceActivityPostCreated,
-		"/app",
+		fmt.Sprintf("/app/posts/%s/%d", url.PathEscape(actor.SpaceID), postID),
 		subscriptions,
 	)
 }

--- a/server/space/controller/notifications_test.go
+++ b/server/space/controller/notifications_test.go
@@ -26,6 +26,7 @@ type recordedSpaceActivity struct {
 	actorUserID  int64
 	actorSpaceID string
 	actorSlug    string
+	postID       int64
 	recipientIDs []int64
 }
 
@@ -37,8 +38,14 @@ func newRecordingSpaceActivityNotifier() *recordingSpaceActivityNotifier {
 	return &recordingSpaceActivityNotifier{events: make(chan recordedSpaceActivity, 8)}
 }
 
-func (n *recordingSpaceActivityNotifier) OnSpacePostCreated(actor SpaceActivityActor) {
-	n.record(spaceActivityPostCreated, actor)
+func (n *recordingSpaceActivityNotifier) OnSpacePostCreated(actor SpaceActivityActor, postID int64) {
+	n.events <- recordedSpaceActivity{
+		event:        spaceActivityPostCreated,
+		actorUserID:  actor.UserID,
+		actorSpaceID: actor.SpaceID,
+		actorSlug:    actor.Slug,
+		postID:       postID,
+	}
 }
 
 func (n *recordingSpaceActivityNotifier) OnSpacePostLiked(actor SpaceActivityActor, recipientUserID int64) {
@@ -182,13 +189,14 @@ func TestNewPostNotifiesWithNoAccountFriends(t *testing.T) {
 	notifier := newRecordingSpaceActivityNotifier()
 	posts := NewModule(repos, nil, notifier, nil).Posts
 
-	posts.notifyFriendsOfNewPost(SpaceActivityActor{UserID: 1, SpaceID: "space_id", Slug: "alice"})
+	posts.notifyFriendsOfNewPost(SpaceActivityActor{UserID: 1, SpaceID: "space_id", Slug: "alice"}, 42)
 
 	require.Equal(t, recordedSpaceActivity{
 		event:        spaceActivityPostCreated,
 		actorUserID:  1,
 		actorSpaceID: "space_id",
 		actorSlug:    "alice",
+		postID:       42,
 	}, requireSpaceActivity(t, notifier))
 }
 

--- a/server/space/controller/posts.go
+++ b/server/space/controller/posts.go
@@ -91,12 +91,12 @@ func (c *PostsController) Create(ctx context.Context, space *repo.SpaceRecord, r
 			space.SpaceID, space.OwnerID, postCount, repo.MaxPostsPerSpace,
 		))
 	}
-	c.notifyFriendsOfNewPost(spaceActivityActor(space))
+	c.notifyFriendsOfNewPost(spaceActivityActor(space), postID)
 	return &models.CreatePostResponse{PostID: postID}, nil
 }
 
-func (c *PostsController) notifyFriendsOfNewPost(actor SpaceActivityActor) {
-	go c.ActivityNotifier.OnSpacePostCreated(actor)
+func (c *PostsController) notifyFriendsOfNewPost(actor SpaceActivityActor, postID int64) {
+	go c.ActivityNotifier.OnSpacePostCreated(actor, postID)
 }
 
 func (c *PostsController) postResponses(ctx context.Context, posts []repo.SpacePostRecord, includeAuthor bool) ([]models.PostResponse, error) {

--- a/server/space/controller/test_helpers_test.go
+++ b/server/space/controller/test_helpers_test.go
@@ -28,7 +28,7 @@ func setupPostsControllerTest(t *testing.T) (*PostsController, *spacerepo.Module
 
 type noopSpaceActivityNotifier struct{}
 
-func (noopSpaceActivityNotifier) OnSpacePostCreated(SpaceActivityActor)            {}
+func (noopSpaceActivityNotifier) OnSpacePostCreated(SpaceActivityActor, int64)     {}
 func (noopSpaceActivityNotifier) OnSpacePostLiked(SpaceActivityActor, int64)       {}
 func (noopSpaceActivityNotifier) OnSpacePostReplied(SpaceActivityActor, int64)     {}
 func (noopSpaceActivityNotifier) OnSpaceMessageSent(SpaceActivityActor, int64)     {}


### PR DESCRIPTION
- Pass the new post ID to the notification sender and link to `/app/posts/<spaceID>/<postID>`.
- Update notification tests to check that the post ID reaches the sender.