### PR TITLE
Specify rust is required for building the web application

### DIFF
--- a/docs/docs/self-hosting/installation/manual.md
+++ b/docs/docs/self-hosting/installation/manual.md
@@ -51,12 +51,27 @@ If you wish to run Ente from source without using Docker, follow the steps descr
     ```shell
     sudo apt install npm nodejs
     ```
+5. **rust and rustup:** Needed for WASM build
 
-5. **Git:** Needed for cloning the repository and pulling in latest changes
+   Rust and rustup are required for the web application builds.
 
-6. **Caddy:** Used for setting reverse proxy and file servers
+   ```shell
+   # Install the Rust installer
+   sudo apt install rustup
 
-7. **Object Storage:** Ensure you have an object storage configured for usage, needed for storing files. You can choose to run MinIO or Garage locally without Docker, however, an external bucket will be reliable and suited for long-term storage.
+   # Install the rust compiler from the stable channel and set as default toolchain
+   rustup default stable
+   ```
+
+   > [!TIP]
+   > `rustup` is available in Debian since Trixie (13). For older builds or other platforms where `rustup` is not available,
+   > please refer to the official installation steps [here](https://rustup.rs/)
+
+6. **Git:** Needed for cloning the repository and pulling in latest changes
+
+7. **Caddy:** Used for setting reverse proxy and file servers
+
+8. **Object Storage:** Ensure you have an object storage configured for usage, needed for storing files. You can choose to run MinIO or Garage locally without Docker, however, an external bucket will be reliable and suited for long-term storage.
 
 ## Step 1: Clone the repository
 


### PR DESCRIPTION
## Description
While following the manual installation steps I noticed that rust is required to compile the web application, but was not covered anywhere.

```
root@37c3e080e262:~/ente/web# npm run build

> ente-web@0.0.0 build
> npm run build:photos


> ente-web@0.0.0 build:photos
> npm run build:prelogin-wasm && npm run build:cast-wasm && npm run build:photos-wasm && npm exec --workspace photos -- next build --webpack


> ente-web@0.0.0 build:prelogin-wasm
> npm run build --workspace ente-prelogin-wasm


> ente-prelogin-wasm@0.0.0 build
> wasm-pack build ../../../../rust/bindings/wasm/prelogin --target bundler --out-dir ../../../../web/packages/wasm/prelogin/pkg --no-pack

Error: failed to start `cargo metadata`: No such file or directory (os error 2)
Caused by: failed to start `cargo metadata`: No such file or directory (os error 2)
Caused by: No such file or directory (os error 2)
npm ERR! Lifecycle script `build` failed with error:
npm ERR! Error: command failed
npm ERR!   in workspace: ente-prelogin-wasm@0.0.0
npm ERR!   at location: /root/ente/web/packages/wasm/prelogin
```

## Tests
Tested the web application build steps from [HERE](https://ente.com/help/self-hosting/installation/manual#step-4-configure-web-application) against `main` branch and latest release - [photos-v1.3.63](https://github.com/ente/ente/releases/tag/photos-v1.3.63). Both builds returned the same error.
