### PR TITLE
[infra] Align Cast releases and add Discord notifications

### DIFF
--- a/.github/docs/app-release.md
+++ b/.github/docs/app-release.md
@@ -9,7 +9,7 @@ Photos, Auth, Locker, Ensu, Cast, and Photos desktop use the same release proces
 ## App specifics
 
 - Photos desktop follows the same flow, but its stable releases live in [ente/photos-desktop](https://github.com/ente/photos-desktop). See [desktop/docs/release.md](../../desktop/docs/release.md) for more details.
-- Cast uses two-part versions, such as `1.2`, and its build workflow is manual. After starting a Cast release, run `cast-build.yml` on the new release branch to upload the RC to TestFlight and create its draft GitHub release.
+- Cast builds are manual. Run `cast-build.yml` on the release branch after starting a release.
 
 ## Normal development
 

--- a/.github/docs/app-release.md
+++ b/.github/docs/app-release.md
@@ -9,7 +9,7 @@ Photos, Auth, Locker, Ensu, Cast, and Photos desktop use the same release proces
 ## App specifics
 
 - Photos desktop follows the same flow, but its stable releases live in [ente/photos-desktop](https://github.com/ente/photos-desktop). See [desktop/docs/release.md](../../desktop/docs/release.md) for more details.
-- Cast builds are manual. Run `cast-build.yml` on the release branch after starting a release.
+- Cast has no scheduled nightly builds and skips the docs changelog PR on promotion.
 
 ## Normal development
 

--- a/.github/scripts/cast-version.mjs
+++ b/.github/scripts/cast-version.mjs
@@ -15,27 +15,24 @@ function source() {
 }
 
 function fieldPattern(name) {
-    return new RegExp(
-        `(${name} = )([^;]+)(;[^}]*PRODUCT_BUNDLE_IDENTIFIER = io\\.ente\\.frame\\.tv\\.cast;)`,
-    );
+    return new RegExp(`${name} = ([^;]+);`, "g");
 }
 
 function value(name) {
-    const found = source().match(fieldPattern(name))?.[2];
-    if (!found) throw new Error(`${name}: no Cast Release entry found`);
+    const found = fieldPattern(name).exec(source())?.[1];
+    if (!found) throw new Error(`${name}: no Cast entry found`);
     return found;
 }
 
 function set(name, next) {
     const text = source();
     const pattern = fieldPattern(name);
-    if (!pattern.test(text))
-        throw new Error(`${name}: no Cast Release entry found`);
-    fs.writeFileSync(xcode, text.replace(pattern, `$1${next}$3`));
+    if (!pattern.test(text)) throw new Error(`${name}: no Cast entry found`);
+    fs.writeFileSync(xcode, text.replace(pattern, `${name} = ${next};`));
 }
 
 function checkVersion(version) {
-    if (!/^\d+\.\d+$/.test(version))
+    if (!/^\d+\.\d+\.\d+$/.test(version))
         throw new Error(`Invalid Cast version: ${version}`);
 }
 
@@ -48,8 +45,8 @@ function usage() {
     console.error(`Usage:
   node .github/scripts/cast-version.mjs get
   node .github/scripts/cast-version.mjs get-build-base
-  node .github/scripts/cast-version.mjs set 1.2
-  node .github/scripts/cast-version.mjs set-build 1.2 34
+  node .github/scripts/cast-version.mjs set 1.2.0
+  node .github/scripts/cast-version.mjs set-build 1.2.0 34
   node .github/scripts/cast-version.mjs bump-build`);
 }
 

--- a/.github/scripts/release-notify.mjs
+++ b/.github/scripts/release-notify.mjs
@@ -19,6 +19,11 @@ const apps = {
         testFlightId: "6758197006",
         accentColor: 16633363,
     },
+    cast: {
+        testFlightId: "6751903820",
+        testFlightPlatform: "tvos",
+        accentColor: 65280,
+    },
     "photos-desktop": { accentColor: 65280 },
 };
 
@@ -68,7 +73,7 @@ if (config.packageId) {
 }
 if (config.testFlightId) {
     downloadLinks.push(
-        `[TestFlight](https://appstoreconnect.apple.com/apps/${config.testFlightId}/testflight/ios)`,
+        `[TestFlight](https://appstoreconnect.apple.com/apps/${config.testFlightId}/testflight/${config.testFlightPlatform ?? "ios"})`,
     );
 }
 downloadLinks.push(`[GitHub Release](${releaseUrl})`);

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -50,15 +50,8 @@ jobs:
             - name: Validate version input
               shell: bash
               run: |
-                  if [[ "${APP}" == "cast" ]]; then
-                      pattern='^[0-9]+\.[0-9]+$'
-                      example=x.y
-                  else
-                      pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
-                      example=x.y.z
-                  fi
-                  if [[ ! "${VERSION}" =~ ${pattern} ]]; then
-                      echo "::error::version must be ${example}"
+                  if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                      echo "::error::version must be x.y.z"
                       exit 1
                   fi
 
@@ -112,14 +105,9 @@ jobs:
 
                   release_branch="release/${APP}-v${VERSION}"
                   beta_tag="${APP}-v${VERSION}-beta"
+                  IFS=. read -r major minor patch <<< "${VERSION}"
                   expected_main_version="${VERSION}"
-                  if [ "${APP}" = "cast" ]; then
-                      IFS=. read -r major minor <<< "${VERSION}"
-                      next_version="${major}.$((minor + 1))"
-                  else
-                      IFS=. read -r major minor patch <<< "${VERSION}"
-                      next_version="${major}.${minor}.$((patch + 1))"
-                  fi
+                  next_version="${major}.${minor}.$((patch + 1))"
                   if [ "${APP}" = "ensu" ] || [ "${APP}" = "photos-desktop" ]; then
                       expected_main_version="${VERSION}-beta"
                       next_version="${next_version}-beta"
@@ -143,10 +131,8 @@ jobs:
                   fi
                   git_push_with_app_token "${release_branch}"
 
-                  if [ "${APP}" != "cast" ]; then
-                      gh release delete "${beta_tag}" --yes --cleanup-tag --repo ente/nightly || true
-                      git push origin ":refs/tags/${beta_tag}" || true
-                  fi
+                  gh release delete "${beta_tag}" --yes --cleanup-tag --repo ente/nightly || true
+                  git push origin ":refs/tags/${beta_tag}" || true
 
                   git switch -c "${next_branch}" main
                   app_version set "${next_version}"
@@ -240,9 +226,7 @@ jobs:
                   gh release edit "${rc_tag}" --tag "${final_tag}" --title "${final_tag}" --target "${release_sha}" --draft=false --prerelease=false --verify-tag
 
                   git push origin ":refs/tags/${rc_tag}" || true
-                  if [ "${APP}" != "cast" ]; then
-                      gh release delete "${rc_tag}" --yes --cleanup-tag --repo ente/nightly || true
-                  fi
+                  gh release delete "${rc_tag}" --yes --cleanup-tag --repo ente/nightly || true
                   git_push_with_app_token ":refs/heads/${release_branch}"
 
     sync-docs:

--- a/.github/workflows/cast-build.yml
+++ b/.github/workflows/cast-build.yml
@@ -37,14 +37,20 @@ jobs:
                       fi
                       build_number="${build_base}"
                       release_tag="cast-v${version}-rc"
-                      echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
-                      node .github/scripts/release-notes.mjs apple/apps/cast/changes "${release_tag}" >> "${GITHUB_OUTPUT}"
+                      release_title="📺 Cast release candidate · ${version} (build ${build_number})"
                   else
                       build_number="$((build_base + GITHUB_RUN_NUMBER))"
+                      release_tag="cast-v${version}-beta"
+                      release_title="📺 Cast beta · ${version} (build ${build_number})"
                   fi
+
+                  git fetch --force --depth=1 --no-tags origin "refs/tags/${release_tag}:refs/tags/${release_tag}" || true
 
                   echo "build_number=${build_number}" >> "${GITHUB_OUTPUT}"
                   echo "commit_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+                  echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+                  echo "release_title=${release_title}" >> "${GITHUB_OUTPUT}"
+                  node .github/scripts/release-notes.mjs apple/apps/cast/changes "${release_tag}" >> "${GITHUB_OUTPUT}"
 
             - name: Generate Cast bindings
               working-directory: rust
@@ -93,6 +99,29 @@ jobs:
                       -authenticationKeyID "${ASC_KEY_ID}" \
                       -authenticationKeyIssuerID "${ASC_ISSUER_ID}"
 
+            - name: Mint nightly token
+              id: nightly_token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.ENTE_CI_GH_CLIENT_ID }}
+                  private-key: ${{ secrets.ENTE_CI_GH_APP_PRIVATE_KEY }}
+                  repositories: nightly
+                  permission-contents: write
+
+            - name: Publish prerelease notes
+              uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+              with:
+                  repo: nightly
+                  token: ${{ steps.nightly_token.outputs.token }}
+                  tag: ${{ steps.metadata.outputs.release_tag }}
+                  name: ${{ steps.metadata.outputs.release_tag }}
+                  body: ${{ steps.metadata.outputs.release_body }}
+                  commit: main
+                  prerelease: true
+                  makeLatest: false
+                  allowUpdates: true
+                  updateOnlyUnreleased: true
+
             - name: Create RC draft
               if: startsWith(github.ref_name, 'release/cast-v')
               uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
@@ -105,11 +134,19 @@ jobs:
                   allowUpdates: true
                   updateOnlyUnreleased: true
 
-            - name: Point RC tag at the successfully uploaded commit
-              if: startsWith(github.ref_name, 'release/cast-v')
+            - name: Point release tag at the successfully uploaded commit
               env:
                   COMMIT_SHA: ${{ steps.metadata.outputs.commit_sha }}
                   RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
               run: |
                   git tag --force "${RELEASE_TAG}" "${COMMIT_SHA}"
                   git push --force origin "refs/tags/${RELEASE_TAG}"
+
+            - name: Notify Discord
+              continue-on-error: true
+              env:
+                  DISCORD_WEBHOOK: ${{ secrets.DISCORD_INTERNAL_RELEASE_WEBHOOK }}
+                  RELEASE_TITLE: ${{ steps.metadata.outputs.release_title }}
+                  RELEASE_BODY_GROUPED: ${{ steps.metadata.outputs.release_body_grouped }}
+                  RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
+              run: node .github/scripts/release-notify.mjs cast "${RELEASE_TAG}"

--- a/.github/workflows/cast-build.yml
+++ b/.github/workflows/cast-build.yml
@@ -1,6 +1,9 @@
 name: "Build (Cast)"
 
 on:
+    push:
+        branches:
+            - "release/cast-v*"
     workflow_dispatch:
 
 permissions:

--- a/apple/apps/cast/Cast.xcodeproj/project.pbxproj
+++ b/apple/apps/cast/Cast.xcodeproj/project.pbxproj
@@ -445,7 +445,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"$(TARGET_TEMP_DIR)/cast_rust/libcast.a",
@@ -483,7 +483,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"$(TARGET_TEMP_DIR)/cast_rust/libcast.a",
@@ -507,7 +507,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 6Z68YJY9Q2;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.ente.photos.tv.castTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -526,7 +526,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 6Z68YJY9Q2;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.ente.photos.tv.castTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -544,7 +544,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 6Z68YJY9Q2;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.ente.photos.tv.castUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -561,7 +561,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 6Z68YJY9Q2;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.ente.photos.tv.castUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;


### PR DESCRIPTION
Standardize Cast versioning and release cleanup, publish beta/RC notes, and notify Discord after successful TestFlight uploads.

Differences from other apps:

- Builds remain manual, including RCs, to keep Cast builds explicitly triggered.
- GitHub releases contain notes only; tvOS builds are distributed through TestFlight.
- Promotion skips the docs changelog PR because Cast has no help-changelog page.

Version bumps, release tags, promotion, and cleanup follow the shared release process.
