### PR TITLE
[mob][photos] Wait for cast token revocation

### DIFF
--- a/mobile/apps/photos/changes/cast-revocation.md
+++ b/mobile/apps/photos/changes/cast-revocation.md
@@ -1,0 +1,1 @@
+Wait for cast access to be revoked before stopping or starting a new pairing, and report failures so you can retry.

--- a/mobile/apps/photos/lib/gateways/cast/cast_gateway.dart
+++ b/mobile/apps/photos/lib/gateways/cast/cast_gateway.dart
@@ -81,11 +81,7 @@ class CastGateway {
   }
 
   Future<void> revokeAllTokens() async {
-    try {
-      await _enteDio.delete("/cast/revoke-all-tokens");
-    } catch (e) {
-      // swallow error
-    }
+    await _enteDio.delete("/cast/revoke-all-tokens");
   }
 
   Future<void> revokeSession(CastInfo session) async {

--- a/mobile/apps/photos/lib/ui/cast/cast.dart
+++ b/mobile/apps/photos/lib/ui/cast/cast.dart
@@ -51,7 +51,7 @@ Future<void> showCastSheet(
       await dialog.hide();
     } catch (e, s) {
       await dialog.hide();
-      logger.severe("Failed to revoke or stop cast sessions", e, s);
+      logger.warning("Failed to revoke or stop cast sessions", e, s);
       if (!context.mounted) return;
       await showGenericErrorDialog(context: context, error: e);
       return;

--- a/mobile/apps/photos/lib/ui/cast/cast.dart
+++ b/mobile/apps/photos/lib/ui/cast/cast.dart
@@ -1,5 +1,4 @@
-import "dart:async";
-
+import "package:ente_cast/ente_cast.dart";
 import "package:ente_components/ente_components.dart";
 import "package:ente_strings/ente_strings.dart";
 import "package:flutter/widgets.dart";
@@ -12,32 +11,56 @@ import "package:photos/service_locator.dart";
 import "package:photos/theme/ente_theme.dart";
 import "package:photos/ui/cast/pair_with_auto.dart";
 import "package:photos/ui/cast/pair_with_code.dart";
+import "package:photos/ui/components/buttons/button_widget.dart";
 import "package:photos/ui/settings/cast/cast_settings_page.dart";
 import "package:photos/utils/dialog_util.dart";
 
-Future<void> showCastSheet(BuildContext context, Collection collection) async {
+Future<void> showCastSheet(
+  BuildContext context,
+  Collection collection, {
+  CastGateway? gateway,
+  CastService? transport,
+}) async {
   final l10n = context.strings;
   final textStyle = getEnteTextTheme(context);
-  final gw = CastGateway(NetworkClient.instance.enteDio);
-  final showAutoPair = castService.isSupported;
+  final gw = gateway ?? CastGateway(NetworkClient.instance.enteDio);
+  final service = transport ?? castService;
+  final showAutoPair = service.isSupported;
+  final logger = Logger("showCastSheet");
   if (!flagService.enableMultiCast) {
-    if (castService.getActiveSessions().isNotEmpty) {
-      await showChoiceDialog(
+    if (service.getActiveSessions().isNotEmpty) {
+      final result = await showChoiceDialog(
         context,
         title: l10n.stopCastingTitle,
         body: l10n.stopCastingBody,
         firstButtonLabel: l10n.yes,
         secondButtonLabel: l10n.no,
         firstButtonOnTap: () async {
-          unawaited(gw.revokeAllTokens());
-          await castService.closeActiveCasts();
+          await gw.revokeAllTokens();
+          await service.closeActiveCasts();
         },
       );
+      if (result?.action == ButtonAction.error && context.mounted) {
+        await showGenericErrorDialog(
+          context: context,
+          error: result?.exception,
+        );
+      }
       return;
     }
-    unawaited(gw.revokeAllTokens());
+    final dialog = createProgressDialog(context, l10n.pleaseWait);
+    await dialog.show();
+    try {
+      await gw.revokeAllTokens();
+      await dialog.hide();
+    } catch (e, s) {
+      await dialog.hide();
+      logger.severe("Failed to revoke cast tokens before pairing", e, s);
+      if (!context.mounted) return;
+      await showGenericErrorDialog(context: context, error: e);
+      return;
+    }
   }
-  final logger = Logger("showCastSheet");
   List<CastInfo> sessions = [];
   if (flagService.enableMultiCast) {
     try {

--- a/mobile/apps/photos/lib/ui/cast/cast.dart
+++ b/mobile/apps/photos/lib/ui/cast/cast.dart
@@ -28,38 +28,35 @@ Future<void> showCastSheet(
   final showAutoPair = service.isSupported;
   final logger = Logger("showCastSheet");
   if (!flagService.enableMultiCast) {
-    if (service.getActiveSessions().isNotEmpty) {
+    final shouldStop = service.getActiveSessions().isNotEmpty;
+    if (shouldStop) {
       final result = await showChoiceDialog(
         context,
         title: l10n.stopCastingTitle,
         body: l10n.stopCastingBody,
         firstButtonLabel: l10n.yes,
         secondButtonLabel: l10n.no,
-        firstButtonOnTap: () async {
-          await gw.revokeAllTokens();
-          await service.closeActiveCasts();
-        },
       );
-      if (result?.action == ButtonAction.error && context.mounted) {
-        await showGenericErrorDialog(
-          context: context,
-          error: result?.exception,
-        );
+      if (result?.action != ButtonAction.first || !context.mounted) {
+        return;
       }
-      return;
     }
     final dialog = createProgressDialog(context, l10n.pleaseWait);
     await dialog.show();
     try {
       await gw.revokeAllTokens();
+      if (shouldStop) {
+        await service.closeActiveCasts();
+      }
       await dialog.hide();
     } catch (e, s) {
       await dialog.hide();
-      logger.severe("Failed to revoke cast tokens before pairing", e, s);
+      logger.severe("Failed to revoke or stop cast sessions", e, s);
       if (!context.mounted) return;
       await showGenericErrorDialog(context: context, error: e);
       return;
     }
+    if (shouldStop) return;
   }
   List<CastInfo> sessions = [];
   if (flagService.enableMultiCast) {

--- a/mobile/apps/photos/lib/ui/cast/pair_with_code.dart
+++ b/mobile/apps/photos/lib/ui/cast/pair_with_code.dart
@@ -20,9 +20,6 @@ Future<void> _pairWithCode(
   String code,
 ) async {
   final gw = CastGateway(NetworkClient.instance.enteDio);
-  if (!flagService.enableMultiCast) {
-    await gw.revokeAllTokens();
-  }
   final publicKeys = await gw.getPublicKeys(code);
   if (publicKeys == null) {
     throw const _DeviceNotFoundException();
@@ -40,6 +37,7 @@ Future<void> _pairWithCode(
   );
 }
 
+// The parent cast sheet revokes old single-cast sessions before offering pairing.
 Future<bool?> showPairWithCodeSheet(
   BuildContext context,
   Collection collection,

--- a/mobile/apps/photos/test/ui/cast/cast_test.dart
+++ b/mobile/apps/photos/test/ui/cast/cast_test.dart
@@ -4,6 +4,7 @@ import "package:ente_strings/ente_strings.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:package_info_plus/package_info_plus.dart";
+import "package:photos/core/network/network.dart";
 import "package:photos/ente_theme_data.dart";
 import "package:photos/gateways/cast/cast_gateway.dart";
 import "package:photos/models/collection/collection.dart";
@@ -43,12 +44,27 @@ void main() {
 
     await tester.tap(find.text("Cast"));
     await tester.pumpAndSettle();
+    await tester.tap(find.text("No"));
+    await tester.pumpAndSettle();
+    expect(requests.pending, isEmpty);
+    expect(transport.closeCount, 0);
+
+    await tester.tap(find.text("Cast"));
+    await tester.pumpAndSettle();
     await tester.tap(find.text("Yes"));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
     await tester.pump(const Duration(seconds: 1));
 
     expect(requests.pending, hasLength(1));
     expect(transport.closeCount, 0);
-    expect(find.text("Stop casting"), findsOneWidget);
+    expect(find.text("No"), findsNothing);
+    expect(find.text("Please wait..."), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(find.text("Please wait..."), findsOneWidget);
 
     requests.fail();
     await tester.pumpAndSettle();
@@ -60,6 +76,8 @@ void main() {
     await tester.tap(find.text("Cast"));
     await tester.pumpAndSettle();
     await tester.tap(find.text("Yes"));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
     await tester.pump(const Duration(seconds: 1));
     expect(transport.closeCount, 0);
 
@@ -99,6 +117,21 @@ void main() {
     expect(find.text("Auto pair"), findsOneWidget);
     expect(find.text("Pair using code"), findsOneWidget);
     expect(transport.closeCount, 0);
+
+    await tester.tap(find.text("Pair using code"));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), "ABC123");
+    await tester.tap(find.text("Pair"));
+    await tester.pump(const Duration(seconds: 1));
+    expect(requests.pending, hasLength(1));
+    expect(requests.pending.single.$1.method, "GET");
+    expect(requests.pending.single.$1.path, "/cast/device-info/ABC123");
+    requests.fail();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(find.text("Error"), findsOneWidget);
+    await tester.tap(find.text("OK"));
+    await tester.pumpAndSettle();
   });
 }
 
@@ -107,6 +140,9 @@ Future<void> _pumpCastButton(
   _RevocationRequests requests,
   CastService transport,
 ) async {
+  final originalNetworkClient = NetworkClient.instance;
+  NetworkClient.instance = _FakeNetworkClient(requests.dio);
+  addTearDown(() => NetworkClient.instance = originalNetworkClient);
   await tester.pumpWidget(
     MaterialApp(
       theme: lightThemeData,
@@ -137,8 +173,6 @@ class _RevocationRequests {
     dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) {
-          expect(options.method, "DELETE");
-          expect(options.path, "/cast/revoke-all-tokens");
           pending.add((options, handler));
         },
       ),
@@ -182,3 +216,10 @@ class _FakeCastService extends Fake implements CastService {
 }
 
 class _FakeCollection extends Fake implements Collection {}
+
+class _FakeNetworkClient extends Fake implements NetworkClient {
+  @override
+  final Dio enteDio;
+
+  _FakeNetworkClient(this.enteDio);
+}

--- a/mobile/apps/photos/test/ui/cast/cast_test.dart
+++ b/mobile/apps/photos/test/ui/cast/cast_test.dart
@@ -1,0 +1,184 @@
+import "package:dio/dio.dart";
+import "package:ente_cast/ente_cast.dart";
+import "package:ente_strings/ente_strings.dart";
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:package_info_plus/package_info_plus.dart";
+import "package:photos/ente_theme_data.dart";
+import "package:photos/gateways/cast/cast_gateway.dart";
+import "package:photos/models/collection/collection.dart";
+import "package:photos/service_locator.dart";
+import "package:photos/ui/cast/cast.dart";
+import "package:shared_preferences/shared_preferences.dart";
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    ServiceLocator.instance.init(
+      preferences,
+      Dio(),
+      Dio(),
+      Dio(),
+      PackageInfo(
+        appName: "Photos",
+        packageName: "photos",
+        version: "1.0.0",
+        buildNumber: "1",
+      ),
+    );
+    await localSettings.setInternalUserDisabled(true);
+    // Initialize the flag refresher outside the widget-test fake clock.
+    expect(flagService.enableMultiCast, isFalse);
+  });
+
+  testWidgets("stop waits for revocation and a failed request can be retried", (
+    tester,
+  ) async {
+    final requests = _RevocationRequests();
+    final transport = _FakeCastService(hasActiveSession: true);
+    await _pumpCastButton(tester, requests, transport);
+
+    await tester.tap(find.text("Cast"));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Yes"));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(requests.pending, hasLength(1));
+    expect(transport.closeCount, 0);
+    expect(find.text("Stop casting"), findsOneWidget);
+
+    requests.fail();
+    await tester.pumpAndSettle();
+    expect(transport.closeCount, 0);
+    expect(find.text("Error"), findsOneWidget);
+
+    await tester.tap(find.text("OK"));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Cast"));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Yes"));
+    await tester.pump(const Duration(seconds: 1));
+    expect(transport.closeCount, 0);
+
+    requests.succeed();
+    await tester.pumpAndSettle();
+    expect(transport.closeCount, 1);
+    expect(find.text("Stop casting"), findsNothing);
+  });
+
+  testWidgets("pairing stays blocked until revocation succeeds after retry", (
+    tester,
+  ) async {
+    final requests = _RevocationRequests();
+    final transport = _FakeCastService(hasActiveSession: false);
+    await _pumpCastButton(tester, requests, transport);
+
+    await tester.tap(find.text("Cast"));
+    await tester.pump(const Duration(seconds: 1));
+    expect(requests.pending, hasLength(1));
+    expect(find.text("Please wait..."), findsOneWidget);
+    expect(find.text("Auto pair"), findsNothing);
+    expect(find.text("Pair using code"), findsNothing);
+
+    requests.fail();
+    await tester.pumpAndSettle();
+    expect(find.text("Error"), findsOneWidget);
+    expect(find.text("Pair using code"), findsNothing);
+
+    await tester.tap(find.text("OK"));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Cast"));
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text("Pair using code"), findsNothing);
+
+    requests.succeed();
+    await tester.pumpAndSettle();
+    expect(find.text("Auto pair"), findsOneWidget);
+    expect(find.text("Pair using code"), findsOneWidget);
+    expect(transport.closeCount, 0);
+  });
+}
+
+Future<void> _pumpCastButton(
+  WidgetTester tester,
+  _RevocationRequests requests,
+  CastService transport,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: lightThemeData,
+      localizationsDelegates: StringsLocalizations.localizationsDelegates,
+      supportedLocales: StringsLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showCastSheet(
+              context,
+              _FakeCollection(),
+              gateway: CastGateway(requests.dio),
+              transport: transport,
+            ),
+            child: const Text("Cast"),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+class _RevocationRequests {
+  final dio = Dio();
+  final pending = <(RequestOptions, RequestInterceptorHandler)>[];
+
+  _RevocationRequests() {
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          expect(options.method, "DELETE");
+          expect(options.path, "/cast/revoke-all-tokens");
+          pending.add((options, handler));
+        },
+      ),
+    );
+  }
+
+  void fail() {
+    final (options, handler) = pending.removeAt(0);
+    handler.reject(
+      DioException(
+        requestOptions: options,
+        type: DioExceptionType.connectionError,
+      ),
+    );
+  }
+
+  void succeed() {
+    final (options, handler) = pending.removeAt(0);
+    handler.resolve(Response<void>(requestOptions: options, statusCode: 200));
+  }
+}
+
+class _FakeCastService extends Fake implements CastService {
+  bool hasActiveSession;
+  int closeCount = 0;
+
+  _FakeCastService({required this.hasActiveSession});
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Map<String, String> getActiveSessions() =>
+      hasActiveSession ? {"device": "connected"} : {};
+
+  @override
+  Future<void> closeActiveCasts() async {
+    closeCount++;
+    hasActiveSession = false;
+  }
+}
+
+class _FakeCollection extends Fake implements Collection {}


### PR DESCRIPTION
## Description

In the single-cast flow, stopping casting or opening pairing options could finish while token revocation was still pending, and the gateway discarded revocation errors. Revoke old sessions once before offering pairing options. For stopping, confirm the choice first, then await revocation and disconnect under the existing non-dismissible progress dialog. Log revocation or stop failures at warning level and surface them so the user can retry.

Cancellation before confirmation sends no request. After confirmation, back and backdrop actions cannot hide the pending operation or its error handling.

## Tests

- `flutter analyze --no-pub` from `mobile/`: clean.
- `flutter test --no-pub test/ui/cast/cast_test.dart test/services/auto_cast_service_test.dart`: 3 passed, covering delayed revocation, failure and retry, cancellation/dismissal, and code pairing without a duplicate revocation.
- `flutter test --no-pub` from `mobile/apps/photos/plugins/ente_cast`: 11 passed.
- The new UI tests fail when either the unawaited calls or the swallowed gateway errors are independently restored.
- Dart formatting, frozen pubspec verification, and source ARB plural checks passed.

- After the logging-only change in `7d9877f`, targeted Dart analysis, formatting, and `git diff --check` passed. Device checks below were performed on `309b646`.

### Android device and browser receiver verification

Tested commit `309b646` on a physical Pixel 4 with the production `cast.ente.com` receiver in two independent browsers (Codex in-app browser and Chrome). A temporary test entry point ran the real app UI, injected revocation delays/failures, and recorded cast request ordering. Single-cast and multi-cast were exercised by temporarily switching the local feature flag. Receiver checks used a generated test image.

- **Delayed failure:** During a 12-second injected revocation delay, Android Back did not dismiss “Please wait”. The subsequent failure showed an error without opening pairing options.
- **Successful retry and pairing:** After a five-second delay, the real revocation request returned HTTP 200 before pairing options appeared. Code pairing then succeeded and the browser displayed the test image, with no duplicate revocation request.
- **Multiple receivers:** Pairing a second receiver in multi-cast mode sent no bulk-revocation request. Both receivers displayed the image and had distinct server sessions. The first receiver also continued working after reload.
- **Individual stop:** Stopping one browser session removed only that session; the other remained active and displayed the image after reload.

Test sessions were cleaned up, and the phone’s original APK and feature-flag settings were restored. Physical TV Auto pair, single-cast stop cancellation on hardware, and the TV transport shutdown through `closeActiveCasts()` remain unverified on hardware. These browser checks do not establish multi-frame slideshow behavior.

## Screenshots

Widget-test captures with a simulated pending revocation request. The host screen is a test harness; the sheets are the actual app UI.

| Flow | Before | After |
| --- | --- | --- |
| Stop: confirmation previously disappeared while revocation was pending; now confirmed stops show non-dismissible progress. | <img src="https://raw.githubusercontent.com/ashil-pilot/ente/b7544ce9f8d2f1ed9c80f29f7c8d722d2e5a03c6/before-stop.png" width="220"> | <img src="https://raw.githubusercontent.com/ashil-pilot/ente/b7544ce9f8d2f1ed9c80f29f7c8d722d2e5a03c6/after-stop.png" width="220"> |
| Pair: options appear before the request completes; now preparation waits. | <img src="https://raw.githubusercontent.com/ashil-pilot/ente/b7544ce9f8d2f1ed9c80f29f7c8d722d2e5a03c6/before-pairing.png" width="220"> | <img src="https://raw.githubusercontent.com/ashil-pilot/ente/b7544ce9f8d2f1ed9c80f29f7c8d722d2e5a03c6/after-pairing.png" width="220"> |
