### PR TITLE
[mobile] Centralize Android build configuration

### DIFF
--- a/mobile/apps/auth/android/app/build.gradle
+++ b/mobile/apps/auth/android/app/build.gradle
@@ -30,17 +30,9 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace "io.ente.auth"
-    compileSdk 36
-    ndkVersion "28.2.13676358"
 
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
 
     sourceSets {
@@ -56,7 +48,6 @@ android {
     defaultConfig {
         applicationId "io.ente.auth"
         minSdkVersion 24
-        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/mobile/apps/auth/android/build.gradle
+++ b/mobile/apps/auth/android/build.gradle
@@ -1,3 +1,5 @@
+apply from: "../../../gradle/ente-android.gradle"
+
 allprojects {
     repositories {
         google()

--- a/mobile/apps/locker/android/app/build.gradle
+++ b/mobile/apps/locker/android/app/build.gradle
@@ -30,22 +30,10 @@ repositories {
 
 android {
     namespace = "io.ente.locker"
-    compileSdk = 36
-    ndkVersion = "28.2.13676358"
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
-    }
 
     defaultConfig {
         applicationId = "io.ente.locker"
         minSdk = 26
-        targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
         ndk {

--- a/mobile/apps/locker/android/build.gradle
+++ b/mobile/apps/locker/android/build.gradle
@@ -1,3 +1,5 @@
+apply from: "../../../gradle/ente-android.gradle"
+
 allprojects {
     repositories {
         google()

--- a/mobile/apps/locker/rust_builder/android/build.gradle
+++ b/mobile/apps/locker/rust_builder/android/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
 }
 
 group 'com.flutter_rust_bridge.ente_locker_frb'

--- a/mobile/apps/locker/rust_builder/android/build.gradle
+++ b/mobile/apps/locker/rust_builder/android/build.gradle
@@ -1,41 +1,12 @@
+plugins {
+    id 'com.android.library'
+}
+
 group 'com.flutter_rust_bridge.ente_locker_frb'
 version '1.0'
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-
 android {
-    if (project.android.hasProperty("namespace")) {
-        namespace 'com.flutter_rust_bridge.ente_locker_frb'
-    }
-
-    // Bumping the plugin compileSdkVersion requires all clients of this plugin
-    // to bump the version in their app.
-    compileSdkVersion 33
-
-    ndkVersion "28.2.13676358"
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+    namespace 'com.flutter_rust_bridge.ente_locker_frb'
 
     defaultConfig {
         minSdkVersion 19

--- a/mobile/apps/photos/android/app/build.gradle
+++ b/mobile/apps/photos/android/app/build.gradle
@@ -56,17 +56,9 @@ configurations.configureEach {
 
 android {
     namespace = "io.ente.photos"
-    compileSdk = 36
-    ndkVersion = "28.2.13676358"
 
     compileOptions {
         coreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
     }
 
     sourceSets {
@@ -82,7 +74,6 @@ android {
     defaultConfig {
         applicationId = "io.ente.photos"
         minSdk = 26
-        targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/mobile/apps/photos/android/build.gradle
+++ b/mobile/apps/photos/android/build.gradle
@@ -1,7 +1,4 @@
-ext {
-    compileSdkVersion   = 35
-    targetSdkVersion    = 35
-}
+apply from: "../../../gradle/ente-android.gradle"
 
 allprojects {
     repositories {

--- a/mobile/apps/photos/plugins/ente_cast/android/build.gradle
+++ b/mobile/apps/photos/plugins/ente_cast/android/build.gradle
@@ -1,45 +1,13 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
 group 'io.ente.cast'
 version '1.0'
 
-buildscript {
-    ext.kotlin_version = '2.1.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.10.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
 android {
     namespace 'io.ente.cast'
-    compileSdk 36
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
 
     defaultConfig {
         minSdkVersion 21

--- a/mobile/apps/photos/plugins/ente_panorama_viewer/android/build.gradle
+++ b/mobile/apps/photos/plugins/ente_panorama_viewer/android/build.gradle
@@ -1,45 +1,13 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
 group 'io.ente.panorama_viewer'
 version '1.0'
 
-buildscript {
-    ext.kotlin_version = '2.1.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.10.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
 android {
     namespace 'io.ente.panorama_viewer'
-    compileSdk 36
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
 
     defaultConfig {
         minSdkVersion 26

--- a/mobile/apps/photos/plugins/ente_photos_platform/android/build.gradle
+++ b/mobile/apps/photos/plugins/ente_photos_platform/android/build.gradle
@@ -1,45 +1,13 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
 group 'io.ente.photos.platform'
 version '1.0'
 
-buildscript {
-    ext.kotlin_version = '2.1.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.10.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
 android {
     namespace 'io.ente.photos.platform'
-    compileSdk 36
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
 
     defaultConfig {
         minSdkVersion 23

--- a/mobile/apps/photos/plugins/media_extension/android/build.gradle
+++ b/mobile/apps/photos/plugins/media_extension/android/build.gradle
@@ -1,33 +1,13 @@
+plugins {
+    id "com.android.library"
+    id "org.jetbrains.kotlin.android"
+}
+
 group = "io.ente.photos.media_extension"
 version = "1.0-SNAPSHOT"
 
-buildscript {
-    ext.kotlin_version = "1.8.22"
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.1.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
-
 android {
     namespace = "io.ente.photos.media_extension"
-
-    compileSdk = 35
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -36,11 +16,6 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11
-    }
-
-    sourceSets {
-        main.java.srcDirs += "src/main/kotlin"
-        test.java.srcDirs += "src/test/kotlin"
     }
 
     defaultConfig {

--- a/mobile/apps/photos/rust_builder/android/build.gradle
+++ b/mobile/apps/photos/rust_builder/android/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
 }
 
 group 'com.flutter_rust_bridge.ente_photos_frb'

--- a/mobile/apps/photos/rust_builder/android/build.gradle
+++ b/mobile/apps/photos/rust_builder/android/build.gradle
@@ -1,42 +1,12 @@
+plugins {
+    id 'com.android.library'
+}
+
 group 'com.flutter_rust_bridge.ente_photos_frb'
 version '1.0'
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-
 android {
-    if (project.android.hasProperty("namespace")) {
-        namespace 'com.flutter_rust_bridge.ente_photos_frb'
-    }
-
-    // Bumping the plugin compileSdkVersion requires all clients of this plugin
-    // to bump the version in their app.
-    compileSdkVersion 33
-
-    // Keep in sync with android/app/build.gradle.
-    ndkVersion "28.2.13676358"
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+    namespace 'com.flutter_rust_bridge.ente_photos_frb'
 
     defaultConfig {
         minSdkVersion 19

--- a/mobile/gradle/ente-android.gradle
+++ b/mobile/gradle/ente-android.gradle
@@ -1,0 +1,27 @@
+def compileSdk = 36
+def targetSdk = 36
+def ndkVersion = "28.2.13676358"
+def jvmTarget = "1.8"
+def javaVersion = JavaVersion.toVersion(jvmTarget)
+def mobileDirectory = rootProject.file("../../..").toPath().normalize()
+def configureAndroid = { extension ->
+    extension.compileSdk = compileSdk
+    extension.ndkVersion = ndkVersion
+    extension.compileOptions.sourceCompatibility = javaVersion
+    extension.compileOptions.targetCompatibility = javaVersion
+}
+
+subprojects {
+    if (!projectDir.toPath().normalize().startsWith(mobileDirectory)) return
+
+    pluginManager.withPlugin("com.android.application") {
+        configureAndroid(android)
+        android.defaultConfig.targetSdk = targetSdk
+    }
+    pluginManager.withPlugin("com.android.library") {
+        configureAndroid(android)
+    }
+    pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+        android.kotlinOptions.jvmTarget = jvmTarget
+    }
+}

--- a/mobile/packages/ente_qr/android/build.gradle
+++ b/mobile/packages/ente_qr/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group 'io.ente.ente_qr'
 version '1.0-SNAPSHOT'
 
+repositories {
+    maven { url 'https://jitpack.io' }
+}
+
 android {
     namespace 'io.ente.ente_qr'
 

--- a/mobile/packages/ente_qr/android/build.gradle
+++ b/mobile/packages/ente_qr/android/build.gradle
@@ -1,55 +1,19 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
 group 'io.ente.ente_qr'
 version '1.0-SNAPSHOT'
 
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
 android {
     namespace 'io.ente.ente_qr'
-    compileSdk 36
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-        test.java.srcDirs += 'src/test/kotlin'
-    }
 
     defaultConfig {
         minSdkVersion 16
     }
 
     dependencies {
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
         implementation 'com.github.markusfisch:zxing-cpp:v3.0.2.1'
         implementation 'androidx.exifinterface:exifinterface:1.3.7'
     }

--- a/mobile/packages/ente_qr_scanner/android/build.gradle
+++ b/mobile/packages/ente_qr_scanner/android/build.gradle
@@ -1,48 +1,15 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
 group 'io.ente.qr_scanner'
 version '1.0'
 
-buildscript {
-    ext.kotlin_version = '1.9.25'
-    ext.camerax_version = '1.6.1'
-    repositories {
-        google()
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+ext.camerax_version = '1.6.1'
 
 android {
     namespace 'io.ente.qr_scanner'
-    compileSdk 36
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
 
     defaultConfig {
         minSdkVersion 21
@@ -50,7 +17,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "androidx.camera:camera-core:$camerax_version"
     implementation "androidx.camera:camera-camera2:$camerax_version"
     implementation "androidx.camera:camera-lifecycle:$camerax_version"

--- a/mobile/packages/install_source/android/build.gradle
+++ b/mobile/packages/install_source/android/build.gradle
@@ -1,41 +1,13 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
 group 'io.ente.install_source'
 version '1.0'
 
-buildscript {
-    ext.kotlin_version = '2.1.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.10.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
 android {
     namespace 'io.ente.install_source'
-    compileSdk 36
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/mobile/packages/mail/android/build.gradle
+++ b/mobile/packages/mail/android/build.gradle
@@ -1,48 +1,13 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
 group 'io.ente.mail'
 version '1.0'
 
-buildscript {
-    ext.kotlin_version = '1.9.25'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
-def mailCompileSdkVersion = rootProject.ext.has('compileSdkVersion') ?
-        rootProject.ext.compileSdkVersion : 35
-
 android {
     namespace 'io.ente.mail'
-    compileSdkVersion mailCompileSdkVersion
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
 
     defaultConfig {
         minSdkVersion 24

--- a/mobile/packages/native_video_editor/android/build.gradle
+++ b/mobile/packages/native_video_editor/android/build.gradle
@@ -1,54 +1,20 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
 group 'io.ente.native_video_editor'
 version '1.0'
 
-buildscript {
-    ext.kotlin_version = '1.9.25'
-    ext.media3_version = '1.10.1'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+ext.media3_version = '1.10.1'
 
 configurations.configureEach {
     // Frame extraction receives videos only, never still images.
     exclude group: "androidx.exifinterface", module: "exifinterface"
 }
 
-def nativeVideoEditorCompileSdkVersion = rootProject.ext.has('compileSdkVersion') ?
-        rootProject.ext.compileSdkVersion : 35
-
 android {
     namespace 'io.ente.native_video_editor'
-    compileSdkVersion nativeVideoEditorCompileSdkVersion
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
 
     defaultConfig {
         minSdkVersion 23
@@ -56,7 +22,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
     testImplementation 'junit:junit:4.13.2'
 

--- a/mobile/packages/screen_cover/android/build.gradle
+++ b/mobile/packages/screen_cover/android/build.gradle
@@ -1,44 +1,12 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
 group 'io.ente.ente_screen_cover'
-
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     namespace 'io.ente.ente_screen_cover'
-    compileSdk 36
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
## What

Centralize Android compile SDK, target SDK, NDK, and JVM settings for Ente-owned Flutter modules, and make plugins inherit the apps' AGP and Kotlin toolchain.

## Why

These values had drifted across apps, plugins, and Rust bridges. Keeping them in one Gradle script lets the monorepo update all owned modules together.