### PR TITLE
[desktop][photos] Fix View logs hanging on Linux

### DIFF
--- a/desktop/changes/view-logs-linux.md
+++ b/desktop/changes/view-logs-linux.md
@@ -1,1 +1,1 @@
-- Fixed the "View logs" button hanging on Linux instead of dismissing once the file manager opened.
+- Fixed the "View logs" button hanging on Linux instead of dismissing once the file manager opened - @aswinpradeepc

--- a/desktop/changes/view-logs-linux.md
+++ b/desktop/changes/view-logs-linux.md
@@ -1,0 +1,1 @@
+- Fixed the "View logs" button hanging on Linux instead of dismissing once the file manager opened.

--- a/desktop/src/main/services/dir.ts
+++ b/desktop/src/main/services/dir.ts
@@ -16,9 +16,7 @@ export const openDirectory = async (dirPath: string) => {
     // shell.openPath requires native separators, not our POSIX IPC paths.
     const nativePath = path.normalize(dirPath);
 
-    // On Linux shell.openPath launches xdg-open without waiting for it, and
-    // drops the callback that'd settle the promise it returned (see OpenPath in
-    // Electron's platform_util_linux.cc). Awaiting it would hang this handler.
+    // On Linux shell.openPath's promise never settles, so don't await it.
     if (process.platform == "linux") {
         if (!existsSync(nativePath))
             throw new Error(`Failed to open directory ${dirPath}`);

--- a/desktop/src/main/services/dir.ts
+++ b/desktop/src/main/services/dir.ts
@@ -1,5 +1,6 @@
 import { shell } from "electron/common";
 import { app, dialog } from "electron/main";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { posixPath } from "../utils/electron";
 
@@ -13,7 +14,19 @@ export const selectDirectory = async () => {
 
 export const openDirectory = async (dirPath: string) => {
     // shell.openPath requires native separators, not our POSIX IPC paths.
-    const res = await shell.openPath(path.normalize(dirPath));
+    const nativePath = path.normalize(dirPath);
+
+    // On Linux shell.openPath launches xdg-open without waiting for it, and
+    // drops the callback that'd settle the promise it returned (see OpenPath in
+    // Electron's platform_util_linux.cc). Awaiting it would hang this handler.
+    if (process.platform == "linux") {
+        if (!existsSync(nativePath))
+            throw new Error(`Failed to open directory ${dirPath}`);
+        void shell.openPath(nativePath);
+        return;
+    }
+
+    const res = await shell.openPath(nativePath);
     // Electron resolves with an error message on failure.
     if (res) throw new Error(`Failed to open directory ${dirPath}: ${res}`);
 };


### PR DESCRIPTION
## Description

On Linux, **View logs** opens the file manager but the confirmation dialog never completes: the button stays in its loading state with *Cancel* disabled, and after an indeterminate delay it flips to *Something went wrong*. The renderer logs, on every click:

```
Error invoking remote method 'openLogDirectory': reply was never sent
```

Reproduced on 1.7.28 and 1.7.29 (Debian 13, GNOME, X11). macOS and Windows are unaffected.

### Cause

`shell.openPath()` returns a promise that **never settles on Linux**. From Electron's [`shell/common/platform_util_linux.cc`](https://github.com/electron/electron/blob/v42.5.0/shell/common/platform_util_linux.cc#L377-L380):

```cpp
void OpenPath(const base::FilePath& full_path, OpenCallback callback) {
  // This is async, so we don't care about the return value.
  XDGOpen(full_path.DirName(), full_path.value(), false, std::move(callback));
}                                                 
```

and in `XDGUtil`, the callback is only ever run inside the [`wait_for_exit`](https://github.com/electron/electron/blob/v42.5.0/shell/common/platform_util_linux.cc#L336-L351) branch:

```cpp
  base::Process process = base::LaunchProcess(argv, options);
  if (!process.IsValid()) return false;      // callback dropped, unrun
  if (wait_for_exit) { ... std::move(callback).Run(GetErrorDescription(exit_code)); ... }
  base::EnsureProcessGetsReaped(std::move(process));
  return true;                               // callback dropped, unrun
```

`wait_for_exit` is `false` at every call site, so the callback that would settle the promise is always dropped. `xdg-open` still launches, hence the file manager appearing - but nothing ever resolves.

`openDirectory` awaited that promise, so the IPC handler never returned. The renderer's `invoke` stayed pending until V8 collected the main-process reply channel, whose destructor sends the canned `"reply was never sent"` (`shell/common/gin_helper/reply_channel.cc`). The delay before *Something went wrong* is GC timing, not a timeout and in one case, it took 42 seconds.

### Fix

On Linux, don't await the promise. Check what we can synchronously, then fire and forget.

The same function is also exposed directly over IPC as `openDirectory`, so this additionally fixes two callers that were rejecting on **every** click on Linux with no visible symptom — `Export.tsx` (export directory) and `DownloadStatusNotifications.tsx` (download directory). Both `void` the promise, so the failure only ever reached the unhandled-rejection logger.

The existence check is there because once we stop awaiting, a deleted directory would otherwise report success.

No UI changes. The dialog behind **View logs** now dismisses instead of hanging; the export/download paths have no error UI in either build (their callers discard the promise), so there the observable change is the log line. This change is behind a `process.platform` check and leaves macOS and Windows paths untouched.

## Tests

Debian 13, GNOME 48, X11, Electron 42.5.0. Tested both as `dist/linux-unpacked/ente` and as an installed `.deb`, against the released 1.7.29 build for comparison.


https://github.com/user-attachments/assets/38a8608f-4a5d-4b5c-994a-180f25f53bfa


| Scenario | 1.7.29 (before) | patched (after) |
| --- | --- | --- |
| **View logs** | file manager opens, dialog spins with *Cancel* disabled, then *Something went wrong*; log shows `reply was never sent` | file manager opens, dialog dismisses immediately; no error |
 **Open export dir — deleted, parent exists** | `gio:` error on stderr only, nothing in `ente.log`; promise hangs, then `reply was never sent` after GC | `Failed to open directory <path>` in `ente.log`, immediately |
| **Open export dir — deleted, parent also deleted** | `Check failed: chdir(current_directory) == 0` per click, forked child aborts, `xdg-open` never runs; promise hangs | `Failed to open directory <path>` in `ente.log`; nothing forked |
| **Open export dir — exists** | opens | opens |

`npm run lint` passes.
