### PR TITLE
[rust] vecdb: amortized graph growth and an sdot-shaped int8 kernel

### DIFF
--- a/rust/crates/ml/src/vecdb/graph.rs
+++ b/rust/crates/ml/src/vecdb/graph.rs
@@ -23,6 +23,17 @@ const LEVEL_SEED: u64 = 0x9E37_79B9_7F4A_7C15;
 const NEIGHBOR_BATCH: usize = LEVEL_ZERO_NEIGHBOR_CAP;
 const ABSENT_LEVEL: u16 = u16::MAX;
 const ABSENT_DENSE: u32 = u32::MAX;
+const MIN_GROWTH_SPARE: usize = 1024;
+
+fn grow_amortized<T: Clone>(values: &mut Vec<T>, len: usize, fill: T) {
+    debug_assert!(len >= values.len());
+    if values.capacity() < len {
+        let spare = (values.len() / 8).max(MIN_GROWTH_SPARE);
+        let target = len.max(values.len() + spare);
+        values.reserve_exact(target - values.len());
+    }
+    values.resize(len, fill);
+}
 
 fn neighbor_cap(level: usize) -> usize {
     if level == 0 {
@@ -401,15 +412,13 @@ impl Graph {
         if self.node_levels.len() >= capacity {
             return;
         }
-        let extra = capacity - self.node_levels.len();
-        self.node_levels.reserve_exact(extra);
-        self.node_levels.resize(capacity, ABSENT_LEVEL);
-        self.zero_lengths.reserve_exact(extra);
-        self.zero_lengths.resize(capacity, 0);
-        let blocks = capacity * LEVEL_ZERO_NEIGHBOR_CAP;
-        self.zero_neighbors
-            .reserve_exact(blocks - self.zero_neighbors.len());
-        self.zero_neighbors.resize(blocks, 0);
+        grow_amortized(&mut self.node_levels, capacity, ABSENT_LEVEL);
+        grow_amortized(&mut self.zero_lengths, capacity, 0);
+        grow_amortized(
+            &mut self.zero_neighbors,
+            capacity * LEVEL_ZERO_NEIGHBOR_CAP,
+            0,
+        );
     }
 
     fn attach_empty_node(&mut self, slot: u32, level: usize) {
@@ -429,10 +438,7 @@ impl Graph {
         let span = self.node_levels.len();
         let upper = &mut self.upper[layer - 1];
         if upper.dense_of_slot.len() < span {
-            upper
-                .dense_of_slot
-                .reserve_exact(span - upper.dense_of_slot.len());
-            upper.dense_of_slot.resize(span, ABSENT_DENSE);
+            grow_amortized(&mut upper.dense_of_slot, span, ABSENT_DENSE);
         }
         let dense = match upper.free.pop() {
             Some(dense) => dense,
@@ -1937,6 +1943,55 @@ mod tests {
             .map(|&(_, slot)| arena.key_of_slot(slot).unwrap())
             .collect();
         assert_eq!(keys(&found), expected);
+    }
+
+    #[test]
+    fn reserve_slots_grows_the_slot_arrays_a_bounded_number_of_times() {
+        let mut graph = Graph::new();
+        let mut reallocations = 0;
+        let mut capacity = graph.zero_neighbors.capacity();
+        for slots in 1..=20_000 {
+            graph.reserve_slots(slots);
+            if graph.zero_neighbors.capacity() != capacity {
+                capacity = graph.zero_neighbors.capacity();
+                reallocations += 1;
+            }
+        }
+        assert!(reallocations < 64, "{reallocations} reallocations");
+        assert_eq!(graph.node_levels.len(), 20_000);
+        for (len, capacity) in [
+            (graph.node_levels.len(), graph.node_levels.capacity()),
+            (graph.zero_lengths.len(), graph.zero_lengths.capacity()),
+            (graph.zero_neighbors.len(), graph.zero_neighbors.capacity()),
+        ] {
+            assert!(
+                capacity <= len + len / 8 + MIN_GROWTH_SPARE,
+                "{capacity} reserved for {len}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_parts_reserves_the_slot_arrays_exactly() {
+        let (arena, graph) = build_fixture(1500, 16, 0x8100_0000);
+        let slots = arena.slot_count();
+        assert!(slots >= 1024);
+        let rebuilt = Graph::from_parts(
+            graph.entry_point(),
+            graph_parts(&graph),
+            slots,
+            graph.insert_ordinal(),
+        )
+        .unwrap();
+        assert_eq!(rebuilt.node_levels.capacity(), slots);
+        assert_eq!(rebuilt.zero_lengths.capacity(), slots);
+        assert_eq!(
+            rebuilt.zero_neighbors.capacity(),
+            slots * LEVEL_ZERO_NEIGHBOR_CAP
+        );
+        for upper in &rebuilt.upper {
+            assert_eq!(upper.dense_of_slot.capacity(), slots);
+        }
     }
 
     #[test]

--- a/rust/crates/ml/src/vecdb/kernel.rs
+++ b/rust/crates/ml/src/vecdb/kernel.rs
@@ -6,6 +6,10 @@ const I8_LIMIT: f32 = 127.0;
 pub(crate) const MAX_DIMS_I8: usize =
     (i32::MAX / ((I8_LIMIT as i32) * (I8_LIMIT as i32))) as usize / LANE_WIDTH_I8 * LANE_WIDTH_I8;
 
+pub(crate) fn is_within_quantized_range(value: i8) -> bool {
+    i32::from(value).abs() <= I8_LIMIT as i32
+}
+
 #[repr(C, align(32))]
 #[derive(Clone, Copy)]
 pub(crate) struct Lane([f32; LANE_WIDTH]);
@@ -262,6 +266,14 @@ mod tests {
         let mut values = vec![0.0; dims];
         values[axis] = 1.0;
         values
+    }
+
+    #[test]
+    fn the_quantized_range_excludes_only_the_int8_minimum() {
+        assert!(is_within_quantized_range(I8_LIMIT as i8));
+        assert!(is_within_quantized_range(-(I8_LIMIT as i8)));
+        assert!(is_within_quantized_range(0));
+        assert!(!is_within_quantized_range(i8::MIN));
     }
 
     #[test]

--- a/rust/crates/ml/src/vecdb/kernel.rs
+++ b/rust/crates/ml/src/vecdb/kernel.rs
@@ -167,13 +167,15 @@ pub(crate) struct I8Kernel;
 impl I8Kernel {
     pub(crate) fn dot(a: &[LaneI8], b: &[LaneI8]) -> i32 {
         debug_assert_eq!(a.len(), b.len());
-        let mut partials = [0i32; LANE_WIDTH_I8];
-        for (x, y) in a.iter().zip(b.iter()) {
-            for (partial, (left, right)) in partials.iter_mut().zip(x.0.iter().zip(&y.0)) {
-                *partial += i32::from(*left) * i32::from(*right);
+        let mut total = 0i32;
+        for (x, y) in a.iter().zip(b) {
+            let mut lane = 0i32;
+            for (left, right) in x.0.iter().zip(&y.0) {
+                lane += i32::from(*left) * i32::from(*right);
             }
+            total += lane;
         }
-        partials.iter().sum()
+        total
     }
 
     pub(crate) fn distance(a: &[LaneI8], scale_a: f32, b: &[LaneI8], scale_b: f32) -> f32 {

--- a/rust/crates/ml/src/vecdb/log.rs
+++ b/rust/crates/ml/src/vecdb/log.rs
@@ -6,7 +6,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::arena::{MAX_KEY_BYTES, validate_key};
 use super::crc::{Crc32, crc32};
-use super::kernel::{StoredVector, VectorPayload, splitmix64, validate_dims};
+use super::kernel::{
+    StoredVector, VectorPayload, is_within_quantized_range, splitmix64, validate_dims,
+};
 use super::{AttrValue, Attribute, StorageKind, VecDbError};
 
 pub(crate) const HEADER_LEN: usize = 32;
@@ -527,35 +529,39 @@ fn decode_body(
         return Some(LogRecord::Tombstone { key });
     }
     let (payload, attr_bytes) = rest.split_at(vector_payload_len(storage, dims));
-    let vector = decode_vector(storage, payload);
+    let vector = decode_vector(storage, payload)?;
     let attrs = decode_attrs(attr_bytes)?;
     Some(LogRecord::Add { key, vector, attrs })
 }
 
-fn decode_vector(storage: StorageKind, payload: &[u8]) -> StoredVector {
+fn decode_vector(storage: StorageKind, payload: &[u8]) -> Option<StoredVector> {
     match storage {
-        StorageKind::F32 => StoredVector::F32(
+        StorageKind::F32 => Some(StoredVector::F32(
             payload
                 .as_chunks::<4>()
                 .0
                 .iter()
                 .map(|bytes| f32::from_le_bytes(*bytes))
                 .collect(),
-        ),
+        )),
         StorageKind::I8 => {
             let (scale_bytes, values) = payload.split_at(size_of::<f32>());
-            StoredVector::I8 {
+            let values: Vec<i8> = values
+                .iter()
+                .map(|&byte| i8::from_le_bytes([byte]))
+                .collect();
+            if !values.iter().all(|&value| is_within_quantized_range(value)) {
+                return None;
+            }
+            Some(StoredVector::I8 {
                 scale: f32::from_le_bytes([
                     scale_bytes[0],
                     scale_bytes[1],
                     scale_bytes[2],
                     scale_bytes[3],
                 ]),
-                values: values
-                    .iter()
-                    .map(|&byte| i8::from_le_bytes([byte]))
-                    .collect(),
-            }
+                values,
+            })
         }
     }
 }
@@ -2542,6 +2548,39 @@ mod tests {
             },
         );
         bytes
+    }
+
+    #[test]
+    fn scanner_stops_at_an_int8_payload_outside_the_quantized_range() {
+        let dims = 32usize;
+        let scale = 0.25f32;
+        let within_range = vec![3i8; dims];
+        let mut beyond_range = vec![5i8; dims];
+        beyond_range[7] = i8::MIN;
+        let first = encoded_i8_add("first", scale, &within_range);
+        let rejected = encoded_i8_add("rejected", scale, &beyond_range);
+        let survivor = encoded_i8_add("survivor", scale, &within_range);
+        let dir = TempDir::new().unwrap();
+        let cases = [
+            ("mid-log", [rejected.clone(), survivor].concat(), true),
+            ("tail", rejected, false),
+        ];
+        for (name, after_first, intact_record_beyond) in cases {
+            let path = dir.path().join(name);
+            let mut bytes = encode_header(dims as u32, &[9u8; 16], StorageKind::I8).to_vec();
+            bytes.extend_from_slice(&first);
+            bytes.extend_from_slice(&after_first);
+            std::fs::write(&path, &bytes).unwrap();
+            let mut log = reopen(&path, dims);
+            let (records, recoverable_end) = scan_all(&mut log);
+            assert_eq!(records.len(), 1);
+            assert!(matches!(&records[0].0, LogRecord::Add { key, .. } if key == "first"));
+            assert_eq!(recoverable_end, HEADER_LEN as u64 + first.len() as u64);
+            assert_eq!(
+                log.tail_contains_valid_record(recoverable_end).unwrap(),
+                intact_record_beyond
+            );
+        }
     }
 
     fn write_i8_log_file(path: &Path, dims: u32, record_bytes: &[u8]) {


### PR DESCRIPTION
Two independent single-thread performance fixes for the vecdb engine, found while comparing the Pixel 8 against the Mac. Engine-only (`graph.rs`, `kernel.rs`), zero dependencies, zero unsafe, no format change, and every observable result is unchanged: snapshots built by the parent and by this branch are byte-identical for f32 and i8 across build, churn and reopen, and search/stored-key digests match.

**1. Graph slot arrays grow amortized instead of one slot at a time.** Every incremental insert grew `node_levels`, `zero_lengths`, `zero_neighbors` and the upper-level slot maps with `reserve_exact` for exactly one more slot. macOS extends large blocks in place so it never showed; Android's Scudo allocator copies the whole block on each growth, which is why bulk add on a Pixel 8 measured 1.4–2.6× slower than the same engine's own full rebuild (a rebuild reserves once because the arena is already full). Growth now reserves `max(requested, len + max(len/8, 1024))`, so over-allocation stays ≤12.5% and reallocations are amortized. On an arm64 Android emulator (same allocator) bulk add at 50k went from 1.26/1.18 ms per vector to 0.72/0.73 with rebuild unchanged as the control; the within-run bulk-add ÷ rebuild-per-vector ratio went from 1.7–1.8 to 1.0–1.1. Mac numbers are unaffected. Reported memory rises by up to 0.6% because it sums capacity. A new test fails with 20,000 reallocations on the old code and passes with 46.

**2. The int8 dot is reduced per lane so LLVM emits `sdot`.** The kernel kept 32 independent i32 partials, mirroring the shape the f32 kernel needs. Integer sums are order-independent, and that shape blocked the instruction we want: the crate's release assembly had 0 `sdot`. A per-lane reduction gives 2 `sdot` inside the i8 distance path and the function collapses from 236 instructions with spilled accumulators to 31 with no stack frame. Kernel microbench over 200k 512-d vectors: 14.5 → 8.7 ns per vector. Engine A/B on the Mac at 100k i8, three interleaved rounds, median branch/base: exact search 0.79×, threshold 0.89×, stored-key 0.89×, approx 0.89×, bulk add 0.75×, rebuild 0.61×; f32 within noise. Results are bit-identical (verified against the old shape over 120 cases up to `MAX_DIMS_I8`, saturated and mixed, with overflow checks on). `dotprod` is in the `aarch64-apple-darwin` baseline but not in `aarch64-linux-android` or `aarch64-apple-ios`; by decision we neither enable it there nor dispatch at runtime, and those targets measure neutral for either shape. The commit body records that the shape must be preserved, as the f32 kernel's independent accumulators must be.
