### PR TITLE
[ensu] Add mobile notes and desktop settings release notes

### DIFF
--- a/rust/apps/ensu/changes/chat-with-notes-mobile.md
+++ b/rust/apps/ensu/changes/chat-with-notes-mobile.md
@@ -1,0 +1,1 @@
+- Chat with your notes in mobile

--- a/rust/apps/ensu/changes/desktop-settings-fix.md
+++ b/rust/apps/ensu/changes/desktop-settings-fix.md
@@ -1,0 +1,1 @@
+- Fixed issue with settings on desktop


### PR DESCRIPTION
Adds separate Ensu release note entries for chatting with notes on mobile and the desktop settings fix.

Validation: `git diff --cached --check` passed before committing. Documentation only.
