### PR TITLE
[mob][photos] Refine justified row sizing

### DIFF
--- a/mobile/apps/photos/lib/models/gallery/flex_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/flex_layout.dart
@@ -8,6 +8,8 @@ import "package:photos/models/gallery/justified_layout.dart";
 class FlexLayoutCalculator {
   static const double _minimumTappableExtent = 48;
   static const double _defaultMaximumRowHeightFactor = 1.6;
+  static const double _minimumLandscapeRowHeight = 96;
+  static const int _minimumLandscapeDensityItemCount = 3;
   static const double _preferredTileWidthFactor = 0.6;
   static const double _cropPenaltyWeight = 4;
 
@@ -90,6 +92,11 @@ class FlexLayoutCalculator {
           maximumHeight: maximumHeight,
           isTail: isTail,
         );
+        if (itemCount >= _minimumLandscapeDensityItemCount &&
+            minimumRatio >= 1 &&
+            geometry.height < _minimumLandscapeRowHeight) {
+          continue;
+        }
         final heightDeviation = math.log(geometry.height / targetRowHeight);
         final narrowness = math.max(
           0.0,

--- a/mobile/apps/photos/lib/models/gallery/justified_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/justified_layout.dart
@@ -96,7 +96,7 @@ class JustifiedLayoutCalculator {
   static const double _minimumAspectRatio = 1 / 3;
   static const double _maximumAspectRatio = 4.0;
   static const double _maximumRowHeightFactor = 2.4;
-  static const double _maximumWideFinalRowHeightFactor = 1.25;
+  static const double _maximumWideFinalRowHeightFactor = 1.0;
   static const double _minimumLandscapeRowHeightFactor = 0.88;
   static const double _mediumWidthBreakpoint = 600;
   static const double _expandedWidthBreakpoint = 1008;

--- a/mobile/apps/photos/lib/models/gallery/justified_layout_tuning.dart
+++ b/mobile/apps/photos/lib/models/gallery/justified_layout_tuning.dart
@@ -95,7 +95,7 @@ class ComfortLargeLayoutTuning {
   const ComfortLargeLayoutTuning({
     this.targetHeightScale = 1.5,
     this.maximumHeightFactor = 2.4,
-    this.wideFinalMaximumHeightFactor = 1.25,
+    this.wideFinalMaximumHeightFactor = 1.0,
     this.minimumLandscapeHeightFactor = 0.88,
   });
 

--- a/mobile/apps/photos/test/models/flex_layout_test.dart
+++ b/mobile/apps/photos/test/models/flex_layout_test.dart
@@ -90,6 +90,32 @@ void main() {
     expect(_occupiedWidth(rows.single), closeTo(402, 1e-9));
   });
 
+  test("avoids cramped landscape rows without imposing a count cap", () {
+    const ratios = [0.75, 0.75, 2.0, 2.0, 2.0, 2.0, 2.0, 0.4, 0.4, 0.4];
+    final compactRows = _rows(ratios, targetHeight: 224);
+
+    for (final row in compactRows) {
+      final rowRatios = ratios.sublist(row.firstIndex, row.lastIndex + 1);
+      if (rowRatios.length >= 3 && rowRatios.every((ratio) => ratio >= 1)) {
+        expect(row.height, greaterThanOrEqualTo(96));
+      }
+    }
+
+    final moderateLandscapeRow = _rows(
+      [4 / 3, 4 / 3, 4 / 3],
+      width: 393,
+      targetHeight: 100,
+    ).single;
+    expect(moderateLandscapeRow.itemWidths, hasLength(3));
+
+    final wideLandscapeRow = _rows(
+      List.filled(5, 2.0),
+      width: 1024,
+      targetHeight: 100,
+    ).single;
+    expect(wideLandscapeRow.itemWidths, hasLength(5));
+  });
+
   test("fills a final row until its configurable maximum height", () {
     final fitted = _rows([0.75, 0.75], targetHeight: 200).single;
     expect(fitted.height, closeTo(400 / 1.5, 1e-9));

--- a/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
+++ b/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
@@ -163,8 +163,12 @@ void main() {
     await localSettings.setJustifiedLayoutStrategy(
       JustifiedLayoutStrategy.flex,
     );
+    await localSettings.setFlexLayoutTuningValue(
+      FlexLayoutTuningField.targetHeightScale,
+      1,
+    );
     final flex = groups().groupLayouts.single as JustifiedSectionLayout;
-    expect(flex.rows.map((row) => row.itemWidths.length), [3, 1]);
+    expect(flex.rows.single.itemWidths, hasLength(4));
   });
 
   test("routes Flex Full Rows with independent tuning", () async {

--- a/mobile/apps/photos/test/models/justified_layout_test.dart
+++ b/mobile/apps/photos/test/models/justified_layout_test.dart
@@ -63,7 +63,7 @@ void main() {
           spacing: 2,
         ).single;
 
-        expect(row.height, 400, reason: "available width ${testCase.width}");
+        expect(row.height, 320, reason: "available width ${testCase.width}");
         expect(
           _occupiedWidth(row, 2),
           lessThan(testCase.width),
@@ -103,8 +103,8 @@ void main() {
         closeTo(1 / 3, 1e-9),
       );
       expect(landscape.height, 200);
-      expect(mediumPortrait.height, 400);
-      expect(mediumPortrait.itemWidths.single, 200);
+      expect(mediumPortrait.height, 320);
+      expect(mediumPortrait.itemWidths.single, 160);
       expect(minimumTappablePortrait.height, 144);
       expect(minimumTappablePortrait.itemWidths.single, 48);
     });
@@ -243,7 +243,7 @@ void main() {
         );
         final expectedFinalHeight = testCase.width < 600
             ? 3 * targetHeight
-            : 1.25 * targetHeight;
+            : targetHeight;
         expect(
           rows.last.height,
           closeTo(expectedFinalHeight, 1e-9),
@@ -330,6 +330,7 @@ void main() {
         availableWidth: 600,
         targetRowHeight: 200,
         spacing: 2,
+        wideFinalMaximumRowHeightFactor: 1.25,
       );
 
       expect(rows.map((row) => row.itemWidths.length), [3, 2]);


### PR DESCRIPTION
Refines the internal justified layouts after device testing: Flex variants avoid cramped rows containing three or more landscape items without imposing an item-count cap, and Comfort Large uses a tighter wide-screen final-row growth limit to prevent oversized sparse tails.