### PR TITLE
[mob][photos] Refresh person cover photo picker

### DIFF
--- a/mobile/apps/photos/changes/person-cover-photo-sheet.md
+++ b/mobile/apps/photos/changes/person-cover-photo-sheet.md
@@ -1,0 +1,1 @@
+- Updated the person cover photo picker to match the current Photos interface.

--- a/mobile/apps/photos/lib/ui/viewer/gallery/hooks/pick_person_avatar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/hooks/pick_person_avatar.dart
@@ -1,6 +1,7 @@
+import "package:ente_components/ente_components.dart";
 import "package:ente_strings/ente_strings.dart";
 import "package:flutter/material.dart";
-import "package:modal_bottom_sheet/modal_bottom_sheet.dart";
+import "package:hugeicons/hugeicons.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/events/people_changed_event.dart";
 import "package:photos/models/file_load_result.dart";
@@ -8,12 +9,6 @@ import "package:photos/models/ml/face/person.dart";
 import "package:photos/models/selected_files.dart";
 import "package:photos/services/machine_learning/face_ml/person/person_service.dart";
 import "package:photos/services/search_service.dart";
-import "package:photos/theme/colors.dart";
-import "package:photos/theme/ente_theme.dart";
-import "package:photos/ui/components/bottom_of_title_bar_widget.dart";
-import "package:photos/ui/components/buttons/button_widget.dart";
-import "package:photos/ui/components/models/button_type.dart";
-import "package:photos/ui/components/title_bar_title_widget.dart";
 import "package:photos/ui/notification/toast.dart";
 import "package:photos/ui/viewer/gallery/gallery.dart";
 import "package:photos/ui/viewer/gallery/state/gallery_files_inherited_widget.dart";
@@ -22,30 +17,44 @@ Future<dynamic> showPersonAvatarPhotoSheet(
   BuildContext context,
   PersonEntity person,
 ) async {
-  return await showBarModalBottomSheet(
+  return await showBottomSheetComponent(
     context: context,
-    builder: (context) {
-      return PickPersonCoverPhotoWidget(person);
-    },
-    shape: const RoundedRectangleBorder(
-      side: BorderSide(width: 0),
-      borderRadius: BorderRadius.vertical(top: Radius.circular(5)),
-    ),
-    topControl: const SizedBox.shrink(),
-    backgroundColor: getEnteColorScheme(context).backgroundElevated,
-    barrierColor: backdropFaintDark,
+    builder: (_) => PickPersonCoverPhotoWidget(person),
     enableDrag: true,
   );
 }
 
-class PickPersonCoverPhotoWidget extends StatelessWidget {
+class PickPersonCoverPhotoWidget extends StatefulWidget {
   final PersonEntity personEntity;
 
   const PickPersonCoverPhotoWidget(this.personEntity, {super.key});
 
+  @override
+  State<PickPersonCoverPhotoWidget> createState() =>
+      _PickPersonCoverPhotoWidgetState();
+}
+
+class _PickPersonCoverPhotoWidgetState
+    extends State<PickPersonCoverPhotoWidget> {
+  late final SelectedFiles _selectedFiles;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedFiles = SelectedFiles()..addListener(_onSelectionChanged);
+  }
+
+  @override
+  void dispose() {
+    _selectedFiles.dispose();
+    super.dispose();
+  }
+
+  void _onSelectionChanged() => setState(() {});
+
   Future<FileLoadResult> loadPersonFiles() async {
     final sortedFiles = await SearchService.instance.getFilesForPersonID(
-      personEntity.remoteID,
+      widget.personEntity.remoteID,
       includeManualAssigned: false,
       sortOnTime: true,
     );
@@ -54,109 +63,102 @@ class PickPersonCoverPhotoWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ValueNotifier<bool> isFileSelected = ValueNotifier(false);
-    final selectedFiles = SelectedFiles();
-    selectedFiles.addListener(() {
-      isFileSelected.value = selectedFiles.files.isNotEmpty;
-    });
+    final l10n = context.strings;
+    final hasSelection = _selectedFiles.files.isNotEmpty;
 
+    return SizedBox(
+      height: MediaQuery.sizeOf(context).height,
+      child: BottomSheetComponent(
+        header: const _PickPersonCoverPhotoHeader(),
+        showCloseButton: false,
+        padding: const EdgeInsets.symmetric(vertical: Spacing.xl),
+        content: Expanded(
+          child: GalleryFilesState(
+            child: Gallery(
+              asyncLoader:
+                  (creationStartTime, creationEndTime, {limit, asc}) async {
+                    final FileLoadResult result = await loadPersonFiles();
+                    return result;
+                  },
+              tagPrefix: "pick_center_point_gallery",
+              selectedFiles: _selectedFiles,
+              limitSelectionToOne: true,
+              showSelectAll: false,
+              disablePinnedGroupHeader: true,
+              disableVerticalPaddingForScrollbar: true,
+            ),
+          ),
+        ),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: Spacing.xl),
+            child: ButtonComponent(
+              isDisabled: !hasSelection,
+              label: l10n.useSelectedPhoto,
+              density: ButtonComponentDensity.compact,
+              shouldShowSuccessState: false,
+              onTap: hasSelection
+                  ? () async {
+                      final selectedFile = _selectedFiles.files.first;
+                      final result = await PersonService.instance.updateAvatar(
+                        widget.personEntity,
+                        selectedFile,
+                      );
+                      Bus.instance.fire(
+                        PeopleChangedEvent(
+                          type: PeopleEventType.saveOrEditPerson,
+                          person: result.person,
+                        ),
+                      );
+                      if (!context.mounted) return;
+                      if (result.contactPictureUpdateFailed) {
+                        showShortToast(
+                          context,
+                          "Failed to update contact picture",
+                        );
+                      }
+                      Navigator.pop(context, result.person);
+                    }
+                  : null,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PickPersonCoverPhotoHeader extends StatelessWidget {
+  const _PickPersonCoverPhotoHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.strings;
+    final colors = context.componentColors;
     return Padding(
-      padding: const EdgeInsets.fromLTRB(0, 32, 0, 8),
+      padding: const EdgeInsets.symmetric(horizontal: Spacing.xl),
       child: SizedBox(
-        width: double.infinity,
-        child: Column(
-          mainAxisSize: MainAxisSize.max,
+        height: 38,
+        child: Row(
           children: [
             Expanded(
-              child: Column(
-                children: [
-                  BottomOfTitleBarWidget(
-                    title: TitleBarTitleWidget(
-                      title: context.strings.selectCoverPhoto,
-                    ),
-                    caption: personEntity.data.name,
-                    showCloseButton: true,
-                  ),
-                  Expanded(
-                    child: GalleryFilesState(
-                      child: Gallery(
-                        asyncLoader:
-                            (
-                              creationStartTime,
-                              creationEndTime, {
-                              limit,
-                              asc,
-                            }) async {
-                              final FileLoadResult result =
-                                  await loadPersonFiles();
-
-                              return result;
-                            },
-                        tagPrefix: "pick_center_point_gallery",
-                        selectedFiles: selectedFiles,
-                        limitSelectionToOne: true,
-                        showSelectAll: false,
-                        disablePinnedGroupHeader: true,
-                        disableVerticalPaddingForScrollbar: true,
-                      ),
-                    ),
-                  ),
-                ],
+              child: Text(
+                l10n.selectCoverPhoto,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyles.h1Bold.copyWith(color: colors.textBase),
               ),
             ),
-            SafeArea(
-              child: Container(
-                decoration: BoxDecoration(
-                  border: Border(
-                    top: BorderSide(
-                      color: getEnteColorScheme(context).strokeFaint,
-                    ),
-                  ),
-                ),
-                child: Center(
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 428),
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 15, 16, 8),
-                      child: ValueListenableBuilder(
-                        valueListenable: isFileSelected,
-                        builder: (context, bool value, _) {
-                          return AnimatedSwitcher(
-                            duration: const Duration(milliseconds: 300),
-                            switchInCurve: Curves.easeInOutExpo,
-                            switchOutCurve: Curves.easeInOutExpo,
-                            child: ButtonWidget(
-                              key: ValueKey(value),
-                              isDisabled: !value,
-                              buttonType: ButtonType.neutral,
-                              labelText: context.strings.useSelectedPhoto,
-                              onTap: () async {
-                                final selectedFile = selectedFiles.files.first;
-                                final result = await PersonService.instance
-                                    .updateAvatar(personEntity, selectedFile);
-                                Bus.instance.fire(
-                                  PeopleChangedEvent(
-                                    type: PeopleEventType.saveOrEditPerson,
-                                    person: result.person,
-                                  ),
-                                );
-                                if (!context.mounted) return;
-                                if (result.contactPictureUpdateFailed) {
-                                  showShortToast(
-                                    context,
-                                    "Failed to update contact picture",
-                                  );
-                                }
-                                Navigator.pop(context, result.person);
-                              },
-                            ),
-                          );
-                        },
-                      ),
-                    ),
-                  ),
-                ),
+            const SizedBox(width: Spacing.md),
+            IconButtonComponent(
+              tooltip: l10n.close,
+              variant: IconButtonComponentVariant.circular,
+              shouldSurfaceExecutionStates: false,
+              icon: const HugeIcon(
+                icon: HugeIcons.strokeRoundedCancel01,
+                size: IconSizes.small,
               ),
+              onTap: () => Navigator.of(context).pop(),
             ),
           ],
         ),


### PR DESCRIPTION
Updates the person cover photo picker to use the current Photos bottom sheet and button components.

## Screenshots

Before / After

<img src="https://github.com/user-attachments/assets/610bb111-3fe0-4e8f-aad7-1225d57432d7" alt="Before: legacy person cover photo picker" width="300" height="650" /> <img src="https://github.com/user-attachments/assets/d07e3505-1f5c-4bb1-800a-7765b3971b46" alt="After: refreshed person cover photo picker" width="300" height="650" />
