### PR TITLE
[mob][photos] Refresh social overlay after sync

### DIFF
--- a/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
@@ -117,7 +117,11 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
   }
 
   bool _isCurrentSocialRefresh(int refreshID) {
-    return mounted && refreshID == _latestRefreshID;
+    return mounted &&
+        refreshID == _latestRefreshID &&
+        !_fileIDsWithReactionUpdateInProgress.contains(
+          widget.file.uploadedFileID,
+        );
   }
 
   bool _isOpenedFromHiddenCollection() {
@@ -289,6 +293,9 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
       );
     } finally {
       _fileIDsWithReactionUpdateInProgress.remove(fileID);
+      if (mounted && widget.file.uploadedFileID == fileID) {
+        unawaited(_refreshSocialState());
+      }
     }
   }
 

--- a/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
+++ b/mobile/apps/photos/lib/ui/social/widgets/file_social_overlay.dart
@@ -7,6 +7,8 @@ import "package:ente_strings/ente_strings.dart";
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:logging/logging.dart";
+import "package:photos/core/event_bus.dart";
+import "package:photos/events/social_data_updated_event.dart";
 import "package:photos/models/api/collection/user.dart";
 import "package:photos/models/collection/collection.dart";
 import "package:photos/models/file/file.dart";
@@ -70,6 +72,9 @@ class FileSocialOverlay extends StatefulWidget {
 }
 
 class _FileSocialOverlayState extends State<FileSocialOverlay> {
+  late final StreamSubscription<SocialDataUpdatedEvent>
+  _socialDataUpdatedSubscription;
+
   bool _hasEligibleSharedCollections = false;
   bool _hasLiked = false;
   int _commentCount = 0;
@@ -82,6 +87,9 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
   @override
   void initState() {
     super.initState();
+    _socialDataUpdatedSubscription = Bus.instance
+        .on<SocialDataUpdatedEvent>()
+        .listen((_) => unawaited(_refreshSocialState()));
     unawaited(_refreshSocialState());
   }
 
@@ -91,6 +99,12 @@ class _FileSocialOverlayState extends State<FileSocialOverlay> {
     if (oldWidget.file.uploadedFileID != widget.file.uploadedFileID) {
       unawaited(_refreshSocialState());
     }
+  }
+
+  @override
+  void dispose() {
+    _socialDataUpdatedSubscription.cancel();
+    super.dispose();
   }
 
   void _clearSocialState() {


### PR DESCRIPTION
## Description

An already-open photo can keep showing an old comment count, latest-comment preview, or heart state after periodic or foreground-resume sync downloads social updates. Restore the `SocialDataUpdatedEvent` listener so the overlay rereads its local state after sync, and cancel the subscription when the widget is disposed.

Preserve optimistic heart state while a like/unlike request is pending, then refresh the current photo after the request finishes. This prevents a concurrent sync from leaving a successful reaction displayed with the old heart state.

Fixes ente/review#57.

## Tests

- `flutter analyze --no-pub lib/ui/social/widgets/file_social_overlay.dart` — passed.
- `flutter test --no-pub test/db/social_db_test.dart test/models/social/comment_author_utils_test.dart` — all 5 existing tests passed.
- Dart formatting and `git diff --check` — passed.
- Four local scripted race checks using the production refresh/reaction methods with dependency doubles passed: like and unlike, with stale reads completing before or after the reaction is saved. The same harness reproduces the failure on the initial PR commit. These checks are kept outside the repository.
- Manual two-device foreground/resume verification has not been run.
