### PR TITLE
[ensu]model-url-update

### DIFF
--- a/apple/apps/ensu/Ensu/EnsuApp.swift
+++ b/apple/apps/ensu/Ensu/EnsuApp.swift
@@ -2,17 +2,17 @@ import SwiftUI
 
 @main
 struct EnsuApp: App {
-    private let assetStore: AssetStore
+    private let assetStoreTask: Task<AssetStore, Never>
 
     init() {
         EnsuLogging.shared.start()
         AssetStore.registerBackgroundTask()
-        assetStore = AssetStore()
+        assetStoreTask = Task { await AssetStore() }
     }
 
     var body: some Scene {
         WindowGroup {
-            RootView(assetStore: assetStore)
+            RootView(assetStoreTask: assetStoreTask)
         }
     }
 }

--- a/apple/apps/ensu/Ensu/RootView.swift
+++ b/apple/apps/ensu/Ensu/RootView.swift
@@ -1,16 +1,24 @@
 import SwiftUI
 
 struct RootView: View {
-    let assetStore: AssetStore
+    let assetStoreTask: Task<AssetStore, Never>
+    @State private var assetStore: AssetStore?
 
     var body: some View {
         ZStack {
             EnsuColor.backgroundBase
                 .ignoresSafeArea()
 
-            HomeView(assetStore: assetStore)
+            if let assetStore {
+                HomeView(assetStore: assetStore)
+            } else {
+                ProgressView()
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .tint(EnsuColor.action)
+        .task {
+            assetStore = await assetStoreTask.value
+        }
     }
 }

--- a/apple/apps/ensu/Ensu/Services/AssetStore.swift
+++ b/apple/apps/ensu/Ensu/Services/AssetStore.swift
@@ -7,7 +7,7 @@ final class AssetStore: @unchecked Sendable {
     private let core: AssetStoreCore
 
     @MainActor
-    init() {
+    init() async {
         let baseDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
         var assetsDir = baseDir.appendingPathComponent("assets", isDirectory: true)
@@ -21,15 +21,15 @@ final class AssetStore: @unchecked Sendable {
         let legacyModelUrl = pendingSelection && settings.bool(forKey: "ensu.model.use_custom")
             ? settings.string(forKey: "ensu.model.url")
             : nil
-        let presetId = migrateEnsuAssets(
-            assetsDir: assetsDir.path,
-            legacy: LegacyAssets(
-                llmDir: baseDir.appendingPathComponent("llm", isDirectory: true).path,
-                transcriptionDir: baseDir.appendingPathComponent("transcription", isDirectory: true).path,
-                modelUrl: legacyModelUrl,
-                mmprojUrl: settings.string(forKey: "ensu.model.mmproj")
-            )
+        let legacy = LegacyAssets(
+            llmDir: baseDir.appendingPathComponent("llm", isDirectory: true).path,
+            transcriptionDir: baseDir.appendingPathComponent("transcription", isDirectory: true).path,
+            modelUrl: legacyModelUrl,
+            mmprojUrl: settings.string(forKey: "ensu.model.mmproj")
         )
+        let presetId = await Task.detached(priority: .userInitiated) { [assetsDir] in
+            migrateEnsuAssets(assetsDir: assetsDir.path, legacy: legacy)
+        }.value
         if pendingSelection {
             settings.set(presetId ?? "", forKey: "ensu.model.id")
         }

--- a/rust/crates/ensu/src/config.rs
+++ b/rust/crates/ensu/src/config.rs
@@ -63,11 +63,11 @@ fn lfm_vl_1_6b() -> ModelPreset {
     ModelPreset {
         id: "lfm-vl-1.6b".to_string(),
         title: "LFM 2.5 VL 1.6B (Q4_0)".to_string(),
-        url: "https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF/resolve/main/LFM2.5-VL-1.6B-Q4_0.gguf?download=true".to_string(),
+        url: "https://huggingface.co/ente-ai/LFM2.5-VL-1.6B-GGUF/resolve/b2995f54e17fd7ec31e9cb399ade8fedfd51624d/LFM2.5-VL-1.6B-Q4_0.gguf?download=true".to_string(),
         size: 695_752_480,
         sha256: "8186364a4e7c3ad30f6dd3d3b7a4e0074c77dd91eed6cad5d8be9090ce285804".to_string(),
         mmproj_url: Some(
-            "https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF/resolve/main/mmproj-LFM2.5-VL-1.6b-Q8_0.gguf"
+            "https://huggingface.co/ente-ai/LFM2.5-VL-1.6B-GGUF/resolve/b2995f54e17fd7ec31e9cb399ade8fedfd51624d/mmproj-LFM2.5-VL-1.6b-Q8_0.gguf"
                 .to_string(),
         ),
         mmproj_size: Some(583_109_888),
@@ -79,11 +79,11 @@ fn qwen_0_8b() -> ModelPreset {
     ModelPreset {
         id: "qwen-0.8b".to_string(),
         title: "Qwen 3.5 0.8B (Q4_K_M)".to_string(),
-        url: "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true".to_string(),
+        url: "https://huggingface.co/ente-ai/Qwen3.5-0.8B-GGUF/resolve/f44fc9bf306e407078288aee9ff7a83b457d260a/Qwen3.5-0.8B-Q4_K_M.gguf?download=true".to_string(),
         size: 532_517_120,
         sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517".to_string(),
         mmproj_url: Some(
-            "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-F16.gguf"
+            "https://huggingface.co/ente-ai/Qwen3.5-0.8B-GGUF/resolve/f44fc9bf306e407078288aee9ff7a83b457d260a/mmproj-F16.gguf"
                 .to_string(),
         ),
         mmproj_size: Some(204_987_232),
@@ -95,11 +95,11 @@ fn qwen_2b_q8() -> ModelPreset {
     ModelPreset {
         id: "qwen-2b-q8".to_string(),
         title: "Qwen 3.5 2B (Q8_0)".to_string(),
-        url: "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q8_0.gguf?download=true".to_string(),
+        url: "https://huggingface.co/ente-ai/Qwen3.5-2B-GGUF/resolve/4cd5d68754a443dc390533792bf345ad219c0b41/Qwen3.5-2B-Q8_0.gguf?download=true".to_string(),
         size: 2_012_012_800,
         sha256: "1b04acba824817554f4ce23639bc8495ff70453b8fcb047900c731521021f2c1".to_string(),
         mmproj_url: Some(
-            "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/mmproj-F16.gguf"
+            "https://huggingface.co/ente-ai/Qwen3.5-2B-GGUF/resolve/4cd5d68754a443dc390533792bf345ad219c0b41/mmproj-F16.gguf"
                 .to_string(),
         ),
         mmproj_size: Some(668_227_264),
@@ -111,11 +111,11 @@ fn qwen_4b_q4km() -> ModelPreset {
     ModelPreset {
         id: "qwen-4b-q4km".to_string(),
         title: "Qwen 3.5 4B (Q4_K_M)".to_string(),
-        url: "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf?download=true".to_string(),
+        url: "https://huggingface.co/ente-ai/Qwen3.5-4B-GGUF/resolve/9b67f8db9bedc8c10f524ac08193b58fa9b20ac7/Qwen3.5-4B-Q4_K_M.gguf?download=true".to_string(),
         size: 2_740_937_888,
         sha256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4".to_string(),
         mmproj_url: Some(
-            "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/mmproj-F16.gguf"
+            "https://huggingface.co/ente-ai/Qwen3.5-4B-GGUF/resolve/9b67f8db9bedc8c10f524ac08193b58fa9b20ac7/mmproj-F16.gguf"
                 .to_string(),
         ),
         mmproj_size: Some(672_423_616),

--- a/rust/crates/ensu/src/model/migrations.rs
+++ b/rust/crates/ensu/src/model/migrations.rs
@@ -3,6 +3,7 @@ use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use ente_assets::download::sha256_file;
 use ente_assets::{Asset, AssetStore};
 
 use crate::config;
@@ -59,6 +60,7 @@ struct LlmMigration {
 struct LlmFile {
     url: String,
     name: &'static str,
+    sha256: String,
 }
 
 fn llm_migrations() -> Result<Vec<LlmMigration>, InvalidPreset> {
@@ -68,11 +70,13 @@ fn llm_migrations() -> Result<Vec<LlmMigration>, InvalidPreset> {
             let mut files = vec![LlmFile {
                 url: preset.url.clone(),
                 name: "model.gguf",
+                sha256: preset.sha256.clone(),
             }];
             if let Some(url) = trimmed(preset.mmproj_url.as_deref()) {
                 files.push(LlmFile {
                     url: url.to_string(),
                     name: "mmproj.gguf",
+                    sha256: preset.mmproj_sha256.clone().unwrap_or_default(),
                 });
             }
             Ok(LlmMigration {
@@ -91,6 +95,28 @@ fn legacy_selected_preset_id(model_url: &str, mmproj_url: Option<&str>) -> Optio
             preset.url == model_url && trimmed(preset.mmproj_url.as_deref()) == mmproj_url
         })
         .map(|preset| preset.id)
+        .or_else(|| {
+            let id = match (model_url, mmproj_url) {
+                (
+                    "https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF/resolve/main/LFM2.5-VL-1.6B-Q4_0.gguf?download=true",
+                    Some("https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF/resolve/main/mmproj-LFM2.5-VL-1.6b-Q8_0.gguf"),
+                ) => "lfm-vl-1.6b",
+                (
+                    "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true",
+                    Some("https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-F16.gguf"),
+                ) => "qwen-0.8b",
+                (
+                    "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q8_0.gguf?download=true",
+                    Some("https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/mmproj-F16.gguf"),
+                ) => "qwen-2b-q8",
+                (
+                    "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf?download=true",
+                    Some("https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/mmproj-F16.gguf"),
+                ) => "qwen-4b-q4km",
+                _ => return None,
+            };
+            Some(id.to_string())
+        })
 }
 
 fn migrate_flat_models(
@@ -170,6 +196,11 @@ fn adopt_flat_targets(store: &AssetStore, targets: &[LlmMigration], flat_dir: &P
                 match sidecar_url(&source) {
                     Some(url) if url == file.url => Some(Some(source)),
                     None if basename_urls[&basename].len() == 1 => Some(Some(source)),
+                    _ if sha256_file(&source)
+                        .is_ok_and(|sha256| sha256.eq_ignore_ascii_case(&file.sha256)) =>
+                    {
+                        Some(Some(source))
+                    }
                     _ => None,
                 }
             })
@@ -269,10 +300,12 @@ mod tests {
                 LlmFile {
                     url: model_url.to_string(),
                     name: "model.gguf",
+                    sha256: preset.sha256.clone(),
                 },
                 LlmFile {
                     url: mmproj_url.to_string(),
                     name: "mmproj.gguf",
+                    sha256: preset.mmproj_sha256.clone().unwrap(),
                 },
             ],
         }

--- a/rust/crates/ensu/src/model/migrations.rs
+++ b/rust/crates/ensu/src/model/migrations.rs
@@ -204,12 +204,12 @@ fn adopt_flat_targets(store: &AssetStore, targets: &[LlmMigration], flat_dir: &P
                     _ => None,
                 }
             })
-            .collect::<Vec<_>>();
-        if sources.iter().any(Option::is_none) {
+            .collect::<Option<Vec<_>>>();
+        let Some(sources) = sources else {
             continue;
-        }
+        };
         for (file, source) in target.files.iter().zip(sources) {
-            if let Some(Some(source)) = source {
+            if let Some(source) = source {
                 complete &= move_file(&source, &destination.join(file.name));
             }
         }

--- a/web/apps/ensu/src/services/llm/provider.ts
+++ b/web/apps/ensu/src/services/llm/provider.ts
@@ -19,10 +19,10 @@ const OVERFLOW_SAFETY_TOKENS = 256;
 export const DEFAULT_MODEL: ModelInfo = {
     id: "lfm-vl-1.6b",
     name: "LFM 2.5 VL 1.6B (Q4_0)",
-    url: "https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF/resolve/main/LFM2.5-VL-1.6B-Q4_0.gguf?download=true",
+    url: "https://huggingface.co/ente-ai/LFM2.5-VL-1.6B-GGUF/resolve/b2995f54e17fd7ec31e9cb399ade8fedfd51624d/LFM2.5-VL-1.6B-Q4_0.gguf?download=true",
     sha256: "8186364a4e7c3ad30f6dd3d3b7a4e0074c77dd91eed6cad5d8be9090ce285804",
     mmprojUrl:
-        "https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B-GGUF/resolve/main/mmproj-LFM2.5-VL-1.6b-Q8_0.gguf",
+        "https://huggingface.co/ente-ai/LFM2.5-VL-1.6B-GGUF/resolve/b2995f54e17fd7ec31e9cb399ade8fedfd51624d/mmproj-LFM2.5-VL-1.6b-Q8_0.gguf",
     mmprojSha256:
         "2ce89e610c56f3198ece2b86cf61743a08b9307279c89125eb2412ebb908689d",
     sizeBytes: 695_752_160,
@@ -81,20 +81,20 @@ const FALLBACK_SHARED_MODEL_PRESETS: ModelInfo[] = [
     {
         id: "qwen-0.8b",
         name: "Qwen 3.5 0.8B (Q4_K_M)",
-        url: "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true",
+        url: "https://huggingface.co/ente-ai/Qwen3.5-0.8B-GGUF/resolve/f44fc9bf306e407078288aee9ff7a83b457d260a/Qwen3.5-0.8B-Q4_K_M.gguf?download=true",
         sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517",
         mmprojUrl:
-            "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-F16.gguf",
+            "https://huggingface.co/ente-ai/Qwen3.5-0.8B-GGUF/resolve/f44fc9bf306e407078288aee9ff7a83b457d260a/mmproj-F16.gguf",
         mmprojSha256:
             "56e4c6cfe73b0c82e3e82bc518d7591997e61d81f723fc41a586f4fa69ea2453",
     },
     {
         id: "qwen-2b-q8",
         name: "Qwen 3.5 2B (Q8_0)",
-        url: "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q8_0.gguf?download=true",
+        url: "https://huggingface.co/ente-ai/Qwen3.5-2B-GGUF/resolve/4cd5d68754a443dc390533792bf345ad219c0b41/Qwen3.5-2B-Q8_0.gguf?download=true",
         sha256: "1b04acba824817554f4ce23639bc8495ff70453b8fcb047900c731521021f2c1",
         mmprojUrl:
-            "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/mmproj-F16.gguf",
+            "https://huggingface.co/ente-ai/Qwen3.5-2B-GGUF/resolve/4cd5d68754a443dc390533792bf345ad219c0b41/mmproj-F16.gguf",
         mmprojSha256:
             "7035e9cb8d7c6a9681d07eef9a364783e86ea4cd73faab2eabb4f43a101830c7",
     },
@@ -118,10 +118,10 @@ export const FALLBACK_DESKTOP_MODEL_PRESETS: ModelInfo[] = [
     {
         id: "qwen-4b-q4km",
         name: "Qwen 3.5 4B (Q4_K_M)",
-        url: "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf?download=true",
+        url: "https://huggingface.co/ente-ai/Qwen3.5-4B-GGUF/resolve/9b67f8db9bedc8c10f524ac08193b58fa9b20ac7/Qwen3.5-4B-Q4_K_M.gguf?download=true",
         sha256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
         mmprojUrl:
-            "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/mmproj-F16.gguf",
+            "https://huggingface.co/ente-ai/Qwen3.5-4B-GGUF/resolve/9b67f8db9bedc8c10f524ac08193b58fa9b20ac7/mmproj-F16.gguf",
         mmprojSha256:
             "cd88edcf8d031894960bb0c9c5b9b7e1fea6ebee02b9f7ce925a00d12891f864",
     },


### PR DESCRIPTION
Use commit-pinned ente-ai mirrors for Ensu’s LFM and Qwen model/projector downloads across native and web catalogs.
Verified all eight downloads against the existing SHA-256 hashes; 14 targeted tests pass.
