### PR TITLE
[mob][photos] Refresh person picker UI

### DIFF
--- a/mobile/apps/photos/changes/person-picker-menu.md
+++ b/mobile/apps/photos/changes/person-picker-menu.md
@@ -1,0 +1,1 @@
+- Updated the person picker app bar and sort menu, and fixed overflowing person names.

--- a/mobile/apps/photos/lib/ui/viewer/people/merge_clusters_to_person_sheet.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/merge_clusters_to_person_sheet.dart
@@ -272,7 +272,6 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                 child: Center(child: EnteLoadingWidget()),
               ),
             );
-            return _buildScrollBody(slivers);
           } else if (snapshot.hasError) {
             _logger.severe(
               "Failed to load persons for merge",
@@ -284,207 +283,259 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                 child: Center(child: Icon(Icons.error_outline_rounded)),
               ),
             );
-            return _buildScrollBody(slivers);
+          } else {
+            final persons = snapshot.data ?? [];
+            final sortedPersons = [...persons];
+            _sortFaces(sortedPersons);
+            final results = _filterPersons(sortedPersons);
+            if (results.isEmpty && !_showNewPersonTile) {
+              slivers.add(
+                SliverFillRemaining(
+                  child: Center(child: Text(context.strings.noResultsFound)),
+                ),
+              );
+            } else {
+              final screenWidth = MediaQuery.of(context).size.width;
+              final estimatedCount = (screenWidth / 100).floor();
+              final crossAxisCount = estimatedCount > 0 ? estimatedCount : 1;
+              final itemSize =
+                  (screenWidth -
+                      ((horizontalEdgePadding * 2) +
+                          ((crossAxisCount - 1) * gridPadding))) /
+                  crossAxisCount;
+
+              final bottomPadding = MediaQuery.paddingOf(context).bottom;
+              slivers.add(
+                SliverPadding(
+                  padding: EdgeInsets.fromLTRB(
+                    horizontalEdgePadding,
+                    16,
+                    horizontalEdgePadding,
+                    16 + bottomPadding,
+                  ),
+                  sliver: SliverGrid(
+                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      mainAxisSpacing: gridPadding,
+                      crossAxisSpacing: gridPadding,
+                      crossAxisCount: crossAxisCount,
+                      childAspectRatio: itemSize / (itemSize + labelHeight),
+                    ),
+                    delegate: SliverChildBuilderDelegate(
+                      childCount: results.length + (_showNewPersonTile ? 1 : 0),
+                      (context, index) {
+                        if (_showNewPersonTile && index == 0) {
+                          return _AddNewPersonGridTile(
+                            size: itemSize,
+                            labelHeight: labelHeight,
+                            onTap: _onAddNewPersonSelected,
+                          );
+                        }
+                        final person =
+                            results[_showNewPersonTile ? index - 1 : index];
+                        final personId =
+                            person.params[kPersonParamID] as String?;
+                        final personKey =
+                            personId != null && personId.isNotEmpty
+                            ? personId
+                            : person.name();
+                        return _ManualPersonGridTile(
+                          key: ValueKey(personKey),
+                          result: person,
+                          size: itemSize,
+                          labelHeight: labelHeight,
+                          onTap: () => _onPersonSelected(person),
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              );
+            }
           }
 
-          final persons = snapshot.data ?? [];
-          final sortedPersons = [...persons];
-          _sortFaces(sortedPersons);
-          final results = _filterPersons(sortedPersons);
-          if (results.isEmpty && !_showNewPersonTile) {
-            slivers.add(
-              SliverFillRemaining(
-                child: Center(child: Text(context.strings.noResultsFound)),
+          return AppBarComponent(
+            title: context.strings.addToPerson,
+            physics: const BouncingScrollPhysics(),
+            titleBuilder: (context, state) => AnimatedSwitcher(
+              duration: _searchTransitionDuration,
+              switchInCurve: Curves.easeOutCubic,
+              switchOutCurve: Curves.easeInCubic,
+              layoutBuilder: (currentChild, previousChildren) => Stack(
+                alignment: Alignment.centerLeft,
+                clipBehavior: Clip.none,
+                children: [...previousChildren, ?currentChild],
               ),
-            );
-            return _buildScrollBody(slivers);
-          }
-          final screenWidth = MediaQuery.of(context).size.width;
-          final estimatedCount = (screenWidth / 100).floor();
-          final crossAxisCount = estimatedCount > 0 ? estimatedCount : 1;
-          final itemSize =
-              (screenWidth -
-                  ((horizontalEdgePadding * 2) +
-                      ((crossAxisCount - 1) * gridPadding))) /
-              crossAxisCount;
+              transitionBuilder: (child, animation) {
+                final curvedAnimation = CurvedAnimation(
+                  parent: animation,
+                  curve: Curves.easeOutCubic,
+                  reverseCurve: Curves.easeInCubic,
+                );
+                final beginOffset =
+                    child.key == const ValueKey("person_search_field")
+                    ? const Offset(0.035, 0)
+                    : const Offset(-0.035, 0);
+                return FadeTransition(
+                  opacity: curvedAnimation,
+                  child: SlideTransition(
+                    position: Tween<Offset>(
+                      begin: beginOffset,
+                      end: Offset.zero,
+                    ).animate(curvedAnimation),
+                    child: child,
+                  ),
+                );
+              },
+              child: _isSearchBarVisible
+                  ? KeyedSubtree(
+                      key: const ValueKey("person_search_field"),
+                      child: TextInputComponent(
+                        controller: _searchController,
+                        focusNode: _searchFocusNode,
+                        hintText: context.strings.search,
+                        autofocus: true,
+                        shouldUnfocusOnClearOrSubmit: true,
+                        prefix: HugeIcon(
+                          icon: HugeIcons.strokeRoundedSearch01,
+                          size: 18,
+                          color: context.componentColors.textLight,
+                        ),
+                        suffix: HugeIcon(
+                          icon: HugeIcons.strokeRoundedCancel01,
+                          size: 18,
+                          color: context.componentColors.textLight,
+                        ),
+                        onSuffixTap: _closeSearch,
+                        onChanged: _updateSearchQuery,
+                      ),
+                    )
+                  : KeyedSubtree(
+                      key: const ValueKey("person_title_row"),
+                      child: SizedBox(
+                        height: state.height,
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Expanded(
+                              child: Text(
+                                state.title,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: state.textStyle,
+                              ),
+                            ),
+                            const SizedBox(width: Spacing.md),
+                            SizedBox.square(
+                              dimension: _titleActionSize,
+                              child: IconButtonComponent(
+                                variant: IconButtonComponentVariant.primary,
+                                shouldSurfaceExecutionStates: false,
+                                icon: const HugeIcon(
+                                  icon: HugeIcons.strokeRoundedSearch01,
+                                ),
+                                onTap: _activateSearch,
+                              ),
+                            ),
+                            const SizedBox(width: Spacing.sm),
+                            SizedBox.square(
+                              dimension: _titleActionSize,
+                              child: galleryAppBarPopupMenuAction<_MergeSortKey>(
+                                icon: const HugeIcon(
+                                  icon: HugeIcons.strokeRoundedFilterHorizontal,
+                                ),
+                                tooltip: context.strings.sort,
+                                optionsBuilder: () {
+                                  final l10n = context.strings;
+                                  final sortKeys = _canUseSimilaritySort
+                                      ? _MergeSortKey.values
+                                      : _MergeSortKey.values
+                                            .where(
+                                              (key) =>
+                                                  key != _MergeSortKey.similar,
+                                            )
+                                            .toList();
+                                  return sortKeys.map((key) {
+                                    String label;
+                                    late final String detail;
+                                    Widget? activeTrailingWidget;
 
-          final bottomPadding = MediaQuery.paddingOf(context).bottom;
-          slivers.add(
-            SliverPadding(
-              padding: EdgeInsets.fromLTRB(
-                horizontalEdgePadding,
-                16,
-                horizontalEdgePadding,
-                16 + bottomPadding,
-              ),
-              sliver: SliverGrid(
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  mainAxisSpacing: gridPadding,
-                  crossAxisSpacing: gridPadding,
-                  crossAxisCount: crossAxisCount,
-                  childAspectRatio: itemSize / (itemSize + labelHeight),
-                ),
-                delegate: SliverChildBuilderDelegate(
-                  childCount: results.length + (_showNewPersonTile ? 1 : 0),
-                  (context, index) {
-                    if (_showNewPersonTile && index == 0) {
-                      return _AddNewPersonGridTile(
-                        size: itemSize,
-                        labelHeight: labelHeight,
-                        onTap: _onAddNewPersonSelected,
-                      );
-                    }
-                    final person =
-                        results[_showNewPersonTile ? index - 1 : index];
-                    final personId = person.params[kPersonParamID] as String?;
-                    final personKey = personId != null && personId.isNotEmpty
-                        ? personId
-                        : person.name();
-                    return _ManualPersonGridTile(
-                      key: ValueKey(personKey),
-                      result: person,
-                      size: itemSize,
-                      labelHeight: labelHeight,
-                      onTap: () => _onPersonSelected(person),
-                    );
-                  },
-                ),
-              ),
+                                    if (key == _MergeSortKey.similar) {
+                                      label = l10n.similar;
+                                      detail = l10n.closest;
+                                    } else {
+                                      final peopleKey =
+                                          _peopleSortKeyFromMergeSortKey(key)!;
+                                      switch (peopleKey) {
+                                        case PeopleSortKey.mostPhotos:
+                                          label = l10n.photos;
+                                          detail = l10n.count;
+                                          break;
+                                        case PeopleSortKey.name:
+                                          label = l10n.name;
+                                          detail = _isSortAscending(peopleKey)
+                                              ? l10n.sortAToZ
+                                              : l10n.sortZToA;
+                                          break;
+                                        case PeopleSortKey.lastUpdated:
+                                          label = l10n.updated;
+                                          detail = _isSortAscending(peopleKey)
+                                              ? l10n.sortOldestFirst
+                                              : l10n.sortNewestFirst;
+                                          break;
+                                      }
+
+                                      final isAscending = _isSortAscending(
+                                        peopleKey,
+                                      );
+                                      final directionIcon =
+                                          peopleKey == PeopleSortKey.name
+                                          ? (isAscending
+                                                ? HugeIcons
+                                                      .strokeRoundedArrowDown02
+                                                : HugeIcons
+                                                      .strokeRoundedArrowUp02)
+                                          : (isAscending
+                                                ? HugeIcons
+                                                      .strokeRoundedArrowUp02
+                                                : HugeIcons
+                                                      .strokeRoundedArrowDown02);
+                                      activeTrailingWidget = HugeIcon(
+                                        icon: directionIcon,
+                                        size: 12,
+                                        strokeWidth: 3,
+                                        color:
+                                            context.componentColors.textLight,
+                                      );
+                                    }
+
+                                    final isSelected =
+                                        _selectedMergeSortKey == key;
+                                    return EntePopupMenuOption(
+                                      value: key,
+                                      label: label,
+                                      secondaryLabel: isSelected
+                                          ? detail
+                                          : null,
+                                      isActive: isSelected,
+                                      activeTrailingWidget:
+                                          activeTrailingWidget,
+                                    );
+                                  }).toList();
+                                },
+                                onSelected: _selectSortKey,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
             ),
+            titleBuilderHeight: _searchTitleHeight,
+            slivers: slivers,
           );
-          return _buildScrollBody(slivers);
         },
       ),
     );
-  }
-
-  Widget _buildScrollBody(List<Widget> slivers) {
-    return AppBarComponent(
-      title: context.strings.addToPerson,
-      physics: const BouncingScrollPhysics(),
-      titleBuilder: _buildTitle,
-      titleBuilderHeight: _searchTitleHeight,
-      slivers: slivers,
-    );
-  }
-
-  Widget _buildTitle(BuildContext context, HeaderAppBarTitleState state) {
-    return AnimatedSwitcher(
-      duration: _searchTransitionDuration,
-      switchInCurve: Curves.easeOutCubic,
-      switchOutCurve: Curves.easeInCubic,
-      layoutBuilder: (currentChild, previousChildren) => Stack(
-        alignment: Alignment.centerLeft,
-        clipBehavior: Clip.none,
-        children: [...previousChildren, ?currentChild],
-      ),
-      transitionBuilder: (child, animation) {
-        final curvedAnimation = CurvedAnimation(
-          parent: animation,
-          curve: Curves.easeOutCubic,
-          reverseCurve: Curves.easeInCubic,
-        );
-        final beginOffset = child.key == const ValueKey("person_search_field")
-            ? const Offset(0.035, 0)
-            : const Offset(-0.035, 0);
-        return FadeTransition(
-          opacity: curvedAnimation,
-          child: SlideTransition(
-            position: Tween<Offset>(
-              begin: beginOffset,
-              end: Offset.zero,
-            ).animate(curvedAnimation),
-            child: child,
-          ),
-        );
-      },
-      child: _isSearchBarVisible
-          ? KeyedSubtree(
-              key: const ValueKey("person_search_field"),
-              child: _buildSearchField(context),
-            )
-          : KeyedSubtree(
-              key: const ValueKey("person_title_row"),
-              child: _buildTitleRow(state),
-            ),
-    );
-  }
-
-  Widget _buildTitleRow(HeaderAppBarTitleState state) {
-    return SizedBox(
-      height: state.height,
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Expanded(
-            child: Text(
-              state.title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: state.textStyle,
-            ),
-          ),
-          const SizedBox(width: Spacing.md),
-          SizedBox.square(
-            dimension: _titleActionSize,
-            child: _buildSearchAction(),
-          ),
-          const SizedBox(width: Spacing.sm),
-          SizedBox.square(dimension: _titleActionSize, child: _buildSortMenu()),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSearchAction() {
-    return IconButtonComponent(
-      variant: IconButtonComponentVariant.primary,
-      shouldSurfaceExecutionStates: false,
-      icon: const HugeIcon(icon: HugeIcons.strokeRoundedSearch01),
-      onTap: _activateSearch,
-    );
-  }
-
-  Widget _buildSearchField(BuildContext context) {
-    final colors = context.componentColors;
-    return TextInputComponent(
-      controller: _searchController,
-      focusNode: _searchFocusNode,
-      hintText: context.strings.search,
-      autofocus: true,
-      shouldUnfocusOnClearOrSubmit: true,
-      prefix: HugeIcon(
-        icon: HugeIcons.strokeRoundedSearch01,
-        size: 18,
-        color: colors.textLight,
-      ),
-      suffix: HugeIcon(
-        icon: HugeIcons.strokeRoundedCancel01,
-        size: 18,
-        color: colors.textLight,
-      ),
-      onSuffixTap: _closeSearch,
-      onChanged: _updateSearchQuery,
-    );
-  }
-
-  Widget _buildSortMenu() {
-    return galleryAppBarPopupMenuAction<_MergeSortKey>(
-      icon: const HugeIcon(icon: HugeIcons.strokeRoundedFilterHorizontal),
-      tooltip: context.strings.sort,
-      optionsBuilder: _buildSortMenuOptions,
-      onSelected: _selectSortKey,
-    );
-  }
-
-  List<EntePopupMenuOption<_MergeSortKey>> _buildSortMenuOptions() {
-    final l10n = context.strings;
-    final sortKeys = _canUseSimilaritySort
-        ? _MergeSortKey.values
-        : _MergeSortKey.values
-              .where((key) => key != _MergeSortKey.similar)
-              .toList();
-    return [for (final key in sortKeys) _buildSortMenuItem(key, l10n)];
   }
 
   void _selectSortKey(_MergeSortKey selectedKey) {
@@ -510,72 +561,6 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
       }
     });
     unawaited(_persistSortPreferences());
-  }
-
-  EntePopupMenuOption<_MergeSortKey> _buildSortMenuItem(
-    _MergeSortKey key,
-    StringsLocalizations l10n,
-  ) {
-    String label;
-    late final String detail;
-    Widget? activeTrailingWidget;
-
-    if (key == _MergeSortKey.similar) {
-      label = l10n.similar;
-      detail = l10n.closest;
-    } else {
-      final peopleKey = _peopleSortKeyFromMergeSortKey(key)!;
-      switch (peopleKey) {
-        case PeopleSortKey.mostPhotos:
-          label = l10n.photos;
-          break;
-        case PeopleSortKey.name:
-          label = l10n.name;
-          break;
-        case PeopleSortKey.lastUpdated:
-          label = l10n.updated;
-          break;
-      }
-
-      switch (peopleKey) {
-        case PeopleSortKey.mostPhotos:
-          detail = l10n.count;
-          break;
-        case PeopleSortKey.name:
-          detail = _isSortAscending(peopleKey) ? l10n.sortAToZ : l10n.sortZToA;
-          break;
-        case PeopleSortKey.lastUpdated:
-          detail = _isSortAscending(peopleKey)
-              ? l10n.sortOldestFirst
-              : l10n.sortNewestFirst;
-          break;
-      }
-
-      final bool isAscending = _isSortAscending(peopleKey);
-      final directionIcon = peopleKey == PeopleSortKey.name
-          ? (isAscending
-                ? HugeIcons.strokeRoundedArrowDown02
-                : HugeIcons.strokeRoundedArrowUp02)
-          : (isAscending
-                ? HugeIcons.strokeRoundedArrowUp02
-                : HugeIcons.strokeRoundedArrowDown02);
-      activeTrailingWidget = HugeIcon(
-        icon: directionIcon,
-        size: 12,
-        strokeWidth: 3,
-        color: context.componentColors.textLight,
-      );
-    }
-
-    final bool isSelected = _selectedMergeSortKey == key;
-
-    return EntePopupMenuOption(
-      value: key,
-      label: label,
-      secondaryLabel: isSelected ? detail : null,
-      isActive: isSelected,
-      activeTrailingWidget: activeTrailingWidget,
-    );
   }
 
   void _onPersonSelected(GenericSearchResult result) {

--- a/mobile/apps/photos/lib/ui/viewer/people/merge_clusters_to_person_sheet.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/merge_clusters_to_person_sheet.dart
@@ -3,10 +3,12 @@ import "dart:math" show max;
 
 import "package:collection/collection.dart";
 import "package:dotted_border/dotted_border.dart";
+import "package:ente_components/ente_components.dart";
 import "package:ente_pure_utils/ente_pure_utils.dart";
 import "package:ente_strings/ente_strings.dart";
 import "package:ente_ui/components/loading_widget.dart";
 import "package:flutter/material.dart";
+import "package:hugeicons/hugeicons.dart";
 import "package:logging/logging.dart";
 import "package:ml_linalg/linalg.dart" as ml;
 import "package:photos/core/event_bus.dart";
@@ -20,11 +22,8 @@ import "package:photos/service_locator.dart";
 import "package:photos/services/machine_learning/face_ml/face_filtering/face_filtering_constants.dart";
 import "package:photos/services/search_service.dart";
 import "package:photos/settings/local_settings.dart";
-import "package:photos/theme/colors.dart";
 import "package:photos/theme/ente_theme.dart";
-import "package:photos/theme/text_style.dart";
-import "package:photos/ui/components/buttons/icon_button_widget.dart";
-import "package:photos/ui/components/searchable_appbar.dart";
+import "package:photos/ui/viewer/gallery/gallery_app_bar_actions.dart";
 import "package:photos/ui/viewer/people/face_thumbnail_squircle.dart";
 import "package:photos/ui/viewer/people/person_face_widget.dart";
 import "package:photos/ui/viewer/people/save_or_edit_person.dart";
@@ -86,18 +85,21 @@ class MergeClustersToPersonPage extends StatefulWidget {
 
 class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
   static final Logger _logger = Logger("MergeClustersToPersonSheet");
+  static const _titleActionSize = 36.0;
+  static const _searchTitleHeight = 52.0;
+  static const _searchTransitionDuration = Duration(milliseconds: 240);
 
   late Future<List<GenericSearchResult>> _personsFuture;
   String _searchQuery = "";
+  bool _isSearchBarVisible = false;
+  final _searchController = TextEditingController();
+  final _searchFocusNode = FocusNode();
   late PeopleSortKey _sortKey;
   bool _useSimilaritySort = true;
   bool _nameSortAscending = true;
   bool _updatedSortAscending = false;
   bool _photosSortAscending = false;
   Map<String, double> _personToMaxSimilarity = {};
-
-  static const double _sortMenuItemHeight = 52;
-  static const double _sortMenuCornerRadius = 12;
 
   bool get _showNewPersonTile =>
       widget.seedClusterId != null && widget.seedClusterId!.isNotEmpty;
@@ -140,12 +142,35 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
     });
   }
 
-  void _clearSearchQuery() {
-    if (_searchQuery.isNotEmpty) {
-      setState(() {
-        _searchQuery = "";
-      });
-    }
+  void _focusSearchField() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _searchFocusNode.requestFocus();
+      }
+    });
+  }
+
+  void _activateSearch() {
+    setState(() {
+      _isSearchBarVisible = true;
+    });
+    _focusSearchField();
+  }
+
+  void _closeSearch() {
+    _searchFocusNode.unfocus();
+    _searchController.clear();
+    setState(() {
+      _isSearchBarVisible = false;
+      _searchQuery = "";
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    super.dispose();
   }
 
   Future<void> _onAddNewPersonSelected() async {
@@ -229,11 +254,10 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
   @override
   Widget build(BuildContext context) {
     final textTheme = getEnteTextTheme(context);
-    final colorScheme = getEnteColorScheme(context);
     final smallFontSize = textTheme.small.fontSize!;
     final textScaleFactor =
         MediaQuery.textScalerOf(context).scale(smallFontSize) / smallFontSize;
-    final textHeight = 24 * textScaleFactor;
+    final labelHeight = 28 * textScaleFactor;
     const horizontalEdgePadding = 20.0;
     const gridPadding = 16.0;
 
@@ -241,33 +265,14 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
       body: FutureBuilder<List<GenericSearchResult>>(
         future: _personsFuture,
         builder: (context, snapshot) {
-          final slivers = <Widget>[
-            SearchableAppBar(
-              title: Text(context.strings.addToPerson),
-              onSearch: _updateSearchQuery,
-              onSearchClosed: _clearSearchQuery,
-              centerTitle: false,
-              searchIconPadding: const EdgeInsets.fromLTRB(
-                12,
-                12,
-                horizontalEdgePadding,
-                12,
-              ),
-              actions: [
-                Padding(
-                  padding: const EdgeInsets.only(right: horizontalEdgePadding),
-                  child: _buildSortMenu(context, textTheme, colorScheme),
-                ),
-              ],
-            ),
-          ];
+          final slivers = <Widget>[];
           if (snapshot.connectionState == ConnectionState.waiting) {
             slivers.add(
               const SliverFillRemaining(
                 child: Center(child: EnteLoadingWidget()),
               ),
             );
-            return CustomScrollView(slivers: slivers);
+            return _buildScrollBody(slivers);
           } else if (snapshot.hasError) {
             _logger.severe(
               "Failed to load persons for merge",
@@ -279,7 +284,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                 child: Center(child: Icon(Icons.error_outline_rounded)),
               ),
             );
-            return CustomScrollView(slivers: slivers);
+            return _buildScrollBody(slivers);
           }
 
           final persons = snapshot.data ?? [];
@@ -292,7 +297,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                 child: Center(child: Text(context.strings.noResultsFound)),
               ),
             );
-            return CustomScrollView(slivers: slivers);
+            return _buildScrollBody(slivers);
           }
           final screenWidth = MediaQuery.of(context).size.width;
           final estimatedCount = (screenWidth / 100).floor();
@@ -317,7 +322,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                   mainAxisSpacing: gridPadding,
                   crossAxisSpacing: gridPadding,
                   crossAxisCount: crossAxisCount,
-                  childAspectRatio: itemSize / (itemSize + textHeight),
+                  childAspectRatio: itemSize / (itemSize + labelHeight),
                 ),
                 delegate: SliverChildBuilderDelegate(
                   childCount: results.length + (_showNewPersonTile ? 1 : 0),
@@ -325,7 +330,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                     if (_showNewPersonTile && index == 0) {
                       return _AddNewPersonGridTile(
                         size: itemSize,
-                        labelHeight: textHeight,
+                        labelHeight: labelHeight,
                         onTap: _onAddNewPersonSelected,
                       );
                     }
@@ -339,7 +344,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
                       key: ValueKey(personKey),
                       result: person,
                       size: itemSize,
-                      labelHeight: textHeight,
+                      labelHeight: labelHeight,
                       onTap: () => _onPersonSelected(person),
                     );
                   },
@@ -347,100 +352,173 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
               ),
             ),
           );
-          return CustomScrollView(slivers: slivers);
+          return _buildScrollBody(slivers);
         },
       ),
     );
   }
 
-  Widget _buildSortMenu(
-    BuildContext context,
-    EnteTextTheme textTheme,
-    EnteColorScheme colorScheme,
-  ) {
-    return Theme(
-      data: Theme.of(context).copyWith(
-        highlightColor: Colors.transparent,
-        splashColor: Colors.transparent,
-      ),
-      child: GestureDetector(
-        onTapDown: (TapDownDetails details) async {
-          final l10n = context.strings;
-          final sortKeys = _canUseSimilaritySort
-              ? _MergeSortKey.values
-              : _MergeSortKey.values
-                    .where((key) => key != _MergeSortKey.similar)
-                    .toList();
-          final _MergeSortKey? selectedKey = await showMenu<_MergeSortKey>(
-            color: colorScheme.backgroundElevated,
-            context: context,
-            elevation: 0,
-            shape: RoundedRectangleBorder(
-              side: BorderSide(width: 0.5, color: colorScheme.strokeFaint),
-              borderRadius: BorderRadius.circular(_sortMenuCornerRadius),
-            ),
-            position: RelativeRect.fromLTRB(
-              details.globalPosition.dx,
-              details.globalPosition.dy,
-              details.globalPosition.dx,
-              details.globalPosition.dy + 50,
-            ),
-            items: List.generate(sortKeys.length, (index) {
-              final key = sortKeys[index];
-              return _buildSortMenuItem(
-                key,
-                index == sortKeys.length - 1,
-                textTheme,
-                colorScheme,
-                l10n,
-              );
-            }),
-          );
-          if (!mounted || selectedKey == null) {
-            return;
-          }
-          final currentKey = _selectedMergeSortKey;
-          if (selectedKey == currentKey) {
-            if (selectedKey == _MergeSortKey.similar ||
-                !_canToggleSortDirection(_sortKey)) {
-              return;
-            }
-            setState(() {
-              _toggleSortDirection(_sortKey);
-            });
-            unawaited(_persistSortPreferences());
-            return;
-          }
+  Widget _buildScrollBody(List<Widget> slivers) {
+    return AppBarComponent(
+      title: context.strings.addToPerson,
+      physics: const BouncingScrollPhysics(),
+      titleBuilder: _buildTitle,
+      titleBuilderHeight: _searchTitleHeight,
+      slivers: slivers,
+    );
+  }
 
-          setState(() {
-            if (selectedKey == _MergeSortKey.similar) {
-              _useSimilaritySort = true;
-            } else {
-              _useSimilaritySort = false;
-              _sortKey = _peopleSortKeyFromMergeSortKey(selectedKey)!;
-            }
-          });
-          unawaited(_persistSortPreferences());
-        },
-        child: IconButtonWidget(
-          icon: Icons.sort_rounded,
-          iconButtonType: IconButtonType.secondary,
-          iconColor: colorScheme.textMuted,
-        ),
+  Widget _buildTitle(BuildContext context, HeaderAppBarTitleState state) {
+    return AnimatedSwitcher(
+      duration: _searchTransitionDuration,
+      switchInCurve: Curves.easeOutCubic,
+      switchOutCurve: Curves.easeInCubic,
+      layoutBuilder: (currentChild, previousChildren) => Stack(
+        alignment: Alignment.centerLeft,
+        clipBehavior: Clip.none,
+        children: [...previousChildren, ?currentChild],
+      ),
+      transitionBuilder: (child, animation) {
+        final curvedAnimation = CurvedAnimation(
+          parent: animation,
+          curve: Curves.easeOutCubic,
+          reverseCurve: Curves.easeInCubic,
+        );
+        final beginOffset = child.key == const ValueKey("person_search_field")
+            ? const Offset(0.035, 0)
+            : const Offset(-0.035, 0);
+        return FadeTransition(
+          opacity: curvedAnimation,
+          child: SlideTransition(
+            position: Tween<Offset>(
+              begin: beginOffset,
+              end: Offset.zero,
+            ).animate(curvedAnimation),
+            child: child,
+          ),
+        );
+      },
+      child: _isSearchBarVisible
+          ? KeyedSubtree(
+              key: const ValueKey("person_search_field"),
+              child: _buildSearchField(context),
+            )
+          : KeyedSubtree(
+              key: const ValueKey("person_title_row"),
+              child: _buildTitleRow(state),
+            ),
+    );
+  }
+
+  Widget _buildTitleRow(HeaderAppBarTitleState state) {
+    return SizedBox(
+      height: state.height,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Text(
+              state.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: state.textStyle,
+            ),
+          ),
+          const SizedBox(width: Spacing.md),
+          SizedBox.square(
+            dimension: _titleActionSize,
+            child: _buildSearchAction(),
+          ),
+          const SizedBox(width: Spacing.sm),
+          SizedBox.square(dimension: _titleActionSize, child: _buildSortMenu()),
+        ],
       ),
     );
   }
 
-  PopupMenuItem<_MergeSortKey> _buildSortMenuItem(
+  Widget _buildSearchAction() {
+    return IconButtonComponent(
+      variant: IconButtonComponentVariant.primary,
+      shouldSurfaceExecutionStates: false,
+      icon: const HugeIcon(icon: HugeIcons.strokeRoundedSearch01),
+      onTap: _activateSearch,
+    );
+  }
+
+  Widget _buildSearchField(BuildContext context) {
+    final colors = context.componentColors;
+    return TextInputComponent(
+      controller: _searchController,
+      focusNode: _searchFocusNode,
+      hintText: context.strings.search,
+      autofocus: true,
+      shouldUnfocusOnClearOrSubmit: true,
+      prefix: HugeIcon(
+        icon: HugeIcons.strokeRoundedSearch01,
+        size: 18,
+        color: colors.textLight,
+      ),
+      suffix: HugeIcon(
+        icon: HugeIcons.strokeRoundedCancel01,
+        size: 18,
+        color: colors.textLight,
+      ),
+      onSuffixTap: _closeSearch,
+      onChanged: _updateSearchQuery,
+    );
+  }
+
+  Widget _buildSortMenu() {
+    return galleryAppBarPopupMenuAction<_MergeSortKey>(
+      icon: const HugeIcon(icon: HugeIcons.strokeRoundedFilterHorizontal),
+      tooltip: context.strings.sort,
+      optionsBuilder: _buildSortMenuOptions,
+      onSelected: _selectSortKey,
+    );
+  }
+
+  List<EntePopupMenuOption<_MergeSortKey>> _buildSortMenuOptions() {
+    final l10n = context.strings;
+    final sortKeys = _canUseSimilaritySort
+        ? _MergeSortKey.values
+        : _MergeSortKey.values
+              .where((key) => key != _MergeSortKey.similar)
+              .toList();
+    return [for (final key in sortKeys) _buildSortMenuItem(key, l10n)];
+  }
+
+  void _selectSortKey(_MergeSortKey selectedKey) {
+    final currentKey = _selectedMergeSortKey;
+    if (selectedKey == currentKey) {
+      if (selectedKey == _MergeSortKey.similar ||
+          !_canToggleSortDirection(_sortKey)) {
+        return;
+      }
+      setState(() {
+        _toggleSortDirection(_sortKey);
+      });
+      unawaited(_persistSortPreferences());
+      return;
+    }
+
+    setState(() {
+      if (selectedKey == _MergeSortKey.similar) {
+        _useSimilaritySort = true;
+      } else {
+        _useSimilaritySort = false;
+        _sortKey = _peopleSortKeyFromMergeSortKey(selectedKey)!;
+      }
+    });
+    unawaited(_persistSortPreferences());
+  }
+
+  EntePopupMenuOption<_MergeSortKey> _buildSortMenuItem(
     _MergeSortKey key,
-    bool isLast,
-    EnteTextTheme textTheme,
-    EnteColorScheme colorScheme,
     StringsLocalizations l10n,
   ) {
     String label;
     late final String detail;
-    IconData? directionIcon;
+    Widget? activeTrailingWidget;
 
     if (key == _MergeSortKey.similar) {
       label = l10n.similar;
@@ -464,7 +542,7 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
           detail = l10n.count;
           break;
         case PeopleSortKey.name:
-          detail = _isSortAscending(peopleKey) ? "A-Z" : "Z-A";
+          detail = _isSortAscending(peopleKey) ? l10n.sortAToZ : l10n.sortZToA;
           break;
         case PeopleSortKey.lastUpdated:
           detail = _isSortAscending(peopleKey)
@@ -474,55 +552,29 @@ class _MergeClustersToPersonPageState extends State<MergeClustersToPersonPage> {
       }
 
       final bool isAscending = _isSortAscending(peopleKey);
-      directionIcon = peopleKey == PeopleSortKey.name
-          ? (isAscending ? Icons.arrow_downward : Icons.arrow_upward)
-          : (isAscending ? Icons.arrow_upward : Icons.arrow_downward);
+      final directionIcon = peopleKey == PeopleSortKey.name
+          ? (isAscending
+                ? HugeIcons.strokeRoundedArrowDown02
+                : HugeIcons.strokeRoundedArrowUp02)
+          : (isAscending
+                ? HugeIcons.strokeRoundedArrowUp02
+                : HugeIcons.strokeRoundedArrowDown02);
+      activeTrailingWidget = HugeIcon(
+        icon: directionIcon,
+        size: 12,
+        strokeWidth: 3,
+        color: context.componentColors.textLight,
+      );
     }
 
     final bool isSelected = _selectedMergeSortKey == key;
 
-    return PopupMenuItem<_MergeSortKey>(
+    return EntePopupMenuOption(
       value: key,
-      padding: EdgeInsets.zero,
-      height: _sortMenuItemHeight,
-      child: Container(
-        width: double.infinity,
-        height: _sortMenuItemHeight,
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        decoration: BoxDecoration(
-          border: isLast
-              ? null
-              : Border(
-                  bottom: BorderSide(
-                    width: 0.5,
-                    color: colorScheme.strokeFaint,
-                  ),
-                ),
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            Text(label, style: textTheme.mini),
-            if (isSelected) ...[
-              const SizedBox(width: 8),
-              Container(
-                width: 4,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: colorScheme.textMuted.withValues(alpha: 0.6),
-                  shape: BoxShape.circle,
-                ),
-              ),
-              const SizedBox(width: 6),
-              Text(detail, style: textTheme.miniMuted),
-              if (directionIcon != null) ...[
-                const SizedBox(width: 4),
-                Icon(directionIcon, size: 16, color: colorScheme.textMuted),
-              ],
-            ],
-          ],
-        ),
-      ),
+      label: label,
+      secondaryLabel: isSelected ? detail : null,
+      isActive: isSelected,
+      activeTrailingWidget: activeTrailingWidget,
     );
   }
 
@@ -744,14 +796,17 @@ class _ManualPersonGridTile extends StatelessWidget {
               child: _FaceSearchResult(result: result),
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.only(top: 6),
-            child: Text(
-              result.name(),
-              maxLines: 1,
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.ellipsis,
-              style: textStyle,
+          SizedBox(
+            height: labelHeight,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Text(
+                result.name(),
+                maxLines: 1,
+                textAlign: TextAlign.center,
+                overflow: TextOverflow.ellipsis,
+                style: textStyle,
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
Updates the unnamed-person picker to use the current Photos app bar and compact sort menu, and fixes the person-name row overflow.

### Before and after

<img src="https://github.com/user-attachments/assets/11f0bc1b-065f-4922-aac7-e65f3b11ce5c" width="300" height="650"> <img src="https://github.com/user-attachments/assets/980b5c6c-73de-42d4-8f2a-f03e2d3051bb" width="300" height="650">

### Sort menu

<img src="https://github.com/user-attachments/assets/9d010c3e-d57b-4b10-8487-0cbbf8519ff9" width="300" height="650">
