### PR TITLE
[mob][photos] Simplify justified Flex layout

### DIFF
--- a/mobile/apps/photos/changes/justified-layout-tuning.md
+++ b/mobile/apps/photos/changes/justified-layout-tuning.md
@@ -1,1 +1,1 @@
-- (i) Added tuning controls and improved the experimental justified gallery layouts.
+- (i) Simplified the experimental justified gallery layout options and tuning controls.

--- a/mobile/apps/photos/lib/models/gallery/flex_layout.dart
+++ b/mobile/apps/photos/lib/models/gallery/flex_layout.dart
@@ -20,8 +20,8 @@ class FlexLayoutCalculator {
     required double availableWidth,
     required double targetRowHeight,
     required double spacing,
+    required double minimumNonFinalSingletonAspectRatio,
     double maximumRowHeightFactor = _defaultMaximumRowHeightFactor,
-    double? minimumNonFinalSingletonAspectRatio,
   }) {
     if (!availableWidth.isFinite || availableWidth <= 0) {
       throw ArgumentError.value(availableWidth, "availableWidth");
@@ -38,9 +38,8 @@ class FlexLayoutCalculator {
         "maximumRowHeightFactor",
       );
     }
-    if (minimumNonFinalSingletonAspectRatio != null &&
-        (!minimumNonFinalSingletonAspectRatio.isFinite ||
-            minimumNonFinalSingletonAspectRatio <= 0)) {
+    if (!minimumNonFinalSingletonAspectRatio.isFinite ||
+        minimumNonFinalSingletonAspectRatio <= 0) {
       throw ArgumentError.value(
         minimumNonFinalSingletonAspectRatio,
         "minimumNonFinalSingletonAspectRatio",
@@ -78,8 +77,7 @@ class FlexLayoutCalculator {
         final isTail = end == count - 1;
         if (!isTail &&
             itemCount == 1 &&
-            (minimumNonFinalSingletonAspectRatio == null ||
-                ratios[start] < minimumNonFinalSingletonAspectRatio)) {
+            ratios[start] < minimumNonFinalSingletonAspectRatio) {
           continue;
         }
         final geometry = _rowGeometry(

--- a/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
+++ b/mobile/apps/photos/lib/models/gallery/gallery_groups.dart
@@ -451,9 +451,6 @@ class GalleryGroups {
     final flexTuning = strategy == JustifiedLayoutStrategy.flex
         ? localSettings.getFlexLayoutTuning()
         : FlexLayoutTuning.defaults;
-    final flexFullRowsTuning = strategy == JustifiedLayoutStrategy.flexFullRows
-        ? localSettings.getFlexFullRowsLayoutTuning()
-        : FlexFullRowsLayoutTuning.defaults;
     final comfortLargeTuning = strategy == JustifiedLayoutStrategy.comfortLarge
         ? localSettings.getComfortLargeLayoutTuning()
         : ComfortLargeLayoutTuning.defaults;
@@ -466,8 +463,6 @@ class GalleryGroups {
       JustifiedLayoutStrategy.comfortLarge =>
         comfortLargeTuning.targetHeightScale,
       JustifiedLayoutStrategy.flex => flexTuning.targetHeightScale,
-      JustifiedLayoutStrategy.flexFullRows =>
-        flexFullRowsTuning.targetHeightScale,
     };
     final targetRowHeight = baseTargetRowHeight * targetHeightScale;
     final groupLayouts = <SectionLayout>[];
@@ -501,17 +496,9 @@ class GalleryGroups {
           targetRowHeight: targetRowHeight,
           spacing: spacing,
           maximumRowHeightFactor: flexTuning.maximumHeightFactor,
+          minimumNonFinalSingletonAspectRatio:
+              flexTuning.minimumNonFinalSingletonAspectRatio,
         ),
-        JustifiedLayoutStrategy.flexFullRows =>
-          FlexLayoutCalculator.computeRows(
-            aspectRatios: aspectRatios,
-            availableWidth: widthAvailable,
-            targetRowHeight: targetRowHeight,
-            spacing: spacing,
-            maximumRowHeightFactor: flexFullRowsTuning.maximumHeightFactor,
-            minimumNonFinalSingletonAspectRatio:
-                flexFullRowsTuning.minimumNonFinalSingletonAspectRatio,
-          ),
       };
       final firstIndex = currentIndex == 0 ? currentIndex : currentIndex + 1;
       final lastIndex = firstIndex + rows.length;

--- a/mobile/apps/photos/lib/models/gallery/justified_layout_strategy.dart
+++ b/mobile/apps/photos/lib/models/gallery/justified_layout_strategy.dart
@@ -1,1 +1,1 @@
-enum JustifiedLayoutStrategy { comfortLarge, flex, flexFullRows }
+enum JustifiedLayoutStrategy { comfortLarge, flex }

--- a/mobile/apps/photos/lib/models/gallery/justified_layout_tuning.dart
+++ b/mobile/apps/photos/lib/models/gallery/justified_layout_tuning.dart
@@ -1,6 +1,4 @@
-enum FlexLayoutTuningField { targetHeightScale, maximumHeightFactor }
-
-enum FlexFullRowsLayoutTuningField {
+enum FlexLayoutTuningField {
   targetHeightScale,
   maximumHeightFactor,
   minimumNonFinalSingletonAspectRatio,
@@ -18,16 +16,20 @@ class FlexLayoutTuning {
 
   final double targetHeightScale;
   final double maximumHeightFactor;
+  final double minimumNonFinalSingletonAspectRatio;
 
   const FlexLayoutTuning({
     this.targetHeightScale = 1.12,
     this.maximumHeightFactor = 1.6,
+    this.minimumNonFinalSingletonAspectRatio = 0.75,
   });
 
   double valueFor(FlexLayoutTuningField field) {
     return switch (field) {
       FlexLayoutTuningField.targetHeightScale => targetHeightScale,
       FlexLayoutTuningField.maximumHeightFactor => maximumHeightFactor,
+      FlexLayoutTuningField.minimumNonFinalSingletonAspectRatio =>
+        minimumNonFinalSingletonAspectRatio,
     };
   }
 }
@@ -38,46 +40,9 @@ extension FlexLayoutTuningFieldValue on FlexLayoutTuningField {
   double get maximumValue => 10;
 
   double get minimumValue => switch (this) {
-    FlexLayoutTuningField.targetHeightScale => 0.1,
+    FlexLayoutTuningField.targetHeightScale ||
+    FlexLayoutTuningField.minimumNonFinalSingletonAspectRatio => 0.1,
     FlexLayoutTuningField.maximumHeightFactor => 1,
-  };
-
-  bool isValid(double value) =>
-      value.isFinite && value >= minimumValue && value <= maximumValue;
-}
-
-class FlexFullRowsLayoutTuning {
-  static const defaults = FlexFullRowsLayoutTuning();
-
-  final double targetHeightScale;
-  final double maximumHeightFactor;
-  final double minimumNonFinalSingletonAspectRatio;
-
-  const FlexFullRowsLayoutTuning({
-    this.targetHeightScale = 1.12,
-    this.maximumHeightFactor = 1.6,
-    this.minimumNonFinalSingletonAspectRatio = 0.75,
-  });
-
-  double valueFor(FlexFullRowsLayoutTuningField field) {
-    return switch (field) {
-      FlexFullRowsLayoutTuningField.targetHeightScale => targetHeightScale,
-      FlexFullRowsLayoutTuningField.maximumHeightFactor => maximumHeightFactor,
-      FlexFullRowsLayoutTuningField.minimumNonFinalSingletonAspectRatio =>
-        minimumNonFinalSingletonAspectRatio,
-    };
-  }
-}
-
-extension FlexFullRowsLayoutTuningFieldValue on FlexFullRowsLayoutTuningField {
-  double get defaultValue => FlexFullRowsLayoutTuning.defaults.valueFor(this);
-
-  double get maximumValue => 10;
-
-  double get minimumValue => switch (this) {
-    FlexFullRowsLayoutTuningField.targetHeightScale ||
-    FlexFullRowsLayoutTuningField.minimumNonFinalSingletonAspectRatio => 0.1,
-    FlexFullRowsLayoutTuningField.maximumHeightFactor => 1,
   };
 
   bool isValid(double value) =>

--- a/mobile/apps/photos/lib/settings/local_settings.dart
+++ b/mobile/apps/photos/lib/settings/local_settings.dart
@@ -60,15 +60,12 @@ class LocalSettings {
   static const kGalleryGroupType = "gallery_group_type";
   static const kGalleryLayoutType = "gallery_layout_type";
   static const kJustifiedLayoutStrategy = "justified_layout_strategy";
+  // Keep the former Full Rows keys so its tuning survives the option rename.
   static const kFlexLayoutTuningTargetHeightScale =
-      "gallery.justified.flex.target_height_scale";
-  static const kFlexLayoutTuningMaximumHeightFactor =
-      "gallery.justified.flex.maximum_height_factor";
-  static const kFlexFullRowsLayoutTuningTargetHeightScale =
       "gallery.justified.flex_full_rows.target_height_scale";
-  static const kFlexFullRowsLayoutTuningMaximumHeightFactor =
+  static const kFlexLayoutTuningMaximumHeightFactor =
       "gallery.justified.flex_full_rows.maximum_height_factor";
-  static const kFlexFullRowsLayoutTuningMinimumNonFinalSingletonAspectRatio =
+  static const kFlexLayoutTuningMinimumNonFinalSingletonAspectRatio =
       "gallery.justified.flex_full_rows.minimum_non_final_singleton_aspect_ratio";
   static const kComfortLargeLayoutTuningTargetHeightScale =
       "gallery.justified.comfort_large.target_height_scale";
@@ -303,8 +300,7 @@ class LocalSettings {
 
   JustifiedLayoutStrategy getJustifiedLayoutStrategy() {
     return switch (_prefs.getString(kJustifiedLayoutStrategy)) {
-      "flex" => JustifiedLayoutStrategy.flex,
-      "flexFullRows" => JustifiedLayoutStrategy.flexFullRows,
+      "flex" || "flexFullRows" => JustifiedLayoutStrategy.flex,
       _ => JustifiedLayoutStrategy.comfortLarge,
     };
   }
@@ -327,6 +323,11 @@ class LocalSettings {
         FlexLayoutTuningField.maximumHeightFactor.defaultValue,
         FlexLayoutTuningField.maximumHeightFactor.isValid,
       ),
+      minimumNonFinalSingletonAspectRatio: _validDoubleOrDefault(
+        kFlexLayoutTuningMinimumNonFinalSingletonAspectRatio,
+        FlexLayoutTuningField.minimumNonFinalSingletonAspectRatio.defaultValue,
+        FlexLayoutTuningField.minimumNonFinalSingletonAspectRatio.isValid,
+      ),
     );
   }
 
@@ -347,54 +348,6 @@ class LocalSettings {
   Future<void> resetFlexLayoutTuning() async {
     await Future.wait(
       FlexLayoutTuningField.values.map(resetFlexLayoutTuningValue),
-    );
-  }
-
-  FlexFullRowsLayoutTuning getFlexFullRowsLayoutTuning() {
-    return FlexFullRowsLayoutTuning(
-      targetHeightScale: _validDoubleOrDefault(
-        kFlexFullRowsLayoutTuningTargetHeightScale,
-        FlexFullRowsLayoutTuningField.targetHeightScale.defaultValue,
-        FlexFullRowsLayoutTuningField.targetHeightScale.isValid,
-      ),
-      maximumHeightFactor: _validDoubleOrDefault(
-        kFlexFullRowsLayoutTuningMaximumHeightFactor,
-        FlexFullRowsLayoutTuningField.maximumHeightFactor.defaultValue,
-        FlexFullRowsLayoutTuningField.maximumHeightFactor.isValid,
-      ),
-      minimumNonFinalSingletonAspectRatio: _validDoubleOrDefault(
-        kFlexFullRowsLayoutTuningMinimumNonFinalSingletonAspectRatio,
-        FlexFullRowsLayoutTuningField
-            .minimumNonFinalSingletonAspectRatio
-            .defaultValue,
-        FlexFullRowsLayoutTuningField
-            .minimumNonFinalSingletonAspectRatio
-            .isValid,
-      ),
-    );
-  }
-
-  Future<void> setFlexFullRowsLayoutTuningValue(
-    FlexFullRowsLayoutTuningField field,
-    double value,
-  ) async {
-    if (!field.isValid(value)) {
-      throw ArgumentError.value(value, field.name);
-    }
-    await _prefs.setDouble(_flexFullRowsLayoutTuningKey(field), value);
-  }
-
-  Future<void> resetFlexFullRowsLayoutTuningValue(
-    FlexFullRowsLayoutTuningField field,
-  ) async {
-    await _prefs.remove(_flexFullRowsLayoutTuningKey(field));
-  }
-
-  Future<void> resetFlexFullRowsLayoutTuning() async {
-    await Future.wait(
-      FlexFullRowsLayoutTuningField.values.map(
-        resetFlexFullRowsLayoutTuningValue,
-      ),
     );
   }
 
@@ -464,6 +417,8 @@ class LocalSettings {
         kFlexLayoutTuningTargetHeightScale,
       FlexLayoutTuningField.maximumHeightFactor =>
         kFlexLayoutTuningMaximumHeightFactor,
+      FlexLayoutTuningField.minimumNonFinalSingletonAspectRatio =>
+        kFlexLayoutTuningMinimumNonFinalSingletonAspectRatio,
     };
   }
 
@@ -479,19 +434,6 @@ class LocalSettings {
         kComfortLargeLayoutTuningWideFinalMaximumHeightFactor,
       ComfortLargeLayoutTuningField.minimumLandscapeHeightFactor =>
         kComfortLargeLayoutTuningMinimumLandscapeHeightFactor,
-    };
-  }
-
-  static String _flexFullRowsLayoutTuningKey(
-    FlexFullRowsLayoutTuningField field,
-  ) {
-    return switch (field) {
-      FlexFullRowsLayoutTuningField.targetHeightScale =>
-        kFlexFullRowsLayoutTuningTargetHeightScale,
-      FlexFullRowsLayoutTuningField.maximumHeightFactor =>
-        kFlexFullRowsLayoutTuningMaximumHeightFactor,
-      FlexFullRowsLayoutTuningField.minimumNonFinalSingletonAspectRatio =>
-        kFlexFullRowsLayoutTuningMinimumNonFinalSingletonAspectRatio,
     };
   }
 

--- a/mobile/apps/photos/lib/ui/settings/gallery_settings_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/gallery_settings_screen.dart
@@ -50,7 +50,7 @@ class _GallerySettingsScreenState extends State<GallerySettingsScreen> {
       children: [
         if (isJustifiedLayoutAvailable) ...[
           SettingsItem(
-            title: l10n.layout,
+            title: "${l10n.layout} (i)",
             trailing: _trailingLabel(
               context,
               _layoutTypeLabel(context, _layoutType, _justifiedStrategy),
@@ -59,7 +59,7 @@ class _GallerySettingsScreenState extends State<GallerySettingsScreen> {
           ),
           const SizedBox(height: 8),
           SettingsItem(
-            title: "Justified layout tuning",
+            title: "Justified layout tuning (i)",
             onTap: () async {
               await Navigator.of(context).push(
                 MaterialPageRoute<void>(

--- a/mobile/apps/photos/lib/ui/settings/justified_layout_tuning_screen.dart
+++ b/mobile/apps/photos/lib/ui/settings/justified_layout_tuning_screen.dart
@@ -20,11 +20,10 @@ class _JustifiedLayoutTuningScreenState
   @override
   Widget build(BuildContext context) {
     final flexTuning = localSettings.getFlexLayoutTuning();
-    final flexFullRowsTuning = localSettings.getFlexFullRowsLayoutTuning();
     final comfortLargeTuning = localSettings.getComfortLargeLayoutTuning();
 
     return SettingsPageScaffold(
-      title: "Justified layout tuning",
+      title: "Justified layout tuning (i)",
       children: [
         Text(
           "Height values are multipliers of the responsive target row height. "
@@ -34,7 +33,7 @@ class _JustifiedLayoutTuningScreenState
           ),
         ),
         const SizedBox(height: 16),
-        const MenuSectionTitle(title: "Flex"),
+        const MenuSectionTitle(title: "Flex (i)"),
         MenuGroupComponent(
           items: [
             for (final field in FlexLayoutTuningField.values)
@@ -51,27 +50,7 @@ class _JustifiedLayoutTuningScreenState
           ],
         ),
         const SizedBox(height: 24),
-        const MenuSectionTitle(title: "Flex Full Rows"),
-        MenuGroupComponent(
-          items: [
-            for (final field in FlexFullRowsLayoutTuningField.values)
-              SettingsItem(
-                title: _flexFullRowsFieldLabel(field),
-                trailing: _valueLabel(
-                  context,
-                  flexFullRowsTuning.valueFor(field),
-                ),
-                onTap: () => _editFlexFullRowsValue(field),
-              ),
-            SettingsItem(
-              title: "Reset all",
-              showChevron: false,
-              onTap: _resetFlexFullRowsValues,
-            ),
-          ],
-        ),
-        const SizedBox(height: 24),
-        const MenuSectionTitle(title: "Comfort Large"),
+        const MenuSectionTitle(title: "Comfort Large (i)"),
         MenuGroupComponent(
           items: [
             for (final field in ComfortLargeLayoutTuningField.values)
@@ -91,27 +70,6 @@ class _JustifiedLayoutTuningScreenState
           ],
         ),
       ],
-    );
-  }
-
-  Future<void> _editFlexFullRowsValue(
-    FlexFullRowsLayoutTuningField field,
-  ) async {
-    final tuning = localSettings.getFlexFullRowsLayoutTuning();
-    await _showValueSheet(
-      title: _flexFullRowsFieldLabel(field),
-      initialValue: tuning.valueFor(field),
-      defaultValue: field.defaultValue,
-      isValid: field.isValid,
-      validRange: (field.minimumValue, field.maximumValue),
-      onSave: (value) async {
-        await localSettings.setFlexFullRowsLayoutTuningValue(field, value);
-        _refreshGallery();
-      },
-      onReset: () async {
-        await localSettings.resetFlexFullRowsLayoutTuningValue(field);
-        _refreshGallery();
-      },
     );
   }
 
@@ -187,11 +145,6 @@ class _JustifiedLayoutTuningScreenState
 
   Future<void> _resetFlexValues() async {
     await localSettings.resetFlexLayoutTuning();
-    _refreshGallery();
-  }
-
-  Future<void> _resetFlexFullRowsValues() async {
-    await localSettings.resetFlexFullRowsLayoutTuning();
     _refreshGallery();
   }
 
@@ -310,16 +263,9 @@ class _TuningValueSheetState extends State<_TuningValueSheet> {
 String _flexFieldLabel(FlexLayoutTuningField field) => switch (field) {
   FlexLayoutTuningField.targetHeightScale => "Target height scale",
   FlexLayoutTuningField.maximumHeightFactor => "Maximum height factor",
+  FlexLayoutTuningField.minimumNonFinalSingletonAspectRatio =>
+    "Minimum non-final singleton aspect ratio",
 };
-
-String _flexFullRowsFieldLabel(FlexFullRowsLayoutTuningField field) =>
-    switch (field) {
-      FlexFullRowsLayoutTuningField.targetHeightScale => "Target height scale",
-      FlexFullRowsLayoutTuningField.maximumHeightFactor =>
-        "Maximum height factor",
-      FlexFullRowsLayoutTuningField.minimumNonFinalSingletonAspectRatio =>
-        "Minimum non-final singleton aspect ratio",
-    };
 
 String _comfortLargeFieldLabel(ComfortLargeLayoutTuningField field) =>
     switch (field) {

--- a/mobile/apps/photos/lib/ui/settings/search/settings_search_registry.dart
+++ b/mobile/apps/photos/lib/ui/settings/search/settings_search_registry.dart
@@ -329,7 +329,7 @@ class SettingsSearchRegistry {
     if (showJustifiedLayout) {
       items.add(
         SettingsSearchItem(
-          title: l10n.layout,
+          title: "${l10n.layout} (i)",
           subtitle: l10n.gallery,
           sectionPath: "${l10n.appearance} > ${l10n.gallery}",
           icon: HugeIcons.strokeRoundedDashboardSquare02,

--- a/mobile/apps/photos/lib/ui/viewer/gallery/justified_layout_strategy_label.dart
+++ b/mobile/apps/photos/lib/ui/viewer/gallery/justified_layout_strategy_label.dart
@@ -5,9 +5,8 @@ import "package:photos/models/gallery/justified_layout_strategy.dart";
 extension JustifiedLayoutStrategyLabel on JustifiedLayoutStrategy {
   String label(BuildContext context) => switch (this) {
     JustifiedLayoutStrategy.comfortLarge =>
-      "${context.strings.layoutJustifiedComfort} Large",
-    JustifiedLayoutStrategy.flex => context.strings.layoutJustifiedFlex,
-    JustifiedLayoutStrategy.flexFullRows =>
-      "${context.strings.layoutJustifiedFlex} Full Rows",
+      "${context.strings.layoutJustifiedComfort} Large (i)",
+    JustifiedLayoutStrategy.flex =>
+      "${context.strings.layoutJustifiedFlex} (i)",
   };
 }

--- a/mobile/apps/photos/test/models/flex_layout_test.dart
+++ b/mobile/apps/photos/test/models/flex_layout_test.dart
@@ -3,42 +3,19 @@ import "package:photos/models/gallery/flex_layout.dart";
 import "package:photos/models/gallery/justified_layout.dart";
 
 void main() {
-  test("never creates a singleton before the final row", () {
-    for (final width in [393.0, 744.0, 1024.0, 1366.0]) {
-      for (final ratios in <List<double>>[
-        [1.5, 0.5, 0.5],
-        [4, 1 / 3, 1, 1],
-        [1 / 3, 4, 1 / 3, 4, 1],
-        List.filled(9, 9 / 16),
-      ]) {
-        final rows = _rows(ratios, width: width);
+  test("allows landscape singletons without internal gaps", () {
+    const ratios = [16 / 9, 16 / 9, 16 / 9];
+    final rows = _rows(ratios);
 
-        expect(
-          rows.take(rows.length - 1).map((row) => row.itemWidths.length),
-          everyElement(greaterThanOrEqualTo(2)),
-          reason: "width $width, ratios $ratios",
-        );
-        expect(rows.last.lastIndex, ratios.length - 1);
-      }
+    expect(rows.first.itemWidths, hasLength(1));
+    for (final row in rows.take(rows.length - 1)) {
+      expect(_occupiedWidth(row), closeTo(402, 1e-9));
     }
   });
 
-  test(
-    "full-row variant allows landscape singletons without internal gaps",
-    () {
-      const ratios = [16 / 9, 16 / 9, 16 / 9];
-      final rows = _rows(ratios, minimumNonFinalSingletonAspectRatio: 0.75);
-
-      expect(rows.first.itemWidths, hasLength(1));
-      for (final row in rows.take(rows.length - 1)) {
-        expect(_occupiedWidth(row), closeTo(402, 1e-9));
-      }
-    },
-  );
-
-  test("full-row variant keeps tall portraits out of non-final singletons", () {
+  test("keeps tall portraits out of non-final singletons", () {
     const ratios = [16 / 9, 9 / 16, 16 / 9, 9 / 16, 16 / 9];
-    final rows = _rows(ratios, minimumNonFinalSingletonAspectRatio: 0.75);
+    final rows = _rows(ratios);
 
     for (final row in rows.take(rows.length - 1)) {
       if (row.itemWidths.length == 1) {
@@ -48,23 +25,21 @@ void main() {
     }
   });
 
-  test("full-row variant permits a ragged portrait-only group", () {
-    final row = _rows([
-      9 / 16,
-    ], minimumNonFinalSingletonAspectRatio: 0.75).single;
+  test("permits a ragged portrait-only group", () {
+    final row = _rows([9 / 16]).single;
 
     expect(_occupiedWidth(row), lessThan(402));
   });
 
   test("uses adaptive cropping only when a row cannot remain tappable", () {
-    final rows = _rows([4, 1 / 3, 1, 1]);
+    final rows = _rows([1 / 3, 4, 1, 1]);
     final extremeRow = rows.first;
 
     expect(extremeRow.itemWidths, hasLength(2));
     expect(_occupiedWidth(extremeRow), closeTo(402, 1e-9));
     expect(extremeRow.itemWidths, everyElement(greaterThanOrEqualTo(48)));
     expect(
-      extremeRow.itemWidths[1] / extremeRow.height,
+      extremeRow.itemWidths[0] / extremeRow.height,
       isNot(closeTo(1 / 3, 1e-9)),
     );
 
@@ -183,7 +158,7 @@ List<JustifiedRowLayout> _rows(
   double width = 402,
   double? targetHeight,
   double maximumHeightFactor = 1.6,
-  double? minimumNonFinalSingletonAspectRatio,
+  double minimumNonFinalSingletonAspectRatio = 0.75,
 }) {
   return FlexLayoutCalculator.computeRows(
     aspectRatios: ratios,

--- a/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
+++ b/mobile/apps/photos/test/models/gallery_groups_justified_test.dart
@@ -53,7 +53,6 @@ void main() {
       JustifiedLayoutStrategy.comfortLarge,
     );
     await localSettings.resetFlexLayoutTuning();
-    await localSettings.resetFlexFullRowsLayoutTuning();
     await localSettings.resetComfortLargeLayoutTuning();
     await localSettings.setPhotoGridSize(4);
   });
@@ -171,7 +170,7 @@ void main() {
     expect(flex.rows.single.itemWidths, hasLength(4));
   });
 
-  test("routes Flex Full Rows with independent tuning", () async {
+  test("routes Flex with its non-final singleton tuning", () async {
     final files = List<EnteFile>.generate(
       3,
       (index) => _file(
@@ -183,7 +182,7 @@ void main() {
     );
     await localSettings.setPhotoGridSize(2);
     await localSettings.setJustifiedLayoutStrategy(
-      JustifiedLayoutStrategy.flexFullRows,
+      JustifiedLayoutStrategy.flex,
     );
 
     JustifiedSectionLayout section() =>
@@ -196,8 +195,8 @@ void main() {
             as JustifiedSectionLayout;
 
     expect(section().rows.map((row) => row.itemWidths.length), [1, 1, 1]);
-    await localSettings.setFlexFullRowsLayoutTuningValue(
-      FlexFullRowsLayoutTuningField.minimumNonFinalSingletonAspectRatio,
+    await localSettings.setFlexLayoutTuningValue(
+      FlexLayoutTuningField.minimumNonFinalSingletonAspectRatio,
       2,
     );
     final constrainedRows = section().rows;

--- a/mobile/apps/photos/test/settings/local_settings_gallery_layout_test.dart
+++ b/mobile/apps/photos/test/settings/local_settings_gallery_layout_test.dart
@@ -29,7 +29,7 @@ void main() {
   });
 
   test(
-    "justified strategy defaults to Comfort Large and persists alternatives",
+    "justified strategy defaults to Comfort Large and persists Flex",
     () async {
       SharedPreferences.setMockInitialValues({});
       final preferences = await SharedPreferences.getInstance();
@@ -38,18 +38,22 @@ void main() {
         settings.getJustifiedLayoutStrategy(),
         JustifiedLayoutStrategy.comfortLarge,
       );
-      for (final strategy in [
+      await settings.setJustifiedLayoutStrategy(JustifiedLayoutStrategy.flex);
+      expect(
+        LocalSettings(preferences).getJustifiedLayoutStrategy(),
         JustifiedLayoutStrategy.flex,
-        JustifiedLayoutStrategy.flexFullRows,
-      ]) {
-        await settings.setJustifiedLayoutStrategy(strategy);
-        expect(
-          LocalSettings(preferences).getJustifiedLayoutStrategy(),
-          strategy,
-        );
-      }
+      );
     },
   );
+
+  test("renamed Flex reads the former Full Rows selection", () async {
+    SharedPreferences.setMockInitialValues({
+      LocalSettings.kJustifiedLayoutStrategy: "flexFullRows",
+    });
+    final settings = LocalSettings(await SharedPreferences.getInstance());
+
+    expect(settings.getJustifiedLayoutStrategy(), JustifiedLayoutStrategy.flex);
+  });
 
   group("justified layout tuning", () {
     test("uses defaults when tuning values are absent", () async {
@@ -59,14 +63,6 @@ void main() {
       final flex = settings.getFlexLayoutTuning();
       for (final field in FlexLayoutTuningField.values) {
         expect(flex.valueFor(field), FlexLayoutTuning.defaults.valueFor(field));
-      }
-
-      final flexFullRows = settings.getFlexFullRowsLayoutTuning();
-      for (final field in FlexFullRowsLayoutTuningField.values) {
-        expect(
-          flexFullRows.valueFor(field),
-          FlexFullRowsLayoutTuning.defaults.valueFor(field),
-        );
       }
 
       final comfortLarge = settings.getComfortLargeLayoutTuning();
@@ -85,12 +81,7 @@ void main() {
       const flexValues = <FlexLayoutTuningField, double>{
         FlexLayoutTuningField.targetHeightScale: 2.718281828,
         FlexLayoutTuningField.maximumHeightFactor: 9.125,
-      };
-      const flexFullRowsValues = <FlexFullRowsLayoutTuningField, double>{
-        FlexFullRowsLayoutTuningField.targetHeightScale: 1.23456789,
-        FlexFullRowsLayoutTuningField.maximumHeightFactor: 7.25,
-        FlexFullRowsLayoutTuningField.minimumNonFinalSingletonAspectRatio:
-            0.8125,
+        FlexLayoutTuningField.minimumNonFinalSingletonAspectRatio: 0.8125,
       };
       const comfortLargeValues = <ComfortLargeLayoutTuningField, double>{
         ComfortLargeLayoutTuningField.targetHeightScale: 0.123456789,
@@ -102,9 +93,6 @@ void main() {
       for (final entry in flexValues.entries) {
         await settings.setFlexLayoutTuningValue(entry.key, entry.value);
       }
-      for (final entry in flexFullRowsValues.entries) {
-        await settings.setFlexFullRowsLayoutTuningValue(entry.key, entry.value);
-      }
       for (final entry in comfortLargeValues.entries) {
         await settings.setComfortLargeLayoutTuningValue(entry.key, entry.value);
       }
@@ -114,10 +102,6 @@ void main() {
       for (final entry in flexValues.entries) {
         expect(flex.valueFor(entry.key), entry.value);
       }
-      final flexFullRows = reloadedSettings.getFlexFullRowsLayoutTuning();
-      for (final entry in flexFullRowsValues.entries) {
-        expect(flexFullRows.valueFor(entry.key), entry.value);
-      }
       final comfortLarge = reloadedSettings.getComfortLargeLayoutTuning();
       for (final entry in comfortLargeValues.entries) {
         expect(comfortLarge.valueFor(entry.key), entry.value);
@@ -126,12 +110,9 @@ void main() {
 
     test("falls back independently for corrupt tuning values", () async {
       SharedPreferences.setMockInitialValues({
-        LocalSettings.kFlexLayoutTuningTargetHeightScale: "invalid",
-        LocalSettings.kFlexLayoutTuningMaximumHeightFactor: double.nan,
-        LocalSettings.kFlexFullRowsLayoutTuningTargetHeightScale: 0.0,
-        LocalSettings.kFlexFullRowsLayoutTuningMaximumHeightFactor: 0.99,
-        LocalSettings
-                .kFlexFullRowsLayoutTuningMinimumNonFinalSingletonAspectRatio:
+        LocalSettings.kFlexLayoutTuningTargetHeightScale: 0.0,
+        LocalSettings.kFlexLayoutTuningMaximumHeightFactor: 0.99,
+        LocalSettings.kFlexLayoutTuningMinimumNonFinalSingletonAspectRatio:
             "invalid",
         LocalSettings.kComfortLargeLayoutTuningTargetHeightScale: 0.0,
         LocalSettings.kComfortLargeLayoutTuningMaximumHeightFactor: 0.99,
@@ -145,13 +126,6 @@ void main() {
       final flex = settings.getFlexLayoutTuning();
       for (final field in FlexLayoutTuningField.values) {
         expect(flex.valueFor(field), FlexLayoutTuning.defaults.valueFor(field));
-      }
-      final flexFullRows = settings.getFlexFullRowsLayoutTuning();
-      for (final field in FlexFullRowsLayoutTuningField.values) {
-        expect(
-          flexFullRows.valueFor(field),
-          FlexFullRowsLayoutTuning.defaults.valueFor(field),
-        );
       }
       final comfortLarge = settings.getComfortLargeLayoutTuning();
       for (final field in ComfortLargeLayoutTuningField.values) {
@@ -176,16 +150,6 @@ void main() {
         ),
         ComfortLargeLayoutTuning.defaults.targetHeightScale,
       );
-      expect(
-        settings.getFlexFullRowsLayoutTuning().targetHeightScale,
-        FlexFullRowsLayoutTuning.defaults.targetHeightScale,
-      );
-
-      await settings.setFlexFullRowsLayoutTuningValue(
-        FlexFullRowsLayoutTuningField.targetHeightScale,
-        2.17,
-      );
-      expect(settings.getFlexLayoutTuning().targetHeightScale, 1.91);
 
       await settings.setComfortLargeLayoutTuningValue(
         ComfortLargeLayoutTuningField.targetHeightScale,
@@ -197,7 +161,6 @@ void main() {
         ),
         1.91,
       );
-      expect(settings.getFlexFullRowsLayoutTuning().targetHeightScale, 2.17);
     });
 
     test("resets one field without changing its siblings", () async {
@@ -219,25 +182,12 @@ void main() {
         ComfortLargeLayoutTuningField.maximumHeightFactor,
         3.41,
       );
-      await settings.setFlexFullRowsLayoutTuningValue(
-        FlexFullRowsLayoutTuningField.targetHeightScale,
-        1.71,
-      );
-      await settings.setFlexFullRowsLayoutTuningValue(
-        FlexFullRowsLayoutTuningField.maximumHeightFactor,
-        2.41,
-      );
-
       await settings.resetFlexLayoutTuningValue(
         FlexLayoutTuningField.targetHeightScale,
       );
       await settings.resetComfortLargeLayoutTuningValue(
         ComfortLargeLayoutTuningField.targetHeightScale,
       );
-      await settings.resetFlexFullRowsLayoutTuningValue(
-        FlexFullRowsLayoutTuningField.targetHeightScale,
-      );
-
       final flex = settings.getFlexLayoutTuning();
       expect(
         flex.targetHeightScale,
@@ -250,12 +200,6 @@ void main() {
         ComfortLargeLayoutTuning.defaults.targetHeightScale,
       );
       expect(comfortLarge.maximumHeightFactor, 3.41);
-      final flexFullRows = settings.getFlexFullRowsLayoutTuning();
-      expect(
-        flexFullRows.targetHeightScale,
-        FlexFullRowsLayoutTuning.defaults.targetHeightScale,
-      );
-      expect(flexFullRows.maximumHeightFactor, 2.41);
     });
 
     test("reset all removes only the selected strategy keys", () async {
@@ -266,14 +210,6 @@ void main() {
         await settings.setFlexLayoutTuningValue(
           field,
           field == FlexLayoutTuningField.maximumHeightFactor ? 2.0 : 1.5,
-        );
-      }
-      for (final field in FlexFullRowsLayoutTuningField.values) {
-        await settings.setFlexFullRowsLayoutTuningValue(
-          field,
-          field == FlexFullRowsLayoutTuningField.maximumHeightFactor
-              ? 2.0
-              : 1.5,
         );
       }
       for (final field in ComfortLargeLayoutTuningField.values) {
@@ -287,23 +223,26 @@ void main() {
       await settings.resetFlexLayoutTuning();
 
       expect(
-        preferences.getKeys().where((key) => key.contains(".flex.")),
-        isEmpty,
+        preferences.containsKey(
+          LocalSettings.kFlexLayoutTuningTargetHeightScale,
+        ),
+        isFalse,
+      );
+      expect(
+        preferences.containsKey(
+          LocalSettings.kFlexLayoutTuningMaximumHeightFactor,
+        ),
+        isFalse,
+      );
+      expect(
+        preferences.containsKey(
+          LocalSettings.kFlexLayoutTuningMinimumNonFinalSingletonAspectRatio,
+        ),
+        isFalse,
       );
       expect(
         preferences.getKeys().where((key) => key.contains(".comfort_large.")),
         isNotEmpty,
-      );
-      expect(
-        preferences.getKeys().where((key) => key.contains(".flex_full_rows.")),
-        isNotEmpty,
-      );
-
-      await settings.resetFlexFullRowsLayoutTuning();
-
-      expect(
-        preferences.getKeys().where((key) => key.contains(".flex_full_rows.")),
-        isEmpty,
       );
 
       await settings.resetComfortLargeLayoutTuning();
@@ -320,7 +259,7 @@ void main() {
 
       await expectLater(
         settings.setFlexLayoutTuningValue(
-          FlexLayoutTuningField.targetHeightScale,
+          FlexLayoutTuningField.minimumNonFinalSingletonAspectRatio,
           0,
         ),
         throwsArgumentError,
@@ -332,27 +271,13 @@ void main() {
         ),
         throwsArgumentError,
       );
-      await expectLater(
-        settings.setFlexFullRowsLayoutTuningValue(
-          FlexFullRowsLayoutTuningField.minimumNonFinalSingletonAspectRatio,
-          0,
-        ),
-        throwsArgumentError,
-      );
-
       expect(
-        settings.getFlexLayoutTuning().targetHeightScale,
-        FlexLayoutTuning.defaults.targetHeightScale,
+        settings.getFlexLayoutTuning().minimumNonFinalSingletonAspectRatio,
+        FlexLayoutTuning.defaults.minimumNonFinalSingletonAspectRatio,
       );
       expect(
         settings.getComfortLargeLayoutTuning().maximumHeightFactor,
         ComfortLargeLayoutTuning.defaults.maximumHeightFactor,
-      );
-      expect(
-        settings
-            .getFlexFullRowsLayoutTuning()
-            .minimumNonFinalSingletonAspectRatio,
-        FlexFullRowsLayoutTuning.defaults.minimumNonFinalSingletonAspectRatio,
       );
     });
   });

--- a/mobile/apps/photos/test/ui/viewer/gallery/gallery_layout_changed_event_test.dart
+++ b/mobile/apps/photos/test/ui/viewer/gallery/gallery_layout_changed_event_test.dart
@@ -64,7 +64,6 @@ void main() {
       JustifiedLayoutStrategy.comfortLarge,
     );
     await localSettings.resetFlexLayoutTuning();
-    await localSettings.resetFlexFullRowsLayoutTuning();
     await localSettings.resetComfortLargeLayoutTuning();
   });
 
@@ -112,11 +111,12 @@ void main() {
         await tester.tap(find.text("Open settings"));
         await tester.pumpAndSettle();
         if (!quickMenu) {
-          await tester.tap(find.text("Layout"));
+          await tester.tap(find.text("Layout (i)"));
           await tester.pumpAndSettle();
         }
         expect(find.text("Justified · Comfort"), findsNothing);
-        await tester.tap(find.text("Justified · Flex Full Rows"));
+        expect(find.text("Justified · Flex Full Rows"), findsNothing);
+        await tester.tap(find.text("Justified · Flex (i)"));
         await tester.pumpAndSettle();
         expect(
           localSettings.getGalleryLayoutType(),
@@ -124,7 +124,7 @@ void main() {
         );
         expect(
           localSettings.getJustifiedLayoutStrategy(),
-          JustifiedLayoutStrategy.flexFullRows,
+          JustifiedLayoutStrategy.flex,
         );
         expect(events, 1);
         await tester.pumpWidget(const SizedBox.shrink());


### PR DESCRIPTION
## Summary
- promote the former Flex Full Rows behavior to the sole Flex option
- remove obsolete strategy and tuning paths, while preserving internal tuning values
- mark feature-flagged gallery options with `(i)`