### PR TITLE
[auth] Fix 2FAS TOTP imports with omitted default settings

### DIFF
--- a/mobile/apps/auth/lib/ui/settings/data/import/two_fas_import.dart
+++ b/mobile/apps/auth/lib/ui/settings/data/import/two_fas_import.dart
@@ -102,6 +102,18 @@ Future<int?> _process2FasExportFile(
   } else {
     await dialog.show();
   }
+  final parsedCodes = parse2FasServices(
+    decodedServices,
+    groupIdToName: groupIdToName,
+  );
+  return saveImportedCodes(parsedCodes);
+}
+
+List<Code> parse2FasServices(
+  Iterable<dynamic> decodedServices, {
+  Map<dynamic, dynamic> groupIdToName = const {},
+}) {
+  const supportedTotpAlgorithms = {'sha1', 'sha256', 'sha512'};
   final parsedCodes = <Code>[];
   for (var item in decodedServices) {
     var kind = item['otp']['tokenType'];
@@ -117,9 +129,16 @@ Future<int?> _process2FasExportFile(
     var digits = item['otp']['digits'];
     var counter = item['otp']['counter'];
 
-    Code code = parseImportOtpCode(
-      item,
-      () => buildImportOtpUri(
+    Code code = parseImportOtpCode(item, () {
+      if (kind is String && kind.toLowerCase() == 'totp') {
+        algorithm ??= 'SHA1';
+        digits ??= Code.defaultDigits;
+        if (algorithm is! String ||
+            !supportedTotpAlgorithms.contains(algorithm.toLowerCase())) {
+          throw const FormatException('Unsupported 2FAS TOTP algorithm');
+        }
+      }
+      return buildImportOtpUri(
         kind: kind,
         issuer: issuer,
         account: account,
@@ -128,8 +147,8 @@ Future<int?> _process2FasExportFile(
         digits: digits,
         period: timer,
         counter: counter,
-      ),
-    );
+      );
+    });
     if (groupID != null && groupIdToName.containsKey(groupID)) {
       code = code.copyWith(
         display: CodeDisplay(tags: [groupIdToName[groupID]]),
@@ -138,7 +157,7 @@ Future<int?> _process2FasExportFile(
     parsedCodes.add(code);
   }
 
-  return saveImportedCodes(parsedCodes);
+  return parsedCodes;
 }
 
 String decrypt2FasVault(dynamic data, {required String password}) {

--- a/mobile/apps/auth/test/ui/settings/data/import/two_fas_import_test.dart
+++ b/mobile/apps/auth/test/ui/settings/data/import/two_fas_import_test.dart
@@ -4,7 +4,6 @@ import 'package:ente_auth/models/code.dart';
 import 'package:ente_auth/ui/settings/data/import/import_flow.dart';
 import 'package:ente_auth/ui/settings/data/import/two_fas_import.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:otp/otp.dart' as otp;
 
 const _secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
 const _groups = {'group-1': 'Synthetic group'};
@@ -246,35 +245,6 @@ void main() {
         period: 60,
       );
     });
-
-    // Public expected vectors: https://www.rfc-editor.org/rfc/rfc6238#appendix-B
-    for (final row in _rfcVectorRows) {
-      for (final (index, vector) in _rfcAlgorithms.indexed) {
-        test('matches RFC 6238 ${vector.algorithm} at ${row.seconds}', () {
-          final code = parse2FasServices([
-            _entry({
-              'algorithm': vector.algorithm,
-              'digits': 8,
-            }, secret: vector.secret),
-          ]).single;
-          final restored = _roundTrip(code);
-          final algorithm = switch (restored.algorithm) {
-            Algorithm.sha1 => otp.Algorithm.SHA1,
-            Algorithm.sha256 => otp.Algorithm.SHA256,
-            Algorithm.sha512 => otp.Algorithm.SHA512,
-          };
-          final actual = otp.OTP.generateTOTPCodeString(
-            restored.secret,
-            row.seconds * 1000,
-            length: restored.digits,
-            interval: restored.period,
-            algorithm: algorithm,
-            isGoogle: true,
-          );
-          expect(actual, row.expected[index]);
-        });
-      }
-    }
   });
 }
 
@@ -366,25 +336,3 @@ const _encryptedServices =
     'VXHXYtrwxWvZrVLjJ0a0y02gK4ytdyVKKecHYVLbPEqP8PQ7UG7zF2RC95p26GDqiVxxPzkqPAkX'
     'uUQxkChFDBtJlkM1COXgFEZ1niuqlK/cm5lRW5YFW7E=:AAECAwQFBgcICQoLDA0ODxAREhMUFRY'
     'XGBkaGxwdHh8=:AAECAwQFBgcICQoL';
-
-const _rfcAlgorithms = <({String algorithm, String secret})>[
-  (algorithm: 'SHA1', secret: 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ'),
-  (
-    algorithm: 'SHA256',
-    secret: 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA====',
-  ),
-  (
-    algorithm: 'SHA512',
-    secret:
-        'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNA=',
-  ),
-];
-
-const _rfcVectorRows = <({int seconds, List<String> expected})>[
-  (seconds: 59, expected: ['94287082', '46119246', '90693936']),
-  (seconds: 1111111109, expected: ['07081804', '68084774', '25091201']),
-  (seconds: 1111111111, expected: ['14050471', '67062674', '99943326']),
-  (seconds: 1234567890, expected: ['89005924', '91819424', '93441116']),
-  (seconds: 2000000000, expected: ['69279037', '90698825', '38618901']),
-  (seconds: 20000000000, expected: ['65353130', '77737706', '47863826']),
-];

--- a/mobile/apps/auth/test/ui/settings/data/import/two_fas_import_test.dart
+++ b/mobile/apps/auth/test/ui/settings/data/import/two_fas_import_test.dart
@@ -1,0 +1,390 @@
+import 'dart:convert';
+
+import 'package:ente_auth/models/code.dart';
+import 'package:ente_auth/ui/settings/data/import/import_flow.dart';
+import 'package:ente_auth/ui/settings/data/import/two_fas_import.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otp/otp.dart' as otp;
+
+const _secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+const _groups = {'group-1': 'Synthetic group'};
+
+void main() {
+  group('parse2FasServices', () {
+    for (final fixture in <({String name, Map<String, dynamic> otp})>[
+      (name: 'algorithm omitted', otp: {'digits': 6, 'period': 30}),
+      (name: 'digits omitted', otp: {'algorithm': 'SHA1', 'period': 30}),
+      (name: 'algorithm and digits omitted', otp: {'period': 30}),
+      (
+        name: 'algorithm null',
+        otp: {'algorithm': null, 'digits': 6, 'period': 30},
+      ),
+      (
+        name: 'digits null',
+        otp: {'algorithm': 'SHA1', 'digits': null, 'period': 30},
+      ),
+      (
+        name: 'algorithm and digits null',
+        otp: {'algorithm': null, 'digits': null, 'period': 30},
+      ),
+      (name: 'all defaults omitted', otp: {}),
+      (
+        name: 'period null',
+        otp: {'algorithm': 'SHA1', 'digits': 6, 'period': null},
+      ),
+    ]) {
+      test('uses TOTP defaults with ${fixture.name}', () {
+        final entry = _entry(fixture.otp);
+        final before = jsonEncode(entry);
+        final codes = parse2FasServices([entry]);
+
+        expect(codes, hasLength(1));
+        _expectCode(codes.single);
+        expect(jsonEncode(entry), before);
+      });
+    }
+
+    for (final fixture in [
+      ('SHA1', Algorithm.sha1),
+      ('SHA256', Algorithm.sha256),
+      ('SHA512', Algorithm.sha512),
+      ('sHa256', Algorithm.sha256),
+    ]) {
+      test('preserves explicit ${fixture.$1}, digits and period', () {
+        final codes = parse2FasServices([
+          _entry({'algorithm': fixture.$1, 'digits': 8, 'period': 60}),
+        ]);
+        _expectCode(codes.single, algorithm: fixture.$2, digits: 8, period: 60);
+      });
+    }
+
+    test('recognizes lowercase TOTP', () {
+      _expectCode(
+        parse2FasServices([
+          _entry({'tokenType': 'totp'}),
+        ]).single,
+      );
+    });
+
+    test('retains name fallback and empty account', () {
+      final entry = _entry({'issuer': null, 'account': null}, name: 'Fallback');
+      _expectCode(
+        parse2FasServices([entry]).single,
+        issuer: 'Fallback',
+        account: '',
+      );
+    });
+
+    test('retains name fallback for an empty issuer', () {
+      final entry = _entry({'issuer': ''}, name: 'Fallback');
+      _expectCode(parse2FasServices([entry]).single, issuer: 'Fallback');
+    });
+
+    test('uses native secret sanitization', () {
+      final entry = _entry({}, secret: ' gezdgnbv gy3tqojqgezdgnbvgy3tqojq ');
+      _expectCode(parse2FasServices([entry]).single);
+    });
+
+    test('retains known group tags through serialization', () {
+      final entry = _entry({}, groupId: 'group-1');
+      final code = parse2FasServices([entry], groupIdToName: _groups).single;
+      _expectCode(code, tags: ['Synthetic group']);
+    });
+
+    test('ignores an unknown group', () {
+      final entry = _entry({}, groupId: 'unknown');
+      _expectCode(parse2FasServices([entry], groupIdToName: _groups).single);
+    });
+
+    for (final fixture in [
+      ('HOTP', Type.hotp, 6, 42),
+      ('STEAM', Type.steam, 5, 0),
+    ]) {
+      test('preserves explicit ${fixture.$1} settings', () {
+        final entry = _entry({
+          'tokenType': fixture.$1,
+          'algorithm': 'SHA1',
+          'digits': fixture.$3,
+          'period': 30,
+          'counter': 42,
+        });
+        _expectCode(
+          parse2FasServices([entry]).single,
+          type: fixture.$2,
+          digits: fixture.$3,
+          counter: fixture.$4,
+        );
+      });
+      for (final missingField in ['algorithm', 'digits']) {
+        test('keeps ${fixture.$1} missing $missingField behavior', () {
+          final settings = <String, dynamic>{
+            'tokenType': fixture.$1,
+            'algorithm': 'SHA1',
+            'digits': fixture.$3,
+          }..remove(missingField);
+          _expectFailure(_entry(settings));
+        });
+      }
+    }
+
+    for (final counter in <int?>[null, 0]) {
+      test('keeps HOTP counter ${counter ?? 'omitted'} as zero', () {
+        final entry = _entry({
+          'tokenType': 'HOTP',
+          'algorithm': 'SHA1',
+          'digits': 6,
+          'counter': ?counter,
+        });
+        _expectCode(parse2FasServices([entry]).single, type: Type.hotp);
+      });
+    }
+
+    test('retains a wrapped error for missing token type', () {
+      _expectFailure(
+        _entry({'tokenType': null, 'algorithm': 'SHA1', 'digits': 6}),
+      );
+    });
+
+    for (final algorithm in <Object>[
+      'SHA224',
+      'SHA384',
+      'not-an-algorithm',
+      '',
+      ' SHA1 ',
+      'Algorithm.sha256',
+      7,
+      <String, Object>{},
+      <Object>[],
+    ]) {
+      for (final digits in <int?>[null, 6]) {
+        test(
+          'rejects TOTP algorithm ${jsonEncode(algorithm)} with digits $digits',
+          () {
+            _expectFailure(
+              _entry({'algorithm': algorithm, 'digits': digits}),
+              message: 'Unsupported 2FAS TOTP algorithm',
+            );
+          },
+        );
+      }
+    }
+
+    test('keeps invalid digits rejected', () {
+      _expectFailure(_entry({'digits': 11}), message: 'Invalid OTP digits: 11');
+    });
+
+    test('keeps negative HOTP counters rejected', () {
+      _expectFailure(
+        _entry({
+          'tokenType': 'HOTP',
+          'algorithm': 'SHA1',
+          'digits': 6,
+          'counter': -1,
+        }),
+        message: 'Invalid HOTP counter: -1',
+      );
+    });
+
+    test('preserves input order', () {
+      final codes = parse2FasServices([
+        _entry({}, groupId: 'group-1'),
+        _entry({'algorithm': 'SHA256', 'digits': 8, 'period': 60}),
+      ], groupIdToName: _groups);
+      expect(codes, hasLength(2));
+      _expectCode(codes.first, tags: ['Synthetic group']);
+      _expectCode(
+        codes.last,
+        algorithm: Algorithm.sha256,
+        digits: 8,
+        period: 60,
+      );
+    });
+
+    test(
+      'fails eagerly at the malformed entry without returning a partial list',
+      () {
+        final bad = _entry({'digits': 11});
+        var visited = 0;
+        Iterable<dynamic> entries() sync* {
+          visited++;
+          yield _entry({});
+          visited++;
+          yield bad;
+          visited++;
+          yield _entry({});
+        }
+
+        expect(
+          () => parse2FasServices(entries()),
+          throwsA(
+            isA<ImportEntryParseException>().having(
+              (error) => error.entry,
+              'entry',
+              same(bad),
+            ),
+          ),
+        );
+        expect(visited, 2);
+      },
+    );
+
+    test('parses decrypted synthetic services through the same mapper', () {
+      final services =
+          jsonDecode(
+                decrypt2FasVault({
+                  'servicesEncrypted': _encryptedServices,
+                }, password: 'synthetic-test-only'),
+              )
+              as List;
+      final codes = parse2FasServices(services, groupIdToName: _groups);
+      expect(codes, hasLength(2));
+      _expectCode(codes.first, tags: ['Synthetic group']);
+      _expectCode(
+        codes.last,
+        algorithm: Algorithm.sha256,
+        digits: 8,
+        period: 60,
+      );
+    });
+
+    // Public expected vectors: https://www.rfc-editor.org/rfc/rfc6238#appendix-B
+    for (final row in _rfcVectorRows) {
+      for (final (index, vector) in _rfcAlgorithms.indexed) {
+        test('matches RFC 6238 ${vector.algorithm} at ${row.seconds}', () {
+          final code = parse2FasServices([
+            _entry({
+              'algorithm': vector.algorithm,
+              'digits': 8,
+            }, secret: vector.secret),
+          ]).single;
+          final restored = _roundTrip(code);
+          final algorithm = switch (restored.algorithm) {
+            Algorithm.sha1 => otp.Algorithm.SHA1,
+            Algorithm.sha256 => otp.Algorithm.SHA256,
+            Algorithm.sha512 => otp.Algorithm.SHA512,
+          };
+          final actual = otp.OTP.generateTOTPCodeString(
+            restored.secret,
+            row.seconds * 1000,
+            length: restored.digits,
+            interval: restored.period,
+            algorithm: algorithm,
+            isGoogle: true,
+          );
+          expect(actual, row.expected[index]);
+        });
+      }
+    }
+  });
+}
+
+Map<String, dynamic> _entry(
+  Map<String, dynamic> otp, {
+  String name = 'Example',
+  String secret = _secret,
+  String? groupId,
+}) =>
+    jsonDecode(
+          jsonEncode({
+            'name': name,
+            'secret': secret,
+            'groupId': ?groupId,
+            'otp': {
+              'tokenType': 'TOTP',
+              'issuer': 'Example',
+              'account': 'synthetic@example.invalid',
+              ...otp,
+            },
+          }),
+        )
+        as Map<String, dynamic>;
+
+void _expectCode(
+  Code code, {
+  Type type = Type.totp,
+  Algorithm algorithm = Algorithm.sha1,
+  int digits = 6,
+  int period = 30,
+  int counter = 0,
+  String issuer = 'Example',
+  String account = 'synthetic@example.invalid',
+  List<String> tags = const [],
+}) {
+  expect(code.type, type);
+  expect(code.algorithm, algorithm);
+  expect(code.digits, digits);
+  expect(code.period, period);
+  expect(code.counter, counter);
+  expect(code.issuer, issuer);
+  expect(code.account, account);
+  expect(code.secret, _secret);
+  expect(code.display.tags, tags);
+  _roundTrip(code);
+}
+
+Code _roundTrip(Code code) {
+  final restored = Code.fromOTPAuthUrl(
+    jsonDecode(code.toOTPAuthUrlFormat()) as String,
+  );
+  expect(restored.type, code.type);
+  expect(restored.algorithm, code.algorithm);
+  expect(restored.digits, code.digits);
+  expect(restored.period, code.period);
+  expect(restored.counter, code.counter);
+  expect(restored.issuer, code.issuer);
+  expect(restored.account, code.account);
+  expect(restored.secret, code.secret);
+  expect(restored.display.toJson(), code.display.toJson());
+  return restored;
+}
+
+void _expectFailure(Map<String, dynamic> entry, {String? message}) {
+  ImportEntryParseException? caught;
+  try {
+    parse2FasServices([entry]);
+  } on ImportEntryParseException catch (error) {
+    caught = error;
+  }
+  expect(caught, isNotNull);
+  expect(caught!.entry, same(entry));
+  if (message != null) {
+    expect(caught.error, isA<FormatException>());
+    expect((caught.error as FormatException).message, message);
+  }
+  expect(caught.toString(), isNot(contains(_secret)));
+  expect(caught.toString(), isNot(contains('synthetic@example.invalid')));
+}
+
+// Fixed synthetic plaintext/password/salt/nonce, generated independently with
+// PBKDF2-HMAC-SHA256 (10,000 iterations, 32-byte key) and AES-256-GCM.
+const _encryptedServices =
+    '9uatiJpqe6rX1neqRCXxklo6EXykan6XH/TAKJmHh8tlb2VhS4QmNkmUUcYQiAy+Yle2zosctjK0'
+    '/SRwGOV3M6z+dsfO8/irJL6VrTm5aZeqvCQKrdk5xR/LwyHn83x9kzFwExsN1XMAs7ESigqYPfwJ'
+    '6EOI2mEdW5BQ8BaNQse9dhKCYwdrKE8qIEabTdAnOHzF2lj46YCjuL0kSc7C7eaaiVIWEW9qw5Tt'
+    'WnVXX6X5NpGEURa3TZtVh3Kj4IXVfEeUDqcIkddVsQTMkqndgceWflLsJ+IIlq/MiSS5GBUCqciO'
+    'J2c+uXsxixuz47jIO63ye6yYQ6tKsACG2JOBl5T/+vW408YHx5IC2mkg6fu4BrFzelE1KXs27lIv'
+    'VXHXYtrwxWvZrVLjJ0a0y02gK4ytdyVKKecHYVLbPEqP8PQ7UG7zF2RC95p26GDqiVxxPzkqPAkX'
+    'uUQxkChFDBtJlkM1COXgFEZ1niuqlK/cm5lRW5YFW7E=:AAECAwQFBgcICQoLDA0ODxAREhMUFRY'
+    'XGBkaGxwdHh8=:AAECAwQFBgcICQoL';
+
+const _rfcAlgorithms = <({String algorithm, String secret})>[
+  (algorithm: 'SHA1', secret: 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ'),
+  (
+    algorithm: 'SHA256',
+    secret: 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA====',
+  ),
+  (
+    algorithm: 'SHA512',
+    secret:
+        'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNA=',
+  ),
+];
+
+const _rfcVectorRows = <({int seconds, List<String> expected})>[
+  (seconds: 59, expected: ['94287082', '46119246', '90693936']),
+  (seconds: 1111111109, expected: ['07081804', '68084774', '25091201']),
+  (seconds: 1111111111, expected: ['14050471', '67062674', '99943326']),
+  (seconds: 1234567890, expected: ['89005924', '91819424', '93441116']),
+  (seconds: 2000000000, expected: ['69279037', '90698825', '38618901']),
+  (seconds: 20000000000, expected: ['65353130', '77737706', '47863826']),
+];


### PR DESCRIPTION
## Description

Valid 2FAS TOTP backups can omit algorithm and digits. Passing those values to the URI builder currently fails with a null-to-Object error. Apply the producer's SHA1/six-digit defaults, preserving supported explicit settings.

Reject explicit TOTP algorithms unsupported by Ente instead of silently treating them as SHA1. Extract the existing service loop for regression testing. HOTP/Steam handling and saving remain unchanged.

The defaults match [2FAS Android's generator](https://github.com/twofas/2fas-android/blob/119ead28ed8d3d2215afd8f55428c1586401149b/data/services/src/main/java/com/twofasapp/data/services/otp/ServiceCodeGenerator.kt#L54-L65).

## Tests

Flutter 3.47.2 / Dart 3.13.2: all 97 Auth tests pass, Auth analysis reports no issues, and the mobile format check passes. Regression coverage includes omitted/null fields, explicit parameters, unsupported algorithms, groups, serialization and encrypted services.

A private Flutter widget smoke test reproduces the original failure and verifies the fixed public import flow for schema 3/4 plaintext and encrypted schema 4. It exercises real parsing, decryption, offline SQLite saving and CodeStore readback with isolated platform adapters. A malformed batch saves no entries. This proof is reused after a test-only trim; the production importer and harness are unchanged. Before/after screenshots use synthetic data.

The installed app, native file dialog and packaging were not tested. Locked dependency resolution passed; Windows symlink privilege blocked desktop plugin generation, so tests and analysis used `--no-pub`.

Before and after, rendered in the isolated Flutter test shell:

| Before | After |
| --- | --- |
| ![2FAS import fails before the fix](https://github.com/user-attachments/assets/0e1e4580-5360-4cf4-996e-17486b3e7e9f) | ![The same synthetic backup imports two codes after the fix](https://github.com/user-attachments/assets/406ee770-0045-454e-b3de-ae8d9f7a87bc) |

AI assistance: OpenAI Codex (GPT-6) produced the code, tests, synthetic validation and this description.
