### PR TITLE
[web][photos] Remove redundant overflow menu from Hidden items

### DIFF
--- a/desktop/changes/hidden-items-download-button.md
+++ b/desktop/changes/hidden-items-download-button.md
@@ -1,0 +1,1 @@
+- Removed the redundant three-dot menu from Hidden items and moved the download button to the right.

--- a/web/apps/photos/src/components/Collections/CollectionHeader.tsx
+++ b/web/apps/photos/src/components/Collections/CollectionHeader.tsx
@@ -431,16 +431,6 @@ const CollectionHeaderOptions: React.FC<CollectionHeaderProps> = ({
             break;
 
         case "hiddenItems":
-            menuOptions = [
-                fileCount && (
-                    <DownloadOption
-                        key="download-hidden"
-                        onClick={downloadCollection}
-                    >
-                        {t("download_hidden_items")}
-                    </DownloadOption>
-                ),
-            ];
             break;
 
         case "sharedIncoming":
@@ -1008,27 +998,6 @@ const CastQuickOption: React.FC<OptionProps> = ({ onClick }) => (
             </Box>
         </IconButton>
     </Tooltip>
-);
-
-type DownloadOptionProps = OptionProps & {
-    isDownloadInProgress?: () => boolean;
-};
-
-const DownloadOption: React.FC<
-    React.PropsWithChildren<DownloadOptionProps>
-> = ({ isDownloadInProgress, onClick, children }) => (
-    <OverflowMenuOption
-        startIcon={
-            isDownloadInProgress?.() ? (
-                <ActivityIndicator size="20px" sx={{ cursor: "not-allowed" }} />
-            ) : (
-                <DownloadIcon />
-            )
-        }
-        onClick={onClick}
-    >
-        {children}
-    </OverflowMenuOption>
 );
 
 interface CollectionSortOrderMenuProps {


### PR DESCRIPTION
Removes the three-dot menu from Hidden items and moves the download button to the right. Download behavior stays the same.
