### PR TITLE
[mob][photos] Preserve shared imports after upload failures

### DIFF
--- a/mobile/apps/photos/changes/preserve-pending-shared-media.md
+++ b/mobile/apps/photos/changes/preserve-pending-shared-media.md
@@ -1,0 +1,1 @@
+- Preserved pending shared photos and videos when an upload fails because device storage is full.

--- a/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
+++ b/mobile/apps/photos/lib/module/upload/service/file_uploader.dart
@@ -31,6 +31,7 @@ import "package:photos/module/upload/service/existing_upload_resolver.dart";
 import "package:photos/module/upload/service/multipart.dart";
 import 'package:photos/module/upload/service/upload_artifact_lifecycle.dart';
 import 'package:photos/module/upload/service/upload_queue.dart';
+import 'package:photos/module/upload/service/upload_source_cleanup.dart';
 import 'package:photos/module/upload/service/upload_transport.dart';
 import "package:photos/module/upload/upload_data.dart";
 import "package:photos/module/upload/upload_metadata.dart";
@@ -443,6 +444,7 @@ class FileUploader {
 
     var uploadCompleted = false;
     var uploadHardFailure = false;
+    var uploadInvalidFile = false;
 
     try {
       final bool isUpdatedFile =
@@ -783,6 +785,7 @@ class FileUploader {
       if (e is InvalidFileError) {
         _logger.severe("File upload ignored for " + file.toString(), e);
         await _onInvalidFileError(file, e);
+        uploadInvalidFile = true;
       }
       if ((e is StorageLimitExceededError ||
           e is FileTooLargeForPlanError ||
@@ -806,6 +809,7 @@ class FileUploader {
         encryptedThumbnailPath,
         lockKey: lockKey,
         isMultiPartUpload: isMultipartUpload,
+        uploadInvalidFile: uploadInvalidFile,
       );
     }
   }
@@ -831,23 +835,19 @@ class FileUploader {
     String encryptedFilePath,
     String encryptedThumbnailPath, {
     required String lockKey,
+    required bool uploadInvalidFile,
     bool isMultiPartUpload = false,
   }) async {
     if (mediaUploadData != null) {
-      // delete the file from app's internal cache if it was copied to app
-      // for upload. On iOS, only remove the file from photo_manager/app cache
-      // when upload is either completed or cannot be retried automatically.
-      // Shared Media should only be cleared when the upload
-      // succeeds.
-      // A Live Photo source is an app-created archive, and each retry rebuilds
-      // it, so it must be removed after every attempt.
-      if ((Platform.isIOS &&
-              (file.fileType == FileType.livePhoto ||
-                  uploadCompleted ||
-                  uploadHardFailure)) ||
-          (uploadCompleted && file.isSharedMediaToAppSandbox)) {
-        await deleteFileSystemEntityIfPresent(mediaUploadData.sourceFile);
-      }
+      await cleanupUploadSource(
+        mediaUploadData.sourceFile,
+        isIOS: Platform.isIOS,
+        isSharedMedia: file.isSharedMediaToAppSandbox,
+        isLivePhoto: file.fileType == FileType.livePhoto,
+        uploadCompleted: uploadCompleted,
+        uploadHardFailure: uploadHardFailure,
+        uploadInvalidFile: uploadInvalidFile,
+      );
     }
     if (File(encryptedFilePath).existsSync()) {
       if (isMultiPartUpload && !uploadCompleted) {

--- a/mobile/apps/photos/lib/module/upload/service/upload_source_cleanup.dart
+++ b/mobile/apps/photos/lib/module/upload/service/upload_source_cleanup.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:ente_pure_utils/ente_pure_utils.dart';
+
+Future<void> cleanupUploadSource(
+  File sourceFile, {
+  required bool isIOS,
+  required bool isSharedMedia,
+  required bool isLivePhoto,
+  required bool uploadCompleted,
+  required bool uploadHardFailure,
+  bool uploadInvalidFile = false,
+}) async {
+  // Shared imports may be the only remaining original. Library exports can be
+  // recreated, and generated Live Photo archives are rebuilt on every retry.
+  // Invalid-file handling removes rejected imports from the database.
+  final shouldDelete = isSharedMedia && !uploadInvalidFile
+      ? uploadCompleted
+      : isIOS && (isLivePhoto || uploadCompleted || uploadHardFailure);
+  if (shouldDelete) {
+    await deleteFileSystemEntityIfPresent(sourceFile);
+  }
+}

--- a/mobile/apps/photos/test/module/upload/service/upload_source_cleanup_test.dart
+++ b/mobile/apps/photos/test/module/upload/service/upload_source_cleanup_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photos/module/upload/service/upload_source_cleanup.dart';
+
+void main() {
+  late Directory directory;
+  late File source;
+  const originalBytes = [1, 2, 3, 4];
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('upload-source-');
+    source = await File('${directory.path}/source').writeAsBytes(originalBytes);
+  });
+
+  tearDown(() async {
+    await directory.delete(recursive: true);
+  });
+
+  for (final isLivePhoto in [false, true]) {
+    test(
+      'iOS shared source survives hard failure (live: $isLivePhoto)',
+      () async {
+        await cleanupUploadSource(
+          source,
+          isIOS: true,
+          isSharedMedia: true,
+          isLivePhoto: isLivePhoto,
+          uploadCompleted: false,
+          uploadHardFailure: true,
+        );
+
+        expect(await source.readAsBytes(), originalBytes);
+
+        await cleanupUploadSource(
+          source,
+          isIOS: true,
+          isSharedMedia: true,
+          isLivePhoto: isLivePhoto,
+          uploadCompleted: true,
+          uploadHardFailure: false,
+        );
+
+        expect(await source.exists(), isFalse);
+      },
+    );
+  }
+
+  test('iOS library export is reclaimed after a hard failure', () async {
+    await cleanupUploadSource(
+      source,
+      isIOS: true,
+      isSharedMedia: false,
+      isLivePhoto: false,
+      uploadCompleted: false,
+      uploadHardFailure: true,
+    );
+
+    expect(await source.exists(), isFalse);
+  });
+
+  test(
+    'iOS rejected shared import is reclaimed after its entry is removed',
+    () async {
+      await cleanupUploadSource(
+        source,
+        isIOS: true,
+        isSharedMedia: true,
+        isLivePhoto: false,
+        uploadCompleted: false,
+        uploadHardFailure: true,
+        uploadInvalidFile: true,
+      );
+
+      expect(await source.exists(), isFalse);
+    },
+  );
+
+  test('iOS generated Live Photo archive is reclaimed before retry', () async {
+    await cleanupUploadSource(
+      source,
+      isIOS: true,
+      isSharedMedia: false,
+      isLivePhoto: true,
+      uploadCompleted: false,
+      uploadHardFailure: false,
+    );
+
+    expect(await source.exists(), isFalse);
+  });
+
+  test(
+    'Android deletes successful shared imports but keeps library originals',
+    () async {
+      for (final uploadCompleted in [false, true]) {
+        await cleanupUploadSource(
+          source,
+          isIOS: false,
+          isSharedMedia: false,
+          isLivePhoto: false,
+          uploadCompleted: uploadCompleted,
+          uploadHardFailure: !uploadCompleted,
+        );
+        expect(await source.readAsBytes(), originalBytes);
+      }
+
+      await cleanupUploadSource(
+        source,
+        isIOS: false,
+        isSharedMedia: true,
+        isLivePhoto: false,
+        uploadCompleted: true,
+        uploadHardFailure: false,
+      );
+
+      expect(await source.exists(), isFalse);
+    },
+  );
+}


### PR DESCRIPTION
## Description

On iOS, running out of device storage while preparing an encrypted upload can delete a shared import's pending original, leaving nothing to retry after space is freed.

Preserve shared sources across retryable upload failures. Keep the existing cleanup for successful uploads, invalid imports whose entries are discarded, and temporary library exports/Live Photo archives. Extract source cleanup for filesystem regression coverage.

## Tests

- `flutter test --no-pub test/module/upload/service` — 50 passed, including six filesystem cleanup tests.
- Confirmed that restoring the original cleanup condition makes both shared-source preservation tests fail.
- `flutter analyze --no-pub` from `mobile/` — no issues.
- Formatting and `git diff --check` passed.

On-device iOS storage-exhaustion and end-to-end upload retry were not exercised; the regression tests exercise source cleanup with real temporary files.
