### PR TITLE
apz/memlane/fixlayoutshift

### DIFF
--- a/mobile/apps/photos/lib/ui/home/memories/memories_strip.dart
+++ b/mobile/apps/photos/lib/ui/home/memories/memories_strip.dart
@@ -11,7 +11,6 @@ import "package:photos/db/ml/db.dart";
 import "package:photos/db/offline_files_db.dart";
 import "package:photos/events/collection_updated_event.dart";
 import "package:photos/events/diff_sync_complete_event.dart";
-import "package:photos/events/event.dart";
 import "package:photos/events/files_updated_event.dart";
 import "package:photos/events/local_photos_updated_event.dart";
 import "package:photos/events/memories_changed_event.dart";
@@ -74,30 +73,26 @@ class _MemoriesStripWidgetState extends State<MemoriesStripWidget> {
   final _videoPrefetcher = MemoryVideoPrefetcher();
   final _scrollController = ScrollController();
   bool _shouldShowCraftingMemories = false;
-  late Future<void> _shouldShowCraftingMemoriesLoaded;
-  late final Future<void> _memoryLaneLoaded;
-  late List<SmartMemory> _initialMemories;
-  late Future<List<SmartMemory>> _memories;
+  List<SmartMemory> _memories = [];
+  late final Future<void> _cardDataLoaded;
 
   @override
   void initState() {
     super.initState();
-    _initialMemories = _getInitialMemories();
-    _shouldShowCraftingMemoriesLoaded = CraftingMemoriesCardWidget.shouldShow()
-        .then((value) {
-          _shouldShowCraftingMemories = value;
-        });
-
-    _fetchMemories(null);
+    _cardDataLoaded = Future.wait<void>([
+      _fetchMemories(),
+      _fetchMemoryLane(),
+      _fetchCraftingMemoriesShouldShow(),
+    ]);
 
     _memoriesSettingSubscription = Bus.instance
         .on<MemoriesSettingChanged>()
-        .listen(_fetchMemories);
+        .listen((_) => _fetchMemories());
     _memoriesChangedSubscription = Bus.instance
         .on<MemoriesChangedEvent>()
-        .listen(_fetchMemories);
+        .listen((_) => _fetchMemories());
     _memorySeenSubscription = Bus.instance.on<MemorySeenEvent>().listen(
-      _fetchMemories,
+      (_) => _fetchMemories(),
     );
     _mlConsentChangedSubscription = Bus.instance
         .on<MLConsentChangedEvent>()
@@ -114,7 +109,6 @@ class _MemoriesStripWidgetState extends State<MemoriesStripWidget> {
     _diffSyncCompleteSubscription = Bus.instance
         .on<DiffSyncCompleteEvent>()
         .listen((_) => _hideMemoryLaneIfFilesMissingOrHidden());
-    _memoryLaneLoaded = _loadScheduledMemoryLane();
     MemoryLaneService.instance.readyPersonIds.addListener(
       _onMemoryLaneReadyTimelinesChanged,
     );
@@ -162,45 +156,36 @@ class _MemoriesStripWidgetState extends State<MemoriesStripWidget> {
       return const SizedBox.shrink();
     }
     return FutureBuilder(
-      future: _memories,
-      initialData: _initialMemories,
+      future: _cardDataLoaded,
       builder: (context, snapshot) {
-        final memories = snapshot.data ?? [];
-        return FutureBuilder(
-          future: _shouldShowCraftingMemoriesLoaded,
-          builder: (context, _) {
-            final cardHeight = _cardWidth / kMemoryCardAspectRatio;
-            return FutureBuilder(
-              future: _memoryLaneLoaded,
-              builder: (context, _) {
-                final cards = _buildCards(memories, cardHeight);
-                if (cards.isEmpty) {
-                  return const SizedBox.shrink();
-                }
-                return Padding(
-                  padding: const EdgeInsets.only(top: 12, bottom: 10),
-                  child: SizedBox(
-                    height: cardHeight + 2,
-                    child: ListView.builder(
-                      controller: _scrollController,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: kMemoryCardStripGap / 2.0,
-                      ),
-                      physics: const AlwaysScrollableScrollPhysics(
-                        parent: BouncingScrollPhysics(),
-                      ),
-                      scrollDirection: Axis.horizontal,
-                      itemCount: cards.length,
-                      itemBuilder: (context, i) => KeyedSubtree(
-                        key: ValueKey(cards[i].id),
-                        child: cards[i].widget(),
-                      ),
-                    ),
-                  ),
-                );
-              },
-            );
-          },
+        final cardHeight = _cardWidth / kMemoryCardAspectRatio;
+        if (snapshot.connectionState != ConnectionState.done) {
+          return SizedBox(height: cardHeight + 24);
+        }
+        final cards = _buildCards(_memories, cardHeight);
+        if (cards.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        return Padding(
+          padding: const EdgeInsets.only(top: 12, bottom: 10),
+          child: SizedBox(
+            height: cardHeight + 2,
+            child: ListView.builder(
+              controller: _scrollController,
+              padding: const EdgeInsets.symmetric(
+                horizontal: kMemoryCardStripGap / 2.0,
+              ),
+              physics: const AlwaysScrollableScrollPhysics(
+                parent: BouncingScrollPhysics(),
+              ),
+              scrollDirection: Axis.horizontal,
+              itemCount: cards.length,
+              itemBuilder: (context, i) => KeyedSubtree(
+                key: ValueKey(cards[i].id),
+                child: cards[i].widget(),
+              ),
+            ),
+          ),
         ).animate().fadeIn(
           duration: const Duration(milliseconds: 250),
           curve: Curves.easeInOutCirc,
@@ -218,14 +203,6 @@ class _MemoriesStripWidgetState extends State<MemoriesStripWidget> {
     });
 
     return indexedMemories.map((entry) => entry.$2).toList();
-  }
-
-  List<SmartMemory> _getInitialMemories() {
-    return _sortMemories(
-      (memoriesCacheService.currentMemoriesSync ?? [])
-          .where((memory) => memory.shouldShowNow())
-          .toList(),
-    );
   }
 
   List<MemoryCardWrapper> _buildCards(
@@ -289,38 +266,33 @@ class _MemoriesStripWidgetState extends State<MemoriesStripWidget> {
     ];
   }
 
-  void _fetchMemories(Event? event) {
+  Future<void> _fetchCraftingMemoriesShouldShow() async {
+    _shouldShowCraftingMemories = await CraftingMemoriesCardWidget.shouldShow();
+  }
+
+  Future<void> _fetchMemories() async {
     final fetchGeneration = ++_fetchMemoriesGeneration;
-    setState(() {
-      if (event is MemoriesSettingChanged &&
-          memoriesCacheService.showAnyMemories) {
-        _initialMemories = _getInitialMemories();
+    try {
+      final memories = _sortMemories(await memoriesCacheService.getMemories());
+      if (!mounted || fetchGeneration != _fetchMemoriesGeneration) {
+        return;
       }
-      _memories = memoriesCacheService
-          .getMemories()
-          .then(_sortMemories)
-          .then((memories) {
-            if (!mounted || fetchGeneration != _fetchMemoriesGeneration) {
-              return memories;
-            }
-            if (_scrollController.hasClients) {
-              _scrollController.jumpTo(0);
-            }
-            if (memories.isEmpty || !memoriesCacheService.showAnyMemories) {
-              _cancelPendingWarm();
-              return <SmartMemory>[];
-            } else {
-              _scheduleWarmCovers(memories);
-            }
-            return memories;
-          })
-          .onError((_, _) {
-            if (mounted && fetchGeneration == _fetchMemoriesGeneration) {
-              _cancelPendingWarm();
-            }
-            return [];
-          });
-    });
+      if (_scrollController.hasClients) {
+        _scrollController.jumpTo(0);
+      }
+      if (memories.isEmpty || !memoriesCacheService.showAnyMemories) {
+        _cancelPendingWarm();
+        setState(() => _memories = []);
+        return;
+      }
+      _scheduleWarmCovers(memories);
+      setState(() => _memories = memories);
+    } catch (_) {
+      if (mounted && fetchGeneration == _fetchMemoriesGeneration) {
+        _cancelPendingWarm();
+        setState(() => _memories = []);
+      }
+    }
   }
 
   void _scheduleWarmCovers(List<SmartMemory> memories) {
@@ -374,7 +346,7 @@ class _MemoriesStripWidgetState extends State<MemoriesStripWidget> {
     _videoPrefetcher.clearPending();
   }
 
-  Future<void> _loadScheduledMemoryLane() async {
+  Future<void> _fetchMemoryLane() async {
     if (!flagService.internalUser) {
       return;
     }


### PR DESCRIPTION
- **[mob][photos] Add filmstrip scrubbing to gallery viewer**
- **[mob][photos] Tighten gallery filmstrip spacing**
- **[mob][photos] Refine gallery filmstrip interactions**
- **[mob][photos] Fix repeated filmstrip flings**
- **[mob][photos] Polish gallery filmstrip lifecycle**
- **[mob][photos] Refactor gallery filmstrip coordination**
- **[mob][photos] Gate gallery filmstrip for internal users**
- **[mob][photos] Move stream switch to viewer menu**
- **[mob][photos] Optimize Rust OCR preprocessing and decoding**
- **[mob][photos] Reduce Rust OCR crop and decoding overhead**
- **[mob][photos] Add Android background processing for ML**
- **[mob][photos] Remove unrelated pet persistence changes**
- **Specify rust is required for building the web application**
- **[mobile][photos] Add Rust-backed ML DB behind rustMlDb flag**
- **vecdb: add opt-in int8 storage with fp32 in and out**
- **vecdb: cap int8 dimensions where a saturated dot product still fits an i32**
- **[mob][photos] Bound Rust OCR recognition memory**
- **docs: clarify Android trash across Photos help**
- **vecdb: judge an existing index by its header before validating the requested storage and dimensions**
- **Fix Rust ML DB file ID set decoding**
- **[mob][photos] Avoid oversized padding in split OCR batches**
- **update(locker):update-settings-sidebar**
- **docs: focus follow-up on Android trash recovery gaps**
- **[mobile][photos] Hide Memory Lane card when person is ignored**
- **Update photos-desktop help changelog for v1.7.29**
- **docs: keep Android recovery guidance under mobile**
- **Move recovery operations to authenticated sessions**
- **Repair stale deleted file memberships**
- **fix-lint**
- **Add Locker document scanner changelog**
- **[mobile][photos] Separate ML DB facade from Dart implementation**
- **[mobile][photos] Initialize ML DB backend during startup**
- **[mobile][photos] Extract Rust ML DB model mappers**
- **[ensu]model-url-update**
- **[ensu] Preserve model selections and downloads across mirror changes**
- **[ensu] Avoid blocking startup during model migration**
- **update(locker):update-ItemDetailView**
- **fix-merge-conflict-issues**
- **Reuse file count initialization scan for repair**
- **New Crowdin translations by GitHub Action**
- **update(locker):trash-page-updated**
- **[mob][photos] Share photos from person pages (#12685)**
- **remove-srcSet-images**
- **remove-srcSet-images**
- **[ensu] Update in-app changelogs for 0.1.20**
- **update(locker):collections-page**
- **[mob][photos] Refine gallery filmstrip previews and scrolling**
- **Simplify stale file membership repair**
- **[mob][photos] Prune redundant filmstrip comments**
- **[mob][photos] Enable gallery filmstrip for all users**
- **[mob][photos] Add gallery filmstrip change entry**
- **[mob][photos] Fix gallery filmstrip lint failures**
- **[mob][photos] Use const filmstrip cache extent**
- **Remove redundant Hidden items overflow menu**
- **Add Android wallpaper setting from Photos**
- **Clarify crop names and remove wallpaper comments**
- **Fix wallpaper orientation, dismissal, and localization**
- **Use Flutter for the wallpaper UI**
- **[locker] Start Locker 1.0.10 (#12745)**
- **Separate change approval policies from reporting**
- **Format JavaScript checks and GitHub scripts**
- **Enforce shared JavaScript formatting for repository checks**
- **Extend JavaScript formatting to scripts directories**
- **refractor(locker):remove-unused-code-deps-and-exports**
- **Add PandaDoc icon (#12753)**
- **Document Hidden items toolbar change**
- **[mobile][photos] scaffold internal memory lane v2 viewer**
- **[mobile] add translucent circular icon button variant**
- **[mobile] add animated digit component**
- **[mobile] add localized memory lane age caption**
- **fixup! [mobile][photos] scaffold internal memory lane v2 viewer**
- **fixup! [mobile] add animated digit component**
- **fixup! [mobile][photos] scaffold internal memory lane v2 viewer**
- **Patch staff and server security dependencies**
- **Centralize validated location reads**
- **Pair ML resources with the state that requires them**
- **Resolve the configured voice activity model path directly**
- **Require explicit exceptions for expect calls**
- **Remove three development expect exemptions**
- **vecdb: grow the graph slot arrays amortized instead of one slot at a time**
- **vecdb: reduce the int8 dot per lane so LLVM emits sdot**
- **Update Go support modules to current stable releases**
- **Scope expect exemptions to individual expressions**
- **Harden Android wallpaper preview**
- **fixup! [mobile][photos] scaffold internal memory lane v2 viewer**
- **fixup! [mobile][photos] scaffold internal memory lane v2 viewer**
- **Start Ensu 0.1.21-beta**
- **fixup! [mobile] add animated digit component**
- **fixup! [mobile][photos] scaffold internal memory lane v2 viewer**
- **fixup! [mobile][photos] scaffold internal memory lane v2 viewer**
- **Test trusted checker execution through the approval workflow**
- **vecdb: treat an int8 log payload outside the quantized range as an undecodable record**
- **[mobile][photos] fix layout shift in memories strip**

## Description

## Tests
