### PR TITLE
[mobile] Improve input capitalization

### DIFF
--- a/mobile/apps/photos/lib/ui/cast/pair_with_code.dart
+++ b/mobile/apps/photos/lib/ui/cast/pair_with_code.dart
@@ -86,6 +86,7 @@ class _PairWithCodeSheetState extends State<_PairWithCodeSheet> {
           autofocus: true,
           hintText: l10n.pairUsingCode,
           keyboardType: .streetAddress,
+          textCapitalization: .characters,
         ),
         ButtonComponent(
           label: l10n.pair,

--- a/mobile/apps/photos/lib/ui/viewer/people/save_or_edit_person.dart
+++ b/mobile/apps/photos/lib/ui/viewer/people/save_or_edit_person.dart
@@ -187,7 +187,6 @@ class _SaveOrEditPersonState extends State<SaveOrEditPerson> {
                               hintText: context.strings.enterName,
                               initialValue: widget.person?.data.name,
                               focusNode: _nameFocsNode,
-                              keyboardType: TextInputType.name,
                               textCapitalization: TextCapitalization.words,
                               autocorrect: false,
                               isRequired: true,


### PR DESCRIPTION
## Summary

- default cast pairing-code input to uppercase characters
- use the standard text keyboard so iOS capitalizes words in person names