### PR TITLE
[mob][photos] Avoid unnecessary gallery group selection work

### DIFF
--- a/mobile/apps/photos/changes/gallery-performance-improvements.md
+++ b/mobile/apps/photos/changes/gallery-performance-improvements.md
@@ -1,0 +1,1 @@
+- Gallery performance improvements.

--- a/mobile/apps/photos/lib/ui/viewer/gallery/component/group/group_header_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/component/group/group_header_widget.dart
@@ -177,12 +177,7 @@ class _GroupHeaderWidgetState extends State<GroupHeaderWidget> {
   }
 
   void _selectedFilesListener() {
-    if (widget.selectedFiles == null) return;
-    final nonDummyFiles = widget.filesInGroup
-        .where((file) => file is! DummyFile)
-        .toSet();
-    _areAllFromGroupSelectedNotifier.value = widget.selectedFiles!.files
-        .containsAll(nonDummyFiles);
+    _areAllFromGroupSelectedNotifier.value = _areAllFromGroupSelected();
   }
 
   Widget _buildSelectionIcon(bool isSelected) {
@@ -209,15 +204,11 @@ class _GroupHeaderWidgetState extends State<GroupHeaderWidget> {
   }
 
   bool _areAllFromGroupSelected() {
-    final nonDummyFiles = widget.filesInGroup
+    final selectedFiles = widget.selectedFiles?.files;
+    if (selectedFiles == null || selectedFiles.isEmpty) return false;
+    return widget.filesInGroup
         .where((file) => file is! DummyFile)
-        .toSet();
-    if (widget.selectedFiles != null &&
-        widget.selectedFiles!.files.length >= nonDummyFiles.length) {
-      return widget.selectedFiles!.files.containsAll(nonDummyFiles);
-    } else {
-      return false;
-    }
+        .every(selectedFiles.contains);
   }
 
   void _showLayoutSettingsOverflowMenu(BuildContext context) {

--- a/mobile/apps/photos/test/ui/viewer/gallery/component/group_header_widget_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/gallery/component/group_header_widget_test.dart
@@ -1,0 +1,115 @@
+import "dart:collection";
+
+import "package:ente_strings/ente_strings.dart";
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:photos/ente_theme_data.dart";
+import "package:photos/models/file/dummy_file.dart";
+import "package:photos/models/file/file.dart";
+import "package:photos/models/selected_files.dart";
+import "package:photos/ui/viewer/actions/select_all_status_icon.dart";
+import "package:photos/ui/viewer/gallery/component/group/group_header_widget.dart";
+
+void main() {
+  testWidgets("unselected date headers do not traverse their file groups", (
+    tester,
+  ) async {
+    final selectedFiles = SelectedFiles();
+    final files = _CountingFiles(
+      List.generate(1000, (index) => EnteFile()..generatedID = index),
+    );
+    await tester.pumpWidget(_header(files, selectedFiles, "First date"));
+    expect(files.reads, 0);
+
+    await tester.pumpWidget(_header(files, selectedFiles, "Next date"));
+    expect(files.reads, 0);
+
+    selectedFiles.selectAll({files.first});
+    await tester.pump();
+    expect(files.reads, greaterThan(0));
+    files.reads = 0;
+    selectedFiles.clearAll(fireEvent: false);
+    await tester.pump();
+    expect(files.reads, 0);
+    expect(_isSelected(tester), isFalse);
+    await tester.pumpWidget(const SizedBox.shrink());
+    selectedFiles.dispose();
+  });
+
+  testWidgets("group selection still ignores dummy cells", (tester) async {
+    final selectedFiles = SelectedFiles();
+    final first = EnteFile()..generatedID = 1;
+    final second = EnteFile()..generatedID = 2;
+    await tester.pumpWidget(
+      _header(
+        [first, second, DummyFile(groupID: "date", index: 0)],
+        selectedFiles,
+        "Date",
+      ),
+    );
+    expect(_isSelected(tester), isFalse);
+    selectedFiles.selectAll({first});
+    await tester.pump();
+    expect(_isSelected(tester), isFalse);
+    selectedFiles.selectAll({second});
+    await tester.pump();
+    expect(_isSelected(tester), isTrue);
+    selectedFiles.clearAll(fireEvent: false);
+    await tester.pump();
+    expect(_isSelected(tester), isFalse);
+    await tester.pumpWidget(const SizedBox.shrink());
+    selectedFiles.dispose();
+  });
+}
+
+bool _isSelected(WidgetTester tester) {
+  return tester
+      .widget<SelectAllStatusIcon>(find.byType(SelectAllStatusIcon))
+      .isSelected;
+}
+
+Widget _header(
+  List<EnteFile> files,
+  SelectedFiles selectedFiles,
+  String title,
+) {
+  return MaterialApp(
+    theme: lightThemeData,
+    localizationsDelegates: StringsLocalizations.localizationsDelegates,
+    supportedLocales: StringsLocalizations.supportedLocales,
+    home: Align(
+      alignment: Alignment.topLeft,
+      child: GroupHeaderWidget(
+        title: title,
+        gridSize: 4,
+        filesInGroup: files,
+        selectedFiles: selectedFiles,
+        showSelectAll: true,
+      ),
+    ),
+  );
+}
+
+class _CountingFiles extends ListBase<EnteFile> {
+  _CountingFiles(this._files);
+
+  final List<EnteFile> _files;
+  int reads = 0;
+
+  @override
+  int get length => _files.length;
+
+  @override
+  set length(int value) => throw UnsupportedError("Read-only test list");
+
+  @override
+  EnteFile operator [](int index) {
+    reads++;
+    return _files[index];
+  }
+
+  @override
+  void operator []=(int index, EnteFile value) {
+    throw UnsupportedError("Read-only test list");
+  }
+}


### PR DESCRIPTION
## Description

Gallery date headers currently traverse their file groups and allocate a temporary set when calculating select-all state, including when no files are selected. Return immediately for an absent or empty selection, and otherwise check real files lazily, stopping at the first unselected file. Reuse the same calculation for initialization and selection updates while continuing to ignore dummy grid cells.

## Tests

- Widget regression verifies that an empty selection does not read group files on initial mount, date changes, or selection clearing.
- Widget coverage verifies partial, full, and cleared group selection with dummy cells present.

Validation passed:

- `flutter test --no-pub test/ui/viewer/gallery/component/group_header_widget_test.dart` — 2 tests passed.
- `flutter analyze --no-pub lib/ui/viewer/gallery/component/group/group_header_widget.dart test/ui/viewer/gallery/component/group_header_widget_test.dart` — no issues.
- Formatting and `git diff --check` passed.
