### PR TITLE
feat: self-hosted cast

### DIFF
--- a/apple/apps/cast/Cast/ContentView.swift
+++ b/apple/apps/cast/Cast/ContentView.swift
@@ -40,6 +40,10 @@ struct ContentView: View {
             }
         }
         .animation(.easeInOut(duration: 0.6), value: viewModel.currentView)
+        .developerSettingsGesture(
+            isEnabled: viewModel.currentView != .slideshow,
+            onEndpointChanged: viewModel.restartForEndpointChange
+        )
     }
 }
 

--- a/apple/apps/cast/Cast/Services/CastPairingService.swift
+++ b/apple/apps/cast/Cast/Services/CastPairingService.swift
@@ -34,7 +34,12 @@ class CastSession: ObservableObject {
 }
 
 class RealCastPairingService {
-    private let baseURL = "https://api.ente.com"
+    private var baseURL: String { EndpointConfig.apiOrigin }
+    // Bumped whenever polling starts or stops. A request already in flight
+    // against the previous server finishes with a stale generation and is then
+    // ignored, instead of rescheduling the shared timer or reporting an error
+    // that belongs to a server the user has already moved away from.
+    private var pollingGeneration: Int = 0
     private var pollingTimer: Timer?
     private var isPolling: Bool = false
     private var isFetchingPayload: Bool = false
@@ -101,26 +106,28 @@ class RealCastPairingService {
         isPolling = true
         pollingStartTime = Date()
         hasLoggedIntervalSwitch = false
+        pollingGeneration += 1
         
-        scheduleNextPoll(device: device, onPayloadReceived: onPayloadReceived, onError: onError)
+        scheduleNextPoll(generation: pollingGeneration, device: device, onPayloadReceived: onPayloadReceived, onError: onError)
     }
     
-    private func scheduleNextPoll(device: CastDevice, onPayloadReceived: @escaping (CastPayload) -> Void, onError: @escaping (Error) -> Void) {
-        guard isPolling && !hasDeliveredPayload else { return }
+    private func scheduleNextPoll(generation: Int, device: CastDevice, onPayloadReceived: @escaping (CastPayload) -> Void, onError: @escaping (Error) -> Void) {
+        guard generation == pollingGeneration, isPolling, !hasDeliveredPayload else { return }
         
         let currentInterval = getCurrentPollingInterval()
         pollingTimer = Timer.scheduledTimer(withTimeInterval: currentInterval, repeats: false) { [weak self] _ in
             Task {
-                await self?.checkForPayload(device: device, onPayloadReceived: onPayloadReceived, onError: onError)
+                await self?.checkForPayload(generation: generation, device: device, onPayloadReceived: onPayloadReceived, onError: onError)
                 // Poll again only after this request finishes.
                 await MainActor.run {
-                    self?.scheduleNextPoll(device: device, onPayloadReceived: onPayloadReceived, onError: onError)
+                    self?.scheduleNextPoll(generation: generation, device: device, onPayloadReceived: onPayloadReceived, onError: onError)
                 }
             }
         }
     }
     
-    private func checkForPayload(device: CastDevice, onPayloadReceived: @escaping (CastPayload) -> Void, onError: @escaping (Error) -> Void) async {
+    private func checkForPayload(generation: Int, device: CastDevice, onPayloadReceived: @escaping (CastPayload) -> Void, onError: @escaping (Error) -> Void) async {
+        if generation != pollingGeneration { return }
         if hasDeliveredPayload { return }
         if isFetchingPayload { return }
         isFetchingPayload = true
@@ -153,6 +160,7 @@ class RealCastPairingService {
             
             let payload = try device.receiver.openPayload(encryptedPayload: encryptedData)
             
+            guard generation == pollingGeneration else { return }
             hasDeliveredPayload = true
             stopPolling()
             
@@ -162,6 +170,7 @@ class RealCastPairingService {
             
         } catch {
             print("Polling error: \(error)")
+            guard generation == pollingGeneration else { return }
             await MainActor.run {
                 onError(error)
             }
@@ -169,6 +178,12 @@ class RealCastPairingService {
     }
     
     func stopPolling() {
+        pollingGeneration += 1
+        // A request suspended against the previous server holds this flag until
+        // it returns, and would make the replacement session's polls take the
+        // early return instead of reaching the newly configured endpoint. Its
+        // own defer clearing the flag again afterwards is harmless.
+        isFetchingPayload = false
         guard isPolling else { return }
         pollingTimer?.invalidate()
         pollingTimer = nil

--- a/apple/apps/cast/Cast/Services/EndpointConfig.swift
+++ b/apple/apps/cast/Cast/Services/EndpointConfig.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+// The Ente server ("museum") this app talks to.
+//
+// Mirrors the developer settings in the Ente mobile and web apps: production by
+// default, with a self-hosted instance settable at runtime rather than needing
+// a custom build. The preference key matches the mobile app's.
+enum EndpointConfig {
+    static let productionAPIOrigin = "https://api.ente.com"
+    static let productionDownloadOrigin = "https://cast-albums.ente.com"
+
+    private static let preferencesKey = "endpoint"
+
+    // The self-hosted origin, or nil when pointed at production.
+    static var customAPIOrigin: String? {
+        guard let value = UserDefaults.standard.string(forKey: preferencesKey),
+              !value.isEmpty,
+              value != productionAPIOrigin
+        else { return nil }
+        return value
+    }
+
+    static var apiOrigin: String {
+        return customAPIOrigin ?? productionAPIOrigin
+    }
+
+    static var isSelfHosted: Bool {
+        return customAPIOrigin != nil
+    }
+
+    static func setAPIOrigin(_ origin: String?) {
+        if let origin = origin, !origin.isEmpty {
+            UserDefaults.standard.set(origin, forKey: preferencesKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: preferencesKey)
+        }
+    }
+
+    // Trims whitespace and trailing slashes, so that "https://ente.example.org/"
+    // and "https://ente.example.org" behave the same.
+    static func normalize(_ input: String) -> String {
+        var origin = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        while origin.hasSuffix("/") {
+            origin.removeLast()
+        }
+        return origin
+    }
+
+    // Museum's preferred route, which answers with the object storage URL to
+    // fetch rather than with the encrypted bytes. Nil for production, whose
+    // Cloudflare worker has no such indirection.
+    static func fileDownloadV3URL(fileID: Int) -> URL? {
+        guard let origin = customAPIOrigin else { return nil }
+        return URL(string: "\(origin)/cast/files/download/v3/\(fileID)")
+    }
+
+    // Where the encrypted bytes themselves are fetched from.
+    //
+    // Production goes through a Cloudflare worker that takes the file ID as a
+    // query parameter. Museum has no such route, so a self-hosted instance uses
+    // the path parameter form instead - the same split the web cast app makes
+    // between cast-albums and fetchCastFile(). On museum this is the pre-v3
+    // route, kept as the fallback for deployments without fileDownloadV3URL.
+    static func fileDownloadURL(fileID: Int) -> URL? {
+        if let origin = customAPIOrigin {
+            return URL(string: "\(origin)/cast/files/download/\(fileID)")
+        }
+        return URL(string: "\(productionDownloadOrigin)/download/?fileID=\(fileID)")
+    }
+
+    enum ValidationError: LocalizedError {
+        case invalidURL
+        case insecureURL
+        case unreachable(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "Enter a full URL, including https://"
+            case .insecureURL:
+                return "Only https:// endpoints are supported"
+            case .unreachable(let detail):
+                return detail
+            }
+        }
+    }
+
+    // Validates like the mobile app does: GET {origin}/ping must answer
+    // {"message": "pong"}.
+    //
+    // Unlike the mobile app this rejects http, because the target ships no App
+    // Transport Security exception. Accepting a cleartext endpoint would store
+    // one that every later request fails on, so it is better refused here with
+    // an explanation than accepted and then permanently unreachable.
+    static func validate(_ origin: String) async throws {
+        guard let url = URL(string: origin),
+              let scheme = url.scheme?.lowercased(),
+              url.host != nil,
+              let pingURL = URL(string: "\(origin)/ping")
+        else {
+            throw ValidationError.invalidURL
+        }
+
+        guard scheme == "https" else {
+            throw ValidationError.insecureURL
+        }
+
+        var request = URLRequest(url: pingURL)
+        request.timeoutInterval = 10
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw ValidationError.unreachable(
+                "Could not reach \(origin): \(error.localizedDescription)")
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ValidationError.unreachable("Invalid response from \(origin)")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            throw ValidationError.unreachable(
+                "\(origin)/ping returned HTTP \(httpResponse.statusCode)")
+        }
+
+        let ping = try? JSONDecoder().decode(PingResponse.self, from: data)
+        guard ping?.message == "pong" else {
+            throw ValidationError.unreachable("\(origin) is not an Ente server")
+        }
+    }
+
+    private struct PingResponse: Decodable {
+        let message: String
+    }
+}

--- a/apple/apps/cast/Cast/ViewModels/CastViewModel.swift
+++ b/apple/apps/cast/Cast/ViewModels/CastViewModel.swift
@@ -12,6 +12,11 @@ class CastViewModel: ObservableObject {
     @Published var statusMessage: String = ""
     @Published var errorMessage: String?
 
+    // Incremented on every (re)start. Registration and polling that was still
+    // in flight against the previous endpoint compares against this and drops
+    // its result rather than overwriting the new session's state.
+    private var sessionGeneration: Int = 0
+
     private var cancellables = Set<AnyCancellable>()
     private let pairingService: RealCastPairingService
     private let castSession: CastSession
@@ -120,6 +125,9 @@ class CastViewModel: ObservableObject {
     }
 
     func startCastSession() {
+        sessionGeneration += 1
+        let generation = sessionGeneration
+
         castSession.setState(.registering)
         deviceCode = ""
         currentView = .pairing
@@ -127,6 +135,8 @@ class CastViewModel: ObservableObject {
         Task {
             do {
                 let device = try await pairingService.registerDevice()
+
+                guard generation == self.sessionGeneration else { return }
 
                 await MainActor.run {
                     deviceCode = device.deviceCode
@@ -139,17 +149,20 @@ class CastViewModel: ObservableObject {
                     device: device,
                     onPayloadReceived: { [weak self] payload in
                         Task { @MainActor in
-                            self?.handlePayloadReceived(payload)
+                            guard let self, generation == self.sessionGeneration else { return }
+                            self.handlePayloadReceived(payload)
                         }
                     },
                     onError: { [weak self] error in
                         Task { @MainActor in
-                            self?.handleNetworkError(error)
+                            guard let self, generation == self.sessionGeneration else { return }
+                            self.handleNetworkError(error)
                         }
                     }
                 )
 
             } catch {
+                guard generation == self.sessionGeneration else { return }
                 handleNetworkError(error)
             }
         }
@@ -180,14 +193,24 @@ class CastViewModel: ObservableObject {
         currentView = .connecting
         statusMessage = ""
 
+        // This payload belongs to whichever server issued it. If the endpoint
+        // changes while it is still loading, starting the slideshow anyway
+        // would request the old album from the new server and the resulting
+        // 401 would tear down the pairing session that just replaced it.
+        let generation = sessionGeneration
+
         Task {
             try? await Task.sleep(nanoseconds: 500_000_000)
+
+            guard generation == self.sessionGeneration else { return }
 
             await slideshowService.start(castPayload: payload)
 
             try? await Task.sleep(nanoseconds: 1_000_000_000)
 
             await MainActor.run {
+                guard generation == self.sessionGeneration else { return }
+
                 let hasError = slideshowService.error != nil && !slideshowService.error!.isEmpty
 
                 if hasError {
@@ -197,6 +220,23 @@ class CastViewModel: ObservableObject {
                     statusMessage = ""
                 }
             }
+        }
+    }
+
+    // Re-registers with the server after the endpoint changes. The old device
+    // code was issued by the old server, so it is no longer valid, and
+    // startCastSession bumps the generation that retires any work still in
+    // flight against it.
+    func restartForEndpointChange() {
+        // Bump first, so anything already in flight against the old server is
+        // retired before the awaits below rather than after them.
+        sessionGeneration += 1
+        pairingService.resetForNewSession()
+        errorMessage = nil
+
+        Task {
+            await slideshowService.resetForEndpointChange()
+            startCastSession()
         }
     }
 
@@ -280,9 +320,13 @@ class CastViewModel: ObservableObject {
     private func handleNetworkError(_ error: Error) {
         handleError("An error occurred: \(error.localizedDescription)")
 
+        // Without this guard, changing the endpoint during the retry delay
+        // would leave the old session's timer to start a second one.
+        let generation = sessionGeneration
         Task {
             try? await Task.sleep(nanoseconds: 5_000_000_000)
             await MainActor.run {
+                guard generation == self.sessionGeneration else { return }
                 startCastSession()
             }
         }

--- a/apple/apps/cast/Cast/ViewModels/SlideshowService.swift
+++ b/apple/apps/cast/Cast/ViewModels/SlideshowService.swift
@@ -51,8 +51,17 @@ class RealSlideshowService: ObservableObject {
     
     private var didDisplayFirstFile: Bool = false
     
-    private let baseURL = "https://api.ente.com"
-    private let castDownloadURL = "https://cast-albums.ente.com/download"
+    private var baseURL: String { EndpointConfig.apiOrigin }
+
+    // Bumped when the endpoint changes. stop() does not cancel work already in
+    // flight, so a download started against the previous server could otherwise
+    // finish after clearCache() and write straight back into it.
+    private var cacheEpoch: Int = 0
+
+    // Mirrors the web client: once the v3 download route 404s, stop probing it
+    // for an hour rather than paying a failed round trip per file.
+    private static var v3RetryAfter: Date = .distantPast
+    private static let v3RetryDelay: TimeInterval = 60 * 60
     
     private let verboseFileLogging = false
     private let verboseDecryptionLogging = false
@@ -219,6 +228,16 @@ class RealSlideshowService: ObservableObject {
         }
     }
     
+    // The file cache is keyed by file ID alone, and file IDs are only unique
+    // within one deployment. Entries downloaded from the previous server would
+    // otherwise be served under the new server's metadata, showing one
+    // instance's photos in another's album.
+    func resetForEndpointChange() async {
+        cacheEpoch += 1
+        await stop()
+        await clearCache()
+    }
+
     func clearExpiredTokenState() async {
         
         ScreenSaverManager.allowScreenSaver()
@@ -841,33 +860,83 @@ class RealSlideshowService: ObservableObject {
     }
     
     private func downloadEncryptedFile(castPayload: CastPayload, fileID: Int) async throws -> Data {
-        let url = URL(string: "\(castDownloadURL)/?fileID=\(fileID)")!
-        
-        var request = URLRequest(url: url)
-        request.setValue(castPayload.castToken, forHTTPHeaderField: "X-Cast-Access-Token")
-        
-        
-        let (data, response) = try await URLSession.shared.data(for: request)
-        
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CastError.networkError("Invalid response")
-        }
-        
-        guard httpResponse.statusCode == 200 else {
-            let snippet = (String(data: data, encoding: .utf8) ?? "").prefix(160)
-            print("Download error [\(httpResponse.statusCode)] fileID=\(fileID): \(snippet)")
-            if httpResponse.statusCode == 401 {
-                await handleUnauthorizedError()
-                throw CastError.serverError(401, "Authentication expired - resetting to pairing mode")
+        // Museum's v3 route answers with {"url": ...} pointing at object storage
+        // rather than with the encrypted bytes, and 404s when the deployment is
+        // too old to have the route at all. Production's cast-albums worker
+        // serves the bytes directly, so it only has the one step.
+        if Date() >= Self.v3RetryAfter,
+           let v3URL = EndpointConfig.fileDownloadV3URL(fileID: fileID) {
+            let (body, status) = try await fetch(v3URL, castToken: castPayload.castToken)
+            if status == 404 {
+                Self.v3RetryAfter = Date().addingTimeInterval(Self.v3RetryDelay)
             } else {
-                throw CastError.serverError(httpResponse.statusCode, String(snippet))
+                try await ensureOK(status, body: body, fileID: fileID)
+                guard let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+                      let urlString = json["url"] as? String,
+                      let objectURL = URL(string: urlString) else {
+                    throw CastError.networkError("Malformed download URL response for file \(fileID)")
+                }
+                guard objectURL.scheme?.lowercased() != "http" else {
+                    throw CastError.networkError(
+                        "This server hands out object storage URLs over http, which tvOS refuses to load. Serve the bucket endpoint over https.")
+                }
+                let (data, objectStatus) = try await fetch(objectURL, castToken: nil)
+                try await ensureOK(
+                    objectStatus,
+                    body: data,
+                    fileID: fileID,
+                    treatUnauthorizedAsSessionExpiry: false
+                )
+                if verboseFileLogging { print("Successfully downloaded \(data.count) bytes for file \(fileID)") }
+                return data
             }
         }
+
+        guard let url = EndpointConfig.fileDownloadURL(fileID: fileID) else {
+            throw CastError.networkError("Invalid download URL")
+        }
+        let (data, status) = try await fetch(url, castToken: castPayload.castToken)
+        try await ensureOK(status, body: data, fileID: fileID)
         if verboseFileLogging { print("Successfully downloaded \(data.count) bytes for file \(fileID)") }
         return data
     }
+
+    private func fetch(_ url: URL, castToken: String?) async throws -> (Data, Int) {
+        var request = URLRequest(url: url)
+        if let castToken {
+            request.setValue(castToken, forHTTPHeaderField: "X-Cast-Access-Token")
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CastError.networkError("Invalid response")
+        }
+        return (data, httpResponse.statusCode)
+    }
+
+    // treatUnauthorizedAsSessionExpiry is false for object storage, where a 401
+    // means the pre-signed URL expired rather than the cast session ending, and
+    // tearing the session down would be the wrong response.
+    private func ensureOK(
+        _ status: Int,
+        body: Data,
+        fileID: Int,
+        treatUnauthorizedAsSessionExpiry: Bool = true
+    ) async throws {
+        guard status != 200 else { return }
+
+        let snippet = (String(data: body, encoding: .utf8) ?? "").prefix(160)
+        print("Download error [\(status)] fileID=\(fileID): \(snippet)")
+        if status == 401, treatUnauthorizedAsSessionExpiry {
+            await handleUnauthorizedError()
+            throw CastError.serverError(401, "Authentication expired - resetting to pairing mode")
+        }
+        throw CastError.serverError(status, String(snippet))
+    }
     
     private func downloadAndDecryptFileContent(castPayload: CastPayload, file: CastFile) async throws -> Data {
+        let epoch = cacheEpoch
         let stopping = await MainActor.run { isStopping }
         if stopping {
             throw CastError.networkError("Service is stopping")
@@ -897,7 +966,12 @@ class RealSlideshowService: ObservableObject {
         )
             
         
-        await cacheFileContent(fileID: file.id, data: decryptedData)
+        // Discard rather than cache if the endpoint changed while this was in
+        // flight: file IDs repeat across deployments, so this would reappear as
+        // another instance's photo under an ID the new server also uses.
+        if epoch == cacheEpoch {
+            await cacheFileContent(fileID: file.id, data: decryptedData)
+        }
         
         return decryptedData
     }

--- a/apple/apps/cast/Cast/Views/DeveloperSettingsGesture.swift
+++ b/apple/apps/cast/Cast/Views/DeveloperSettingsGesture.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+// Seven presses opens developer settings, matching the gesture in the Ente
+// mobile apps.
+//
+// It is attached once, around the whole app, rather than to the pairing screen
+// alone. A server that cannot be reached puts the app into a five second error
+// and retry cycle, and an entry point that only existed while pairing would
+// appear for a fraction of a second at a time - unusable for exactly the person
+// who needs it, someone whose Apple TV cannot reach ente.com and has to point
+// the app at a local server before anything else can work. Keeping the press
+// count in one place also means it survives those state changes.
+struct DeveloperSettingsGesture: ViewModifier {
+    // False during the slideshow, where play/pause belongs to playback.
+    let isEnabled: Bool
+    let onEndpointChanged: () -> Void
+
+    @State private var pressCount = 0
+    @State private var isPresented = false
+
+    func body(content: Content) -> some View {
+        content
+            // tvOS has no touchscreen, and these screens have nothing else
+            // focusable, so the select button is picked up through a focusable
+            // overlay, with play/pause accepted as an alternative.
+            .focusable(isEnabled)
+            .onTapGesture {
+                registerPress()
+            }
+            .onPlayPauseCommand {
+                registerPress()
+            }
+            .sheet(isPresented: $isPresented) {
+                DeveloperSettingsView(onSave: onEndpointChanged)
+            }
+    }
+
+    private func registerPress() {
+        guard isEnabled else { return }
+        pressCount += 1
+        guard pressCount >= 7 else { return }
+        pressCount = 0
+        isPresented = true
+    }
+}
+
+extension View {
+    func developerSettingsGesture(
+        isEnabled: Bool,
+        onEndpointChanged: @escaping () -> Void
+    ) -> some View {
+        modifier(
+            DeveloperSettingsGesture(
+                isEnabled: isEnabled,
+                onEndpointChanged: onEndpointChanged
+            )
+        )
+    }
+}

--- a/apple/apps/cast/Cast/Views/DeveloperSettingsView.swift
+++ b/apple/apps/cast/Cast/Views/DeveloperSettingsView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+// Runtime server configuration, opened from the pairing screen by pressing the
+// remote seven times - the tvOS counterpart of the seven-tap developer
+// settings in the Ente mobile apps, so that pointing this app at a self-hosted
+// instance does not require building it from source.
+struct DeveloperSettingsView: View {
+    // Called once the endpoint has changed, so that pairing can restart.
+    let onSave: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var endpoint: String = EndpointConfig.customAPIOrigin ?? ""
+    @State private var isValidating = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 40) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Developer settings")
+                    .font(.system(size: 56, weight: .bold))
+
+                Text("Point this Apple TV at a self-hosted Ente server, reachable over https. Leave this empty to use ente.com.")
+                    .font(.system(size: 26))
+                    .foregroundColor(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Server endpoint")
+                    .font(.system(size: 28, weight: .semibold))
+
+                TextField("https://ente.example.org", text: $endpoint)
+                    .keyboardType(.URL)
+                    .disableAutocorrection(true)
+            }
+
+            if let errorMessage = errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 24))
+                    .foregroundColor(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if isValidating {
+                ProgressView()
+            }
+
+            HStack(spacing: 32) {
+                Button("Save") {
+                    save()
+                }
+                .disabled(isValidating)
+
+                Button("Use ente.com") {
+                    useProduction()
+                }
+                .disabled(isValidating)
+
+                Button("Cancel") {
+                    dismiss()
+                }
+                .disabled(isValidating)
+            }
+
+            Spacer()
+        }
+        .padding(80)
+    }
+
+    private func save() {
+        let origin = EndpointConfig.normalize(endpoint)
+        guard !origin.isEmpty else {
+            useProduction()
+            return
+        }
+
+        errorMessage = nil
+        isValidating = true
+
+        Task {
+            do {
+                try await EndpointConfig.validate(origin)
+                await MainActor.run {
+                    EndpointConfig.setAPIOrigin(origin)
+                    isValidating = false
+                    onSave()
+                    dismiss()
+                }
+            } catch {
+                await MainActor.run {
+                    isValidating = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func useProduction() {
+        EndpointConfig.setAPIOrigin(nil)
+        onSave()
+        dismiss()
+    }
+}
+
+#Preview {
+    DeveloperSettingsView(onSave: {})
+}

--- a/apple/apps/cast/Cast/Views/PairingView.swift
+++ b/apple/apps/cast/Cast/Views/PairingView.swift
@@ -91,7 +91,9 @@ struct PairingView: View {
                             Spacer()
                                 .frame(height: geometry.size.height * 0.06)
                             
-                            Text("Visit ente.com/cast for help")
+                            Text(EndpointConfig.isSelfHosted
+                                 ? EndpointConfig.apiOrigin
+                                 : "Visit ente.com/cast for help")
                                 .font(FontUtils.interMedium(size: geometry.size.width * 0.012))
                                 .foregroundColor(.white)
                             


### PR DESCRIPTION
Discussion: https://github.com/ente/ente/discussions/12804

Production behaviour is unchanged: the v3 download branch is gated behind a custom origin, and the pairing screen only shows the endpoint when one is set. Two production code paths are still modified though - the download refactor, which is behaviour-preserving, and the session generation guards, which as a side effect also close pre-existing races on the existing `authenticationExpired` restart path.

Two things here reach past the self-hosting path, called out deliberately rather than left to be found:

- `stopPolling()` now clears `isFetchingPayload`. A poll suspended against the old server otherwise keeps the shared flag and stalls the replacement session. This is reachable on `main` today through the `authenticationExpired` restart, so it is a pre-existing fix rather than a new-feature one - happy to pull it into its own PR if you would rather keep this one narrow.
- The session generation guards close the same class of race on that same restart path.

A 401 from object storage is no longer treated as an expired cast session: there it means the pre-signed URL lapsed, and resetting to pairing would be the wrong response.

For transparency: this was vibe-coded. I don't have much experience in iOS development, but I thought it is minor enough to vibe-code.