### PR TITLE
docs: note desktop stream processing progress

### DIFF
--- a/docs/docs/photos/features/utilities/video-streaming.md
+++ b/docs/docs/photos/features/utilities/video-streaming.md
@@ -64,6 +64,7 @@ These controls are available whether Ente plays the original video or a streamab
 - New uploads will automatically generate streams
 - All existing previously uploaded videos will be processed
 - Stream generation is CPU intensive and happens in the background
+- The **Streamable videos** section shows the percentage of existing videos processed
 - Click the search bar to see "Processing videos..." status
 - Processed videos sync to mobile automatically
 


### PR DESCRIPTION
## Summary

- document the processed percentage shown while desktop generates streamable videos
- keep the video-streaming guide aligned with Photos desktop v1.7.29

## Checks

- `npx prettier --check docs/photos/features/utilities/video-streaming.md`
- `npm run build`
- `git diff --check origin/main...HEAD`
