### PR TITLE
[mob][photos] Scale gallery filmstrip for large screens

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/detail_page.dart
@@ -139,7 +139,7 @@ class _DetailPageState extends State<DetailPage> {
           isGuestView: false,
           itemCount: widget.config.files.length,
         )
-        ? GalleryFileViewerFilmstripLayout.additionalBottomInset
+        ? GalleryFileViewerFilmstripLayout.compact.additionalBottomInset
         : 0;
   }
 
@@ -203,6 +203,8 @@ class _BodyState extends State<_Body> {
   final Map<EnteFile, VideoStreamChangeController>
   _videoStreamChangeControllers = Map.identity();
   ValueNotifier<double>? _bottomControlsAdditionalInsetNotifier;
+  GalleryFileViewerFilmstripLayout _filmstripLayout =
+      GalleryFileViewerFilmstripLayout.compact;
 
   @override
   void initState() {
@@ -277,6 +279,9 @@ class _BodyState extends State<_Body> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _filmstripLayout = GalleryFileViewerFilmstripLayout.fromMediaQuery(
+      MediaQuery.of(context),
+    );
     _bottomControlsAdditionalInsetNotifier = InheritedDetailPageState.of(
       context,
     ).bottomControlsAdditionalInsetNotifier;
@@ -402,6 +407,7 @@ class _BodyState extends State<_Body> {
                     mode: widget.config.mode,
                     isGuestView: isGuestView,
                     hasFilmstrip: _shouldShowFilmstrip,
+                    filmstripLayout: _filmstripLayout,
                     enableFullScreenNotifier: fullScreenNotifier,
                   );
                 },
@@ -415,6 +421,7 @@ class _BodyState extends State<_Body> {
                     mode: widget.config.mode,
                     isGuestView: isGuestView,
                     hasFilmstrip: _shouldShowFilmstrip,
+                    filmstripLayout: _filmstripLayout,
                   );
                 },
               ),
@@ -528,6 +535,7 @@ class _BodyState extends State<_Body> {
                       enableFullScreenNotifier: InheritedDetailPageState.of(
                         context,
                       ).enableFullScreenNotifier,
+                      layout: _filmstripLayout,
                       onEvent: _filmstripCoordinator.handleEvent,
                     );
                   },
@@ -897,7 +905,7 @@ class _BodyState extends State<_Body> {
     if (notifier == null) return;
     if (!_shouldShowFilmstrip) _filmstripCoordinator.reset();
     final inset = _shouldShowFilmstrip
-        ? GalleryFileViewerFilmstripLayout.additionalBottomInset
+        ? _filmstripLayout.additionalBottomInset
         : 0.0;
     notifier.value = inset;
   }
@@ -952,6 +960,7 @@ class _GalleryFileViewerBottomOverlay extends StatelessWidget {
   final DetailPageMode mode;
   final bool isGuestView;
   final bool hasFilmstrip;
+  final GalleryFileViewerFilmstripLayout filmstripLayout;
   final ValueListenable<bool> enableFullScreenNotifier;
 
   const _GalleryFileViewerBottomOverlay({
@@ -959,6 +968,7 @@ class _GalleryFileViewerBottomOverlay extends StatelessWidget {
     required this.mode,
     required this.isGuestView,
     required this.hasFilmstrip,
+    required this.filmstripLayout,
     required this.enableFullScreenNotifier,
   });
 
@@ -977,7 +987,7 @@ class _GalleryFileViewerBottomOverlay extends StatelessWidget {
       context,
     ).mini.copyWith(color: textBaseDark.withValues(alpha: 0.8));
     final filmstripInset = hasFilmstrip
-        ? GalleryFileViewerFilmstripLayout.additionalBottomInset
+        ? filmstripLayout.additionalBottomInset
         : 0.0;
     return ValueListenableBuilder<bool>(
       valueListenable: enableFullScreenNotifier,
@@ -1072,12 +1082,14 @@ class _GallerySocialOverlay extends StatelessWidget {
   final DetailPageMode mode;
   final bool isGuestView;
   final bool hasFilmstrip;
+  final GalleryFileViewerFilmstripLayout filmstripLayout;
 
   const _GallerySocialOverlay({
     required this.file,
     required this.mode,
     required this.isGuestView,
     required this.hasFilmstrip,
+    required this.filmstripLayout,
   });
 
   @override
@@ -1095,9 +1107,7 @@ class _GallerySocialOverlay extends StatelessWidget {
       bottom:
           padding.bottom +
           _socialBottomBarClearance +
-          (hasFilmstrip
-              ? GalleryFileViewerFilmstripLayout.additionalBottomInset
-              : 0),
+          (hasFilmstrip ? filmstripLayout.additionalBottomInset : 0),
       child: ValueListenableBuilder<bool>(
         valueListenable: fullScreenNotifier,
         builder: (context, isFullScreen, child) => IgnorePointer(

--- a/mobile/apps/photos/lib/ui/viewer/file/file_viewer_filmstrip.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_viewer_filmstrip.dart
@@ -12,19 +12,67 @@ const fileViewerFilmstripListKey = ValueKey<String>(
   "file-viewer-filmstrip-list",
 );
 
-abstract final class FileViewerFilmstripLayout {
-  static const height = 45.0;
+@immutable
+class FileViewerFilmstripLayout {
+  static const compact = FileViewerFilmstripLayout._(
+    scale: 1,
+    height: 45,
+    itemExtent: 33,
+    selectedThumbnailSize: Size(34, 43),
+    thumbnailSize: Size(29, 35),
+    thumbnailBorderRadius: BorderRadius.all(Radius.circular(2.5)),
+  );
+  static const _compactShortestSide = 600.0;
+  static const _maximumScale = 1.5;
+
+  final double scale;
+  final double height;
+  final double itemExtent;
+  final Size selectedThumbnailSize;
+  final Size thumbnailSize;
+  final BorderRadius thumbnailBorderRadius;
+
+  const FileViewerFilmstripLayout._({
+    required this.scale,
+    required this.height,
+    required this.itemExtent,
+    required this.selectedThumbnailSize,
+    required this.thumbnailSize,
+    required this.thumbnailBorderRadius,
+  });
+
+  factory FileViewerFilmstripLayout.forAvailableSize(Size availableSize) {
+    final shortestSide = min(availableSize.width, availableSize.height);
+    final scale = (shortestSide / _compactShortestSide)
+        .clamp(1.0, _maximumScale)
+        .toDouble();
+    if (scale == 1) return compact;
+    return FileViewerFilmstripLayout._(
+      scale: scale,
+      height: compact.height * scale,
+      itemExtent: compact.itemExtent * scale,
+      selectedThumbnailSize: compact.selectedThumbnailSize * scale,
+      thumbnailSize: compact.thumbnailSize * scale,
+      thumbnailBorderRadius: BorderRadius.all(Radius.circular(2.5 * scale)),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FileViewerFilmstripLayout && scale == other.scale;
+
+  @override
+  int get hashCode => scale.hashCode;
 }
 
-const _itemExtent = 33.0;
-const _selectedThumbnailSize = Size(34, 43);
-const _thumbnailSize = Size(29, 35);
-const _thumbnailBorderRadius = BorderRadius.all(Radius.circular(2.5));
 const _cacheExtentInItems = 4;
 const _scrollAnimationDuration = Duration(milliseconds: 180);
 
-typedef FileViewerFilmstripSemanticValueBuilder =
-    String Function(int current, int total);
+typedef FileViewerFilmstripSemanticValueBuilder = String Function(
+  int current,
+  int total,
+);
 
 class FileViewerFilmstrip extends StatefulWidget {
   final int itemCount;
@@ -35,6 +83,7 @@ class FileViewerFilmstrip extends StatefulWidget {
   final FileViewerFilmstripEventCallback onEvent;
   final String? semanticLabel;
   final FileViewerFilmstripSemanticValueBuilder semanticValueBuilder;
+  final FileViewerFilmstripLayout layout;
 
   const FileViewerFilmstrip({
     required this.itemCount,
@@ -45,6 +94,7 @@ class FileViewerFilmstrip extends StatefulWidget {
     this.itemKeyBuilder,
     this.findChildIndexCallback,
     this.semanticLabel,
+    this.layout = FileViewerFilmstripLayout.compact,
     super.key = fileViewerFilmstripKey,
   }) : assert(itemCount >= 0);
 
@@ -74,12 +124,15 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
     super.didUpdateWidget(oldWidget);
     final selectedIndex = _clampIndex(widget.selectedIndex);
     final itemCountChanged = widget.itemCount != oldWidget.itemCount;
+    final layoutChanged = widget.layout != oldWidget.layout;
     final shouldSyncFocus =
         !_interaction.isUserScrollSessionActive ||
         _focusedIndex >= widget.itemCount;
     final focusChanged = shouldSyncFocus && _setFocusedIndex(selectedIndex);
 
-    if (!_interaction.isUserScrollSessionActive &&
+    if (layoutChanged) {
+      _requestCentering(jump: true);
+    } else if (!_interaction.isUserScrollSessionActive &&
         (focusChanged || itemCountChanged)) {
       _requestCentering();
     }
@@ -106,7 +159,7 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
           builder: (context, constraints) {
             final horizontalPadding = max(
               0.0,
-              (constraints.maxWidth - _itemExtent) / 2,
+              (constraints.maxWidth - widget.layout.itemExtent) / 2,
             );
             return Listener(
               onPointerDown: (event) => _interaction.pointerDown(event.pointer),
@@ -115,7 +168,7 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
               child: NotificationListener<ScrollNotification>(
                 onNotification: _onScrollNotification,
                 child: SizedBox(
-                  height: FileViewerFilmstripLayout.height,
+                  height: widget.layout.height,
                   child: ListView.builder(
                     key: fileViewerFilmstripListKey,
                     controller: _scrollController,
@@ -123,13 +176,13 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
                     scrollDirection: Axis.horizontal,
                     physics: fileViewerFilmstripPhysics,
                     itemCount: widget.itemCount,
-                    itemExtent: _itemExtent,
+                    itemExtent: widget.layout.itemExtent,
                     findChildIndexCallback: widget.findChildIndexCallback,
                     padding: EdgeInsets.symmetric(
                       horizontal: horizontalPadding,
                     ),
-                    scrollCacheExtent: const ScrollCacheExtent.pixels(
-                      _itemExtent * _cacheExtentInItems,
+                    scrollCacheExtent: ScrollCacheExtent.pixels(
+                      widget.layout.itemExtent * _cacheExtentInItems,
                     ),
                     addAutomaticKeepAlives: false,
                     addSemanticIndexes: false,
@@ -185,16 +238,17 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
       behavior: HitTestBehavior.opaque,
       onTap: () => _selectIndex(index, FileViewerFilmstripEventType.tap),
       child: SizedBox(
-        width: _itemExtent,
-        height: FileViewerFilmstripLayout.height,
+        width: widget.layout.itemExtent,
+        height: widget.layout.height,
         child: OverflowBox(
           minWidth: 0,
-          maxWidth: _selectedThumbnailSize.width,
+          maxWidth: widget.layout.selectedThumbnailSize.width,
           minHeight: 0,
-          maxHeight: _selectedThumbnailSize.height,
+          maxHeight: widget.layout.selectedThumbnailSize.height,
           child: _FilmstripThumbnailFrame(
             scrollPosition: _scrollController,
             proximity: () => _centerProximity(index),
+            layout: widget.layout,
             child: widget.itemBuilder(context, index),
           ),
         ),
@@ -259,7 +313,9 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
 
   int _nearestScrolledIndex() {
     if (!_scrollController.hasClients || widget.itemCount == 0) return 0;
-    return _clampIndex((_scrollController.offset / _itemExtent).round());
+    return _clampIndex(
+      (_scrollController.offset / widget.layout.itemExtent).round(),
+    );
   }
 
   void _selectIndex(
@@ -303,7 +359,9 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
           : position.pixels;
     }
     final linearProximity =
-        (1 - ((scrollOffset - _offsetForIndex(index)).abs() / _itemExtent))
+        (1 -
+                ((scrollOffset - _offsetForIndex(index)).abs() /
+                    widget.layout.itemExtent))
             .clamp(0.0, 1.0)
             .toDouble();
     // Smoothstep avoids a visible change in slope as an item enters or leaves
@@ -311,23 +369,39 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
     return linearProximity * linearProximity * (3 - (2 * linearProximity));
   }
 
-  void _requestCentering() {
+  bool _jumpOnNextCentering = false;
+
+  void _requestCentering({bool jump = false}) {
+    _jumpOnNextCentering |= jump;
     if (widget.itemCount == 0 || !_interaction.tryScheduleCentering()) {
       return;
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       if (!_interaction.resolveScheduledCentering()) return;
-      _animateToIndex(_focusedIndex);
+      if (_jumpOnNextCentering) {
+        _jumpOnNextCentering = false;
+        _jumpToIndex(_focusedIndex);
+      } else {
+        _animateToIndex(_focusedIndex);
+      }
     });
+  }
+
+  void _jumpToIndex(int index) {
+    if (widget.itemCount == 0 || !_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    final target = _offsetForIndex(_clampIndex(index))
+        .clamp(position.minScrollExtent, position.maxScrollExtent);
+    if ((position.pixels - target).abs() < 0.5) return;
+    _scrollController.jumpTo(target);
   }
 
   void _animateToIndex(int index) {
     if (widget.itemCount == 0 || !_scrollController.hasClients) return;
     final position = _scrollController.position;
-    final target = _offsetForIndex(
-      _clampIndex(index),
-    ).clamp(position.minScrollExtent, position.maxScrollExtent);
+    final target = _offsetForIndex(_clampIndex(index))
+        .clamp(position.minScrollExtent, position.maxScrollExtent);
     if ((position.pixels - target).abs() < 0.5) return;
     unawaited(
       _scrollController.animateTo(
@@ -343,7 +417,7 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
     return index.clamp(0, widget.itemCount - 1);
   }
 
-  double _offsetForIndex(int index) => index * _itemExtent;
+  double _offsetForIndex(int index) => index * widget.layout.itemExtent;
 }
 
 enum _CenteringRequestState { idle, scheduled, deferred }
@@ -397,11 +471,13 @@ class _FilmstripInteractionState {
 
 class _FilmstripThumbnailFrame extends AnimatedWidget {
   final ValueGetter<double> proximity;
+  final FileViewerFilmstripLayout layout;
   final Widget child;
 
   const _FilmstripThumbnailFrame({
     required Listenable scrollPosition,
     required this.proximity,
+    required this.layout,
     required this.child,
   }) : super(listenable: scrollPosition);
 
@@ -409,15 +485,15 @@ class _FilmstripThumbnailFrame extends AnimatedWidget {
   Widget build(BuildContext context) {
     final centerProximity = proximity();
     final size = Size.lerp(
-      _thumbnailSize,
-      _selectedThumbnailSize,
+      layout.thumbnailSize,
+      layout.selectedThumbnailSize,
       centerProximity,
     )!;
     return SizedBox.fromSize(
       size: size,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          borderRadius: _thumbnailBorderRadius,
+          borderRadius: layout.thumbnailBorderRadius,
           boxShadow: [
             BoxShadow(
               color: Color.lerp(
@@ -425,13 +501,13 @@ class _FilmstripThumbnailFrame extends AnimatedWidget {
                 const Color(0x33000000),
                 centerProximity,
               )!,
-              blurRadius: 2 + centerProximity,
-              offset: const Offset(0, 1),
+              blurRadius: (2 + centerProximity) * layout.scale,
+              offset: Offset(0, layout.scale),
             ),
           ],
         ),
         child: ClipRRect(
-          borderRadius: _thumbnailBorderRadius,
+          borderRadius: layout.thumbnailBorderRadius,
           child: Stack(
             fit: StackFit.expand,
             children: [

--- a/mobile/apps/photos/lib/ui/viewer/file/file_viewer_filmstrip.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_viewer_filmstrip.dart
@@ -69,10 +69,8 @@ class FileViewerFilmstripLayout {
 const _cacheExtentInItems = 4;
 const _scrollAnimationDuration = Duration(milliseconds: 180);
 
-typedef FileViewerFilmstripSemanticValueBuilder = String Function(
-  int current,
-  int total,
-);
+typedef FileViewerFilmstripSemanticValueBuilder =
+    String Function(int current, int total);
 
 class FileViewerFilmstrip extends StatefulWidget {
   final int itemCount;
@@ -391,8 +389,9 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
   void _jumpToIndex(int index) {
     if (widget.itemCount == 0 || !_scrollController.hasClients) return;
     final position = _scrollController.position;
-    final target = _offsetForIndex(_clampIndex(index))
-        .clamp(position.minScrollExtent, position.maxScrollExtent);
+    final target = _offsetForIndex(
+      _clampIndex(index),
+    ).clamp(position.minScrollExtent, position.maxScrollExtent);
     if ((position.pixels - target).abs() < 0.5) return;
     _scrollController.jumpTo(target);
   }
@@ -400,8 +399,9 @@ class _FileViewerFilmstripState extends State<FileViewerFilmstrip> {
   void _animateToIndex(int index) {
     if (widget.itemCount == 0 || !_scrollController.hasClients) return;
     final position = _scrollController.position;
-    final target = _offsetForIndex(_clampIndex(index))
-        .clamp(position.minScrollExtent, position.maxScrollExtent);
+    final target = _offsetForIndex(
+      _clampIndex(index),
+    ).clamp(position.minScrollExtent, position.maxScrollExtent);
     if ((position.pixels - target).abs() < 0.5) return;
     unawaited(
       _scrollController.animateTo(

--- a/mobile/apps/photos/lib/ui/viewer/file/gallery_file_viewer_filmstrip.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/gallery_file_viewer_filmstrip.dart
@@ -1,3 +1,5 @@
+import "dart:math";
+
 import "package:ente_components/ente_components.dart" show fillDarkDark;
 import "package:ente_strings/ente_strings.dart";
 import "package:flutter/foundation.dart";
@@ -12,10 +14,31 @@ import "package:photos/ui/viewer/file/file_viewer_filmstrip_event.dart";
 import "package:photos/ui/viewer/file/file_viewer_filmstrip_preview_layer.dart";
 import "package:photos/ui/viewer/file/thumbnail_widget.dart";
 
-abstract final class GalleryFileViewerFilmstripLayout {
+@immutable
+class GalleryFileViewerFilmstripLayout {
   static const upperContentGap = 6.0;
-  static const additionalBottomInset =
-      FileViewerFilmstripLayout.height + upperContentGap;
+  static const compact = GalleryFileViewerFilmstripLayout._(
+    FileViewerFilmstripLayout.compact,
+  );
+
+  final FileViewerFilmstripLayout filmstrip;
+
+  const GalleryFileViewerFilmstripLayout._(this.filmstrip);
+
+  factory GalleryFileViewerFilmstripLayout.fromMediaQuery(
+    MediaQueryData mediaQuery,
+  ) {
+    final viewPadding = mediaQuery.viewPadding;
+    final availableSize = Size(
+      max(0.0, mediaQuery.size.width - viewPadding.horizontal),
+      max(0.0, mediaQuery.size.height - viewPadding.vertical),
+    );
+    return GalleryFileViewerFilmstripLayout._(
+      FileViewerFilmstripLayout.forAvailableSize(availableSize),
+    );
+  }
+
+  double get additionalBottomInset => filmstrip.height + upperContentGap;
 }
 
 bool shouldShowGalleryFileViewerFilmstrip({
@@ -80,6 +103,7 @@ class GalleryFileViewerFilmstripOverlay extends StatelessWidget {
   final int? Function(Key key) findChildIndexCallback;
   final ValueListenable<bool> enableFullScreenNotifier;
   final FileViewerFilmstripEventCallback onEvent;
+  final GalleryFileViewerFilmstripLayout layout;
 
   const GalleryFileViewerFilmstripOverlay({
     required this.files,
@@ -88,6 +112,7 @@ class GalleryFileViewerFilmstripOverlay extends StatelessWidget {
     required this.findChildIndexCallback,
     required this.enableFullScreenNotifier,
     required this.onEvent,
+    required this.layout,
     super.key,
   });
 
@@ -98,7 +123,7 @@ class GalleryFileViewerFilmstripOverlay extends StatelessWidget {
       left: safePadding.left,
       right: safePadding.right,
       bottom: safePadding.bottom + bottomControlsHeight,
-      height: FileViewerFilmstripLayout.height,
+      height: layout.filmstrip.height,
       child: ValueListenableBuilder<bool>(
         valueListenable: enableFullScreenNotifier,
         builder: (context, isFullScreen, child) => IgnorePointer(
@@ -111,6 +136,7 @@ class GalleryFileViewerFilmstripOverlay extends StatelessWidget {
           ),
         ),
         child: FileViewerFilmstrip(
+          layout: layout.filmstrip,
           itemCount: files.length,
           selectedIndex: selectedIndex,
           semanticLabel: context.strings.photoViewerFilmstripLabel,
@@ -125,12 +151,14 @@ class GalleryFileViewerFilmstripOverlay extends StatelessWidget {
               children: [
                 _GalleryFilmstripThumbnail(file: file, fit: BoxFit.cover),
                 if (file.fileType == FileType.video)
-                  const Center(
+                  Center(
                     child: Icon(
                       Icons.play_arrow_rounded,
                       color: Colors.white,
-                      size: 14,
-                      shadows: [Shadow(color: Colors.black87, blurRadius: 3)],
+                      size: 14 * layout.filmstrip.scale,
+                      shadows: const [
+                        Shadow(color: Colors.black87, blurRadius: 3),
+                      ],
                     ),
                   ),
               ],

--- a/mobile/apps/photos/test/ui/viewer/file/file_viewer_filmstrip_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/file/file_viewer_filmstrip_test.dart
@@ -6,6 +6,26 @@ import "package:photos/ui/viewer/file/file_viewer_filmstrip.dart";
 import "package:photos/ui/viewer/file/file_viewer_filmstrip_event.dart";
 
 void main() {
+  test("scales with the shortest side and caps large-screen growth", () {
+    final phonePortrait = FileViewerFilmstripLayout.forAvailableSize(
+      const Size(390, 844),
+    );
+    final phoneLandscape = FileViewerFilmstripLayout.forAvailableSize(
+      const Size(844, 390),
+    );
+    final iPadMini = FileViewerFilmstripLayout.forAvailableSize(
+      const Size(744, 1133),
+    );
+    final largeIPad = FileViewerFilmstripLayout.forAvailableSize(
+      const Size(1032, 1376),
+    );
+
+    expect(phonePortrait, FileViewerFilmstripLayout.compact);
+    expect(phoneLandscape, FileViewerFilmstripLayout.compact);
+    expect(iPadMini.scale, closeTo(1.24, 0.001));
+    expect(largeIPad.scale, 1.5);
+  });
+
   testWidgets("centers the selected item and exposes adjustable semantics", (
     tester,
   ) async {
@@ -101,6 +121,35 @@ void main() {
     expect(haptics.count, 1);
     _expectCentered(tester, 8);
     expect(_thumbnailSize(tester, 8), const Size(34, 43));
+  });
+
+  testWidgets("recenters the selected item when its layout changes", (
+    tester,
+  ) async {
+    final key = GlobalKey<_FilmstripHarnessState>();
+    await tester.pumpWidget(
+      _TestApp(
+        child: _FilmstripHarness(key: key, itemCount: 20, selectedIndex: 7),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final largeLayout = FileViewerFilmstripLayout.forAvailableSize(
+      const Size(1032, 1376),
+    );
+    key.currentState!.update(layout: largeLayout);
+    await tester.pumpAndSettle();
+
+    _expectCentered(tester, 7);
+    expect(tester.getSize(find.byKey(fileViewerFilmstripListKey)).height, 67.5);
+    expect(_thumbnailSize(tester, 7), const Size(51, 64.5));
+    expect(
+      tester.getCenter(find.byKey(const ValueKey("filmstrip-test-item-8"))).dx -
+          tester
+              .getCenter(find.byKey(const ValueKey("filmstrip-test-item-7")))
+              .dx,
+      closeTo(49.5, 0.01),
+    );
   });
 
   testWidgets("sizes thumbnails continuously by their distance from center", (
@@ -705,18 +754,25 @@ class _FilmstripHarness extends StatefulWidget {
 class _FilmstripHarnessState extends State<_FilmstripHarness> {
   late int itemCount = widget.itemCount;
   late int selectedIndex = widget.selectedIndex;
+  FileViewerFilmstripLayout layout = FileViewerFilmstripLayout.compact;
   final selections = <FileViewerFilmstripEvent>[];
 
-  void update({int? itemCount, int? selectedIndex}) {
+  void update({
+    int? itemCount,
+    int? selectedIndex,
+    FileViewerFilmstripLayout? layout,
+  }) {
     setState(() {
       this.itemCount = itemCount ?? this.itemCount;
       this.selectedIndex = selectedIndex ?? this.selectedIndex;
+      this.layout = layout ?? this.layout;
     });
   }
 
   @override
   Widget build(BuildContext context) {
     return FileViewerFilmstrip(
+      layout: layout,
       itemCount: itemCount,
       selectedIndex: selectedIndex,
       semanticLabel: "Photo chooser",


### PR DESCRIPTION
## Summary

- scale gallery filmstrip geometry from 1.0x to a capped 1.5x using the usable shortest screen dimension
- keep phone and landscape-phone sizing unchanged while adapting tablets and resizable windows
- propagate the resolved strip height through viewer overlays and recenter after layout changes

## Testing

- `flutter test test/ui/viewer/file/file_viewer_filmstrip_test.dart`
- `flutter analyze lib/ui/viewer/file/file_viewer_filmstrip.dart lib/ui/viewer/file/gallery_file_viewer_filmstrip.dart lib/ui/viewer/file/detail_page.dart test/ui/viewer/file/file_viewer_filmstrip_test.dart`