### PR TITLE
[server] Avoid unused Locker file count queries

### DIFF
--- a/server/pkg/controller/user/user_details.go
+++ b/server/pkg/controller/user/user_details.go
@@ -58,9 +58,10 @@ func (c *UserController) GetDetailsV2(ctx *gin.Context, userID int64, fetchMemor
 		if bonusErr != nil {
 			return stacktrace.Propagate(bonusErr, "failed to fetch storage bonus")
 		}
-		if app == ente.Locker {
+		switch app {
+		case ente.Locker:
 			lockerUsage, err = c.UsageRepo.GetLockerUsage(ctx, subscriptionUserIDs)
-		} else {
+		case ente.Photos:
 			lockerUsage, err = c.UsageRepo.GetLockerStorageUsage(ctx, subscriptionUserIDs)
 		}
 		if err != nil {

--- a/server/pkg/controller/user/user_details.go
+++ b/server/pkg/controller/user/user_details.go
@@ -58,7 +58,11 @@ func (c *UserController) GetDetailsV2(ctx *gin.Context, userID int64, fetchMemor
 		if bonusErr != nil {
 			return stacktrace.Propagate(bonusErr, "failed to fetch storage bonus")
 		}
-		lockerUsage, err = c.UsageRepo.GetLockerUsage(ctx, subscriptionUserIDs)
+		if app == ente.Locker {
+			lockerUsage, err = c.UsageRepo.GetLockerUsage(ctx, subscriptionUserIDs)
+		} else {
+			lockerUsage, err = c.UsageRepo.GetLockerStorageUsage(ctx, subscriptionUserIDs)
+		}
 		if err != nil {
 			return stacktrace.Propagate(err, "failed to fetch locker usage")
 		}

--- a/server/pkg/repo/file_count_read_test.go
+++ b/server/pkg/repo/file_count_read_test.go
@@ -22,10 +22,11 @@ func TestGetLockerUsageUsesStoredAndLegacyCountsPerUser(t *testing.T) {
 	linkObjectTestFileToCollection(t, db, collectionID, fileID, legacyUserID)
 
 	var queued []int64
-	usage, err := (&UsageRepository{
+	usageRepo := &UsageRepository{
 		DB:                           db,
 		QueueFileCountInitialization: func(userID int64) { queued = append(queued, userID) },
-	}).GetLockerUsage(t.Context(), []int64{readyUserID, legacyUserID})
+	}
+	usage, err := usageRepo.GetLockerUsage(t.Context(), []int64{readyUserID, legacyUserID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,5 +38,14 @@ func TestGetLockerUsageUsesStoredAndLegacyCountsPerUser(t *testing.T) {
 	}
 	if len(queued) != 1 || queued[0] != legacyUserID {
 		t.Fatalf("queued users = %v, want [%d]", queued, legacyUserID)
+	}
+
+	queued = nil
+	usage, err = usageRepo.GetLockerStorageUsage(t.Context(), []int64{readyUserID, legacyUserID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.TotalFileCount != 0 || len(queued) != 0 {
+		t.Fatalf("storage-only usage = %+v, queued users = %v", usage, queued)
 	}
 }

--- a/server/pkg/repo/usage.go
+++ b/server/pkg/repo/usage.go
@@ -119,6 +119,14 @@ func (repo *UsageRepository) GetStorageWarningCandidates(ctx context.Context, us
 }
 
 func (repo *UsageRepository) GetLockerUsage(ctx context.Context, userIDs []int64) (*LockerUsage, error) {
+	return repo.getLockerUsage(ctx, userIDs, true)
+}
+
+func (repo *UsageRepository) GetLockerStorageUsage(ctx context.Context, userIDs []int64) (*LockerUsage, error) {
+	return repo.getLockerUsage(ctx, userIDs, false)
+}
+
+func (repo *UsageRepository) getLockerUsage(ctx context.Context, userIDs []int64, includeFileCounts bool) (*LockerUsage, error) {
 	usage := &LockerUsage{}
 	if len(userIDs) == 0 {
 		return usage, nil
@@ -129,55 +137,57 @@ func (repo *UsageRepository) GetLockerUsage(ctx context.Context, userIDs []int64
 		userMap[userID] = &UserLockerUsage{UserID: userID}
 	}
 
-	rows, err := repo.DB.QueryContext(ctx, `SELECT requested.user_id, u.locker_file_count
-		FROM unnest($1::bigint[]) AS requested(user_id)
-		LEFT JOIN usage AS u ON u.user_id = requested.user_id`, pq.Array(userIDs))
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "")
-	}
-	defer rows.Close()
-	var uninitializedUserIDs []int64
-	for rows.Next() {
-		var userID int64
-		var fileCount sql.NullInt64
-		if err := rows.Scan(&userID, &fileCount); err != nil {
-			return nil, stacktrace.Propagate(err, "")
-		}
-		if fileCount.Valid {
-			userMap[userID].FileCount = fileCount.Int64
-		} else {
-			uninitializedUserIDs = append(uninitializedUserIDs, userID)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, stacktrace.Propagate(err, "")
-	}
-	if repo.QueueFileCountInitialization != nil {
-		for _, userID := range uninitializedUserIDs {
-			repo.QueueFileCountInitialization(userID)
-		}
-	}
-
-	if len(uninitializedUserIDs) > 0 {
-		rows, err = repo.DB.QueryContext(ctx, `SELECT c.owner_id, COUNT(DISTINCT cf.file_id)
-			FROM collections AS c
-			JOIN collection_files AS cf ON c.collection_id = cf.collection_id
-			WHERE c.app = 'locker' AND c.owner_id = ANY($1)
-				AND cf.f_owner_id = c.owner_id AND cf.is_deleted = FALSE
-			GROUP BY c.owner_id`, pq.Array(uninitializedUserIDs))
+	if includeFileCounts {
+		rows, err := repo.DB.QueryContext(ctx, `SELECT requested.user_id, u.locker_file_count
+			FROM unnest($1::bigint[]) AS requested(user_id)
+			LEFT JOIN usage AS u ON u.user_id = requested.user_id`, pq.Array(userIDs))
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "")
 		}
 		defer rows.Close()
+		var uninitializedUserIDs []int64
 		for rows.Next() {
-			var userID, fileCount int64
+			var userID int64
+			var fileCount sql.NullInt64
 			if err := rows.Scan(&userID, &fileCount); err != nil {
 				return nil, stacktrace.Propagate(err, "")
 			}
-			userMap[userID].FileCount = fileCount
+			if fileCount.Valid {
+				userMap[userID].FileCount = fileCount.Int64
+			} else {
+				uninitializedUserIDs = append(uninitializedUserIDs, userID)
+			}
 		}
 		if err := rows.Err(); err != nil {
 			return nil, stacktrace.Propagate(err, "")
+		}
+		if repo.QueueFileCountInitialization != nil {
+			for _, userID := range uninitializedUserIDs {
+				repo.QueueFileCountInitialization(userID)
+			}
+		}
+
+		if len(uninitializedUserIDs) > 0 {
+			rows, err = repo.DB.QueryContext(ctx, `SELECT c.owner_id, COUNT(DISTINCT cf.file_id)
+				FROM collections AS c
+				JOIN collection_files AS cf ON c.collection_id = cf.collection_id
+				WHERE c.app = 'locker' AND c.owner_id = ANY($1)
+					AND cf.f_owner_id = c.owner_id AND cf.is_deleted = FALSE
+				GROUP BY c.owner_id`, pq.Array(uninitializedUserIDs))
+			if err != nil {
+				return nil, stacktrace.Propagate(err, "")
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var userID, fileCount int64
+				if err := rows.Scan(&userID, &fileCount); err != nil {
+					return nil, stacktrace.Propagate(err, "")
+				}
+				userMap[userID].FileCount = fileCount
+			}
+			if err := rows.Err(); err != nil {
+				return nil, stacktrace.Propagate(err, "")
+			}
 		}
 	}
 
@@ -197,7 +207,7 @@ func (repo *UsageRepository) GetLockerUsage(ctx context.Context, userIDs []int64
       GROUP BY unique_files.owner_id;
    `
 
-	rows, err = repo.DB.QueryContext(ctx, sizeQuery, pq.Array(userIDs))
+	rows, err := repo.DB.QueryContext(ctx, sizeQuery, pq.Array(userIDs))
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}


### PR DESCRIPTION
## Summary

- fetch Locker file counts only for Locker user-details requests
- keep the storage-only Locker calculation needed by Photos
- return total storage usage to Auth without querying Locker usage

This avoids legacy Locker count work where its result is discarded and removes the Locker usage query entirely from Auth requests.