### PR TITLE
[mob][photos] Center video download progress

### DIFF
--- a/mobile/apps/photos/changes/video-download-progress-alignment.md
+++ b/mobile/apps/photos/changes/video-download-progress-alignment.md
@@ -1,0 +1,1 @@
+- Fixed video download progress appearing away from the center of the viewer.

--- a/mobile/apps/photos/lib/ui/viewer/file/video_download_progress_indicator.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_download_progress_indicator.dart
@@ -1,0 +1,45 @@
+import "package:ente_ui/components/loading_widget.dart";
+import "package:flutter/material.dart";
+import "package:photos/theme/colors.dart";
+import "package:photos/theme/ente_theme.dart";
+
+class VideoDownloadProgressIndicator extends StatelessWidget {
+  final double? progress;
+
+  const VideoDownloadProgressIndicator({required this.progress, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = this.progress;
+    if (progress == null || progress == 1) {
+      return const EnteLoadingWidget(size: 32, color: fillBaseDark, padding: 0);
+    }
+
+    return SizedBox.square(
+      dimension: 32,
+      child: Stack(
+        fit: StackFit.expand,
+        alignment: Alignment.center,
+        children: [
+          CircularProgressIndicator(
+            backgroundColor: Colors.transparent,
+            value: progress,
+            valueColor: const AlwaysStoppedAnimation<Color>(
+              Color.fromRGBO(45, 194, 98, 1.0),
+            ),
+            strokeWidth: 2,
+            strokeCap: StrokeCap.round,
+          ),
+          Center(
+            child: Text(
+              "${(progress * 100).toStringAsFixed(0)}%",
+              style: getEnteTextTheme(
+                context,
+              ).tiny.copyWith(color: textBaseDark),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_media_kit.dart
@@ -2,7 +2,6 @@ import "dart:async";
 import "dart:io";
 
 import "package:ente_strings/ente_strings.dart";
-import "package:ente_ui/components/loading_widget.dart";
 import "package:flutter/material.dart";
 import "package:logging/logging.dart";
 import "package:media_kit/media_kit.dart";
@@ -23,10 +22,9 @@ import "package:photos/service_locator.dart";
 import "package:photos/services/files_service.dart";
 import "package:photos/services/wake_lock_service.dart";
 import "package:photos/states/detail_page_state.dart";
-import "package:photos/theme/colors.dart";
-import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/actions/file/file_actions.dart";
 import "package:photos/ui/notification/toast.dart";
+import "package:photos/ui/viewer/file/video_download_progress_indicator.dart";
 import "package:photos/ui/viewer/file/video_widget_media_kit_common.dart"
     as common;
 import "package:photos/utils/dialog_util.dart";
@@ -270,33 +268,7 @@ class _VideoWidgetMediaKitState extends State<VideoWidgetMediaKit>
                 child: ValueListenableBuilder(
                   valueListenable: _progressNotifier,
                   builder: (BuildContext context, double? progress, _) {
-                    return progress == null || progress == 1
-                        ? const EnteLoadingWidget(
-                            size: 32,
-                            color: fillBaseDark,
-                            padding: 0,
-                          )
-                        : Stack(
-                            children: [
-                              CircularProgressIndicator(
-                                backgroundColor: Colors.transparent,
-                                value: progress,
-                                valueColor: const AlwaysStoppedAnimation<Color>(
-                                  Color.fromRGBO(45, 194, 98, 1.0),
-                                ),
-                                strokeWidth: 2,
-                                strokeCap: StrokeCap.round,
-                              ),
-                              Center(
-                                child: Text(
-                                  "${(progress * 100).toStringAsFixed(0)}%",
-                                  style: getEnteTextTheme(
-                                    context,
-                                  ).tiny.copyWith(color: textBaseDark),
-                                ),
-                              ),
-                            ],
-                          );
+                    return VideoDownloadProgressIndicator(progress: progress);
                   },
                 ),
               ),

--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -3,7 +3,6 @@ import "dart:io";
 
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_strings/ente_strings.dart";
-import "package:ente_ui/components/loading_widget.dart";
 import "package:flutter/material.dart";
 import "package:logging/logging.dart";
 import "package:native_video_player/native_video_player.dart";
@@ -28,7 +27,6 @@ import "package:photos/services/files_service.dart";
 import "package:photos/services/wake_lock_service.dart";
 import "package:photos/states/detail_page_state.dart";
 import "package:photos/theme/colors.dart";
-import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/actions/file/file_actions.dart";
 import "package:photos/ui/notification/toast.dart";
 import "package:photos/ui/viewer/file/native_video_player_controls/play_pause_button.dart";
@@ -36,6 +34,7 @@ import "package:photos/ui/viewer/file/native_video_player_controls/seek_bar.dart
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
 import "package:photos/ui/viewer/file/video_control/gallery_video_controls.dart";
 import "package:photos/ui/viewer/file/video_double_tap_seek.dart";
+import "package:photos/ui/viewer/file/video_download_progress_indicator.dart";
 import "package:photos/ui/viewer/file/video_seek_controller.dart";
 import "package:photos/ui/viewer/file/zoomable_video_viewer.dart";
 import "package:photos/utils/dialog_util.dart";
@@ -779,33 +778,7 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
             child: ValueListenableBuilder(
               valueListenable: _progressNotifier,
               builder: (BuildContext context, double? progress, _) {
-                return progress == null || progress == 1
-                    ? const EnteLoadingWidget(
-                        size: 32,
-                        color: fillBaseDark,
-                        padding: 0,
-                      )
-                    : Stack(
-                        children: [
-                          CircularProgressIndicator(
-                            backgroundColor: Colors.transparent,
-                            value: progress,
-                            valueColor: const AlwaysStoppedAnimation<Color>(
-                              Color.fromRGBO(45, 194, 98, 1.0),
-                            ),
-                            strokeWidth: 2,
-                            strokeCap: StrokeCap.round,
-                          ),
-                          Center(
-                            child: Text(
-                              "${(progress * 100).toStringAsFixed(0)}%",
-                              style: getEnteTextTheme(
-                                context,
-                              ).tiny.copyWith(color: textBaseDark),
-                            ),
-                          ),
-                        ],
-                      );
+                return VideoDownloadProgressIndicator(progress: progress);
               },
             ),
           ),

--- a/mobile/apps/photos/test/ui/viewer/file/video_download_progress_indicator_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/file/video_download_progress_indicator_test.dart
@@ -1,0 +1,21 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/ui/viewer/file/video_download_progress_indicator.dart";
+
+void main() {
+  testWidgets("centers determinate video download progress", (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(child: VideoDownloadProgressIndicator(progress: 0.42)),
+        ),
+      ),
+    );
+
+    final ring = find.byType(CircularProgressIndicator);
+    final percentage = find.text("42%");
+
+    expect(tester.getSize(ring), const Size.square(32));
+    expect(tester.getCenter(ring), tester.getCenter(percentage));
+  });
+}


### PR DESCRIPTION
## Summary

- constrain determinate video download progress to a centered 32px square
- share the indicator implementation between native and MediaKit players
- add focused regression coverage and a mobile Photos change entry

This follows the gallery viewer filmstrip work in #12676. The separately parked photo handoff-readiness experiment is not included.

## Validation

- flutter test test/ui/viewer/file/video_download_progress_indicator_test.dart
- dart analyze lib/ui/viewer/file/video_download_progress_indicator.dart lib/ui/viewer/file/video_widget_media_kit.dart lib/ui/viewer/file/video_widget_native.dart test/ui/viewer/file/video_download_progress_indicator_test.dart
- dart format verification
- git diff --check