### PR TITLE
[desktop] Fix video pillarboxing when entering native macOS fullscreen

### DIFF
--- a/desktop/changes/video-fullscreen-native-macos.md
+++ b/desktop/changes/video-fullscreen-native-macos.md
@@ -1,0 +1,1 @@
+- Fixed videos rendering small and pillarboxed when entering fullscreen via the native macOS fullscreen button or Cmd+Ctrl+F instead of the in-app fullscreen control.

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -226,6 +226,23 @@ const createMainWindow = () => {
     window.on("focus", () => window.webContents.send("mainWindowFocus"));
     window.on("blur", () => window.webContents.send("mainWindowBlur"));
 
+    // The OS-level fullscreen toggle (green traffic light button / Cmd+Ctrl+F
+    // on macOS, F11 or the "Toggle Full Screen" menu item elsewhere) resizes
+    // the window directly in the main process, bypassing the renderer's
+    // Fullscreen API entirely - and on macOS specifically, the renderer's
+    // own `requestFullscreen` also puts the native window into this same
+    // fullscreen, unlike on Windows/Linux where HTML5 fullscreen stays
+    // simulated within the window. Forward native transitions on every
+    // platform (that native toggle isn't macOS-only either) so the renderer
+    // can keep `document.fullscreenElement` - and anything derived from it,
+    // like the file viewer's video layout - in sync with them.
+    window.on("enter-full-screen", () =>
+        window.webContents.send("mainWindowFullscreenChange", true),
+    );
+    window.on("leave-full-screen", () =>
+        window.webContents.send("mainWindowFullscreenChange", false),
+    );
+
     return window;
 };
 

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -276,6 +276,13 @@ export const attachIPCHandlers = () => {
 };
 
 export const attachMainWindowIPCHandlers = (mainWindow: BrowserWindow) => {
+    handle("isMainWindowFullscreen", () => mainWindow.isFullScreen());
+
+    on("setMainWindowFullscreen", (_, isFullscreen: unknown) => {
+        if (typeof isFullscreen != "boolean") return;
+        mainWindow.setFullScreen(isFullscreen);
+    });
+
     on(
         "setTitleBarOverlay",
         (_, themeMode: unknown, isFileViewerOpen: unknown) => {

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -106,6 +106,24 @@ const onMainWindowBlur = (cb: (() => void) | undefined) => {
     if (cb) ipcRenderer.on("mainWindowBlur", cb);
 };
 
+const onMainWindowFullscreenChange = (
+    cb: ((isFullscreen: boolean) => void) | undefined,
+) => {
+    ipcRenderer.removeAllListeners("mainWindowFullscreenChange");
+    if (cb) {
+        ipcRenderer.on(
+            "mainWindowFullscreenChange",
+            (_: IpcRendererEvent, isFullscreen: boolean) => cb(isFullscreen),
+        );
+    }
+};
+
+const isMainWindowFullscreen = (): Promise<boolean> =>
+    ipcRenderer.invoke("isMainWindowFullscreen");
+
+const setMainWindowFullscreen = (isFullscreen: boolean): void =>
+    ipcRenderer.send("setMainWindowFullscreen", isFullscreen);
+
 const setTitleBarOverlay = (themeMode: ThemeMode, isFileViewerOpen: boolean) =>
     ipcRenderer.send("setTitleBarOverlay", themeMode, isFileViewerOpen);
 
@@ -293,6 +311,9 @@ contextBridge.exposeInMainWorld("electron", {
     promptDeviceLock,
     onMainWindowFocus,
     onMainWindowBlur,
+    onMainWindowFullscreenChange,
+    isMainWindowFullscreen,
+    setMainWindowFullscreen,
     setTitleBarOverlay,
     onOpenEnteURL,
 

--- a/web/packages/base/electron.ts
+++ b/web/packages/base/electron.ts
@@ -29,89 +29,81 @@ export const clearMainWindowBlurSuppression = () => {
     suppressMainWindowBlurUntil = 0;
 };
 
-type MainWindowFocusListener = () => void;
-type MainWindowBlurListener = () => void;
-
 // Electron exposes one callback per event; multiplex local subscribers here.
-const mainWindowFocusListeners = new Set<MainWindowFocusListener>();
-let hasAttachedMainWindowFocusBridge = false;
-const mainWindowBlurListeners = new Set<MainWindowBlurListener>();
-let hasAttachedMainWindowBlurBridge = false;
+// `attach`/`detach` get the injected `electron` bridge and are expected to
+// guard themselves against a method being absent (an older desktop build's
+// preload script might not have it yet).
+const createMainWindowEventBridge = <A extends unknown[]>(
+    attach: (electron: Electron, emit: (...args: A) => void) => void,
+    detach: (electron: Electron) => void,
+) => {
+    type Listener = (...args: A) => void;
 
-const emitMainWindowFocus = () => {
-    for (const listener of mainWindowFocusListeners) {
-        listener();
-    }
-};
+    const listeners = new Set<Listener>();
+    let hasAttached = false;
 
-const attachMainWindowFocusBridgeIfNeeded = () => {
-    if (hasAttachedMainWindowFocusBridge) return;
-    const electron = globalThis.electron;
-    if (!electron) return;
-    electron.onMainWindowFocus(emitMainWindowFocus);
-    hasAttachedMainWindowFocusBridge = true;
-};
+    const emit = (...args: A) => {
+        for (const listener of listeners) listener(...args);
+    };
 
-const detachMainWindowFocusBridgeIfNeeded = () => {
-    if (
-        !hasAttachedMainWindowFocusBridge ||
-        mainWindowFocusListeners.size > 0
-    ) {
-        return;
-    }
+    const attachIfNeeded = () => {
+        if (hasAttached) return;
+        const electron = globalThis.electron;
+        if (!electron) return;
+        attach(electron, emit);
+        hasAttached = true;
+    };
 
-    const electron = globalThis.electron;
-    if (electron) {
-        electron.onMainWindowFocus(undefined);
-    }
-    hasAttachedMainWindowFocusBridge = false;
-};
+    const detachIfNeeded = () => {
+        if (!hasAttached || listeners.size > 0) return;
+        const electron = globalThis.electron;
+        if (electron) detach(electron);
+        hasAttached = false;
+    };
 
-export const subscribeMainWindowFocus = (
-    listener: MainWindowFocusListener,
-): (() => void) => {
-    mainWindowFocusListeners.add(listener);
-    attachMainWindowFocusBridgeIfNeeded();
-    return () => {
-        mainWindowFocusListeners.delete(listener);
-        detachMainWindowFocusBridgeIfNeeded();
+    return (listener: Listener): (() => void) => {
+        listeners.add(listener);
+        attachIfNeeded();
+        return () => {
+            listeners.delete(listener);
+            detachIfNeeded();
+        };
     };
 };
 
-const emitMainWindowBlur = () => {
-    for (const listener of mainWindowBlurListeners) {
-        listener();
-    }
-};
+export const subscribeMainWindowFocus = createMainWindowEventBridge<[]>(
+    (electron, emit) => electron.onMainWindowFocus(emit),
+    (electron) => electron.onMainWindowFocus(undefined),
+);
 
-const attachMainWindowBlurBridgeIfNeeded = () => {
-    if (hasAttachedMainWindowBlurBridge) return;
-    const electron = globalThis.electron;
-    if (!electron) return;
-    if (typeof electron.onMainWindowBlur != "function") return;
-    electron.onMainWindowBlur(emitMainWindowBlur);
-    hasAttachedMainWindowBlurBridge = true;
-};
+export const subscribeMainWindowBlur = createMainWindowEventBridge<[]>(
+    (electron, emit) => {
+        if (typeof electron.onMainWindowBlur != "function") return;
+        electron.onMainWindowBlur(emit);
+    },
+    (electron) => {
+        if (typeof electron.onMainWindowBlur == "function") {
+            electron.onMainWindowBlur(undefined);
+        }
+    },
+);
 
-const detachMainWindowBlurBridgeIfNeeded = () => {
-    if (!hasAttachedMainWindowBlurBridge || mainWindowBlurListeners.size > 0) {
-        return;
-    }
-
-    const electron = globalThis.electron;
-    if (electron && typeof electron.onMainWindowBlur == "function") {
-        electron.onMainWindowBlur(undefined);
-    }
-    hasAttachedMainWindowBlurBridge = false;
-};
-
-export const subscribeMainWindowBlur = (
-    listener: MainWindowBlurListener,
-): (() => void) => {
-    mainWindowBlurListeners.add(listener);
-    attachMainWindowBlurBridgeIfNeeded();
-    return () => {
-        mainWindowBlurListeners.delete(listener);
-        detachMainWindowBlurBridgeIfNeeded();
-    };
-};
+// Bridges the OS-level fullscreen toggle (green traffic light button, or the
+// Cmd+Ctrl+F menu shortcut) back into the renderer. That toggle resizes the
+// window directly in the main process without going through the Fullscreen
+// API, so `document.fullscreenElement` never reflects it on its own.
+export const subscribeMainWindowFullscreenChange = createMainWindowEventBridge<
+    [isFullscreen: boolean]
+>(
+    (electron, emit) => {
+        if (typeof electron.onMainWindowFullscreenChange != "function") {
+            return;
+        }
+        electron.onMainWindowFullscreenChange(emit);
+    },
+    (electron) => {
+        if (typeof electron.onMainWindowFullscreenChange == "function") {
+            electron.onMainWindowFullscreenChange(undefined);
+        }
+    },
+);

--- a/web/packages/base/types/ipc.ts
+++ b/web/packages/base/types/ipc.ts
@@ -41,6 +41,11 @@ export interface Electron {
     clearAppLockConfigFromSafeStorage: () => Promise<void>;
     onMainWindowFocus: (cb: (() => void) | undefined) => void;
     onMainWindowBlur: (cb: (() => void) | undefined) => void;
+    onMainWindowFullscreenChange: (
+        cb: ((isFullscreen: boolean) => void) | undefined,
+    ) => void;
+    isMainWindowFullscreen: () => Promise<boolean>;
+    setMainWindowFullscreen: (isFullscreen: boolean) => void;
     setTitleBarOverlay: (
         themeMode: ThemeMode,
         isFileViewerOpen: boolean,

--- a/web/packages/gallery/components/viewer/FileViewer.tsx
+++ b/web/packages/gallery/components/viewer/FileViewer.tsx
@@ -101,6 +101,24 @@ const hasFileViewerBackStateMarker = (state: unknown, marker: string) =>
     typeof state == "object" &&
     (state as Record<string, unknown>)[fileViewerBackStateKey] == marker;
 
+// A renderer can run against an older desktop preload that predates these
+// IPC methods - guard against them being absent (calling `undefined()`
+// throws synchronously, before any promise exists to catch it).
+const queryMainWindowFullscreen = (): Promise<boolean> => {
+    const electron = globalThis.electron;
+    if (!electron || typeof electron.isMainWindowFullscreen != "function") {
+        return Promise.resolve(false);
+    }
+    return electron.isMainWindowFullscreen();
+};
+
+const setMainWindowFullscreenIfSupported = (isFullscreen: boolean) => {
+    const electron = globalThis.electron;
+    if (electron && typeof electron.setMainWindowFullscreen == "function") {
+        electron.setMainWindowFullscreen(isFullscreen);
+    }
+};
+
 export interface FileViewerFileAnnotation {
     fileID: number;
     isOwnFile: boolean;
@@ -386,11 +404,11 @@ export const FileViewer: React.FC<FileViewerProps> = ({
                 )
                 .then(() => {
                     if (shouldExitNativeFullscreen) {
-                        globalThis.electron?.setMainWindowFullscreen(false);
+                        setMainWindowFullscreenIfSupported(false);
                     }
                 });
         } else if (shouldExitNativeFullscreen) {
-            globalThis.electron?.setMainWindowFullscreen(false);
+            setMainWindowFullscreenIfSupported(false);
         }
         if (shouldExitNativeFullscreen) isNativeFullscreenRef.current = false;
 
@@ -1282,7 +1300,7 @@ export const FileViewer: React.FC<FileViewerProps> = ({
                 )
                 .then(() => {
                     if (wasNativeFullscreen) {
-                        globalThis.electron?.setMainWindowFullscreen(false);
+                        setMainWindowFullscreenIfSupported(false);
                     }
                     setTimeout(updateFullscreenStatus, 200);
                 });
@@ -1932,8 +1950,7 @@ export const FileViewer: React.FC<FileViewerProps> = ({
         // The file viewer can also be opened while the window is already
         // natively fullscreen, in which case no enter-full-screen event
         // will fire again to tell us - so seed the current state too.
-        void globalThis.electron
-            ?.isMainWindowFullscreen()
+        void queryMainWindowFullscreen()
             .catch((e: unknown) => {
                 log.error("Failed to query main window fullscreen state", e);
                 return undefined;
@@ -1978,7 +1995,7 @@ export const FileViewer: React.FC<FileViewerProps> = ({
                 isNativeFullscreenRef.current &&
                 !wasNativeFullscreenAtOpenRef.current
             ) {
-                globalThis.electron?.setMainWindowFullscreen(false);
+                setMainWindowFullscreenIfSupported(false);
                 isNativeFullscreenRef.current = false;
             }
         };

--- a/web/packages/gallery/components/viewer/FileViewer.tsx
+++ b/web/packages/gallery/components/viewer/FileViewer.tsx
@@ -31,6 +31,7 @@ import { LoadingButton } from "ente-base/components/mui/LoadingButton";
 import { useInterval, useIsSmallWidth } from "ente-base/components/utils/hooks";
 import type { ModalVisibilityProps } from "ente-base/components/utils/modal";
 import { useBaseContext } from "ente-base/context";
+import { subscribeMainWindowFullscreenChange } from "ente-base/electron";
 import { lowercaseExtension } from "ente-base/file-name";
 import { formattedListJoin, ut } from "ente-base/i18n";
 import log from "ente-base/log";
@@ -216,6 +217,14 @@ export const FileViewer: React.FC<FileViewerProps> = ({
     >(undefined);
     const handleCloseRef = useRef<() => void>(() => undefined);
     const browserBackStateRef = useRef<string | undefined>(undefined);
+    // Whether the OS reports the app window as natively fullscreen (macOS
+    // green traffic-light button / Cmd+Ctrl+F), independent of whether the
+    // page itself is in Fullscreen-API fullscreen.
+    const isNativeFullscreenRef = useRef(false);
+    // Whether the window was already natively fullscreen when the viewer
+    // opened, so that closing it does not yank the user out of a fullscreen
+    // mode they set independently of (and before) the viewer.
+    const wasNativeFullscreenAtOpenRef = useRef(false);
 
     // This is the file from the last PhotoSwipe callback, not necessarily its current slide.
     const [activeAnnotatedFile, setActiveAnnotatedFile] = useState<
@@ -358,7 +367,33 @@ export const FileViewer: React.FC<FileViewerProps> = ({
     );
 
     const handleClose = useCallback(() => {
-        if (document.fullscreenElement) void document.exitFullscreen();
+        // Only exit native fullscreen if the viewer's own session put the
+        // window into it - not if the app was already fullscreen (a mode
+        // the user chose independently of, and before, the viewer) when it
+        // opened.
+        const shouldExitNativeFullscreen =
+            isNativeFullscreenRef.current &&
+            !wasNativeFullscreenAtOpenRef.current;
+
+        if (document.fullscreenElement) {
+            // Sequenced rather than fired concurrently with the native exit
+            // below - sending both exit directives to macOS at once for the
+            // same window can glitch the animation.
+            void document
+                .exitFullscreen()
+                .catch((e: unknown) =>
+                    log.error("Failed to exit fullscreen", e),
+                )
+                .then(() => {
+                    if (shouldExitNativeFullscreen) {
+                        globalThis.electron?.setMainWindowFullscreen(false);
+                    }
+                });
+        } else if (shouldExitNativeFullscreen) {
+            globalThis.electron?.setMainWindowFullscreen(false);
+        }
+        if (shouldExitNativeFullscreen) isNativeFullscreenRef.current = false;
+
         setNeedsRemotePull((needsPull) => {
             if (needsPull) onTriggerRemotePull?.();
             return false;
@@ -372,7 +407,10 @@ export const FileViewer: React.FC<FileViewerProps> = ({
         setOpenImageEditor(false);
         setOpenConfirmDelete(false);
         setOpenShortcuts(false);
-        setIsFullscreen(false);
+        // Reflects reality rather than assuming false: native fullscreen
+        // that was intentionally preserved above (a pre-existing mode, not
+        // one this session caused) leaves isNativeFullscreenRef.current true.
+        setIsFullscreen(isNativeFullscreenRef.current);
         onClose();
     }, [onTriggerRemotePull, onClose]);
 
@@ -1211,16 +1249,52 @@ export const FileViewer: React.FC<FileViewerProps> = ({
     );
 
     const updateFullscreenStatus = useCallback(() => {
-        setIsFullscreen(!!document.fullscreenElement);
+        setIsFullscreen(
+            isNativeFullscreenRef.current || !!document.fullscreenElement,
+        );
     }, []);
 
     const handleToggleFullscreen = useCallback(() => {
         handleMoreMenuCloseIfNeeded();
-        void (
-            document.fullscreenElement
+
+        if (isNativeFullscreenRef.current || document.fullscreenElement) {
+            // Entering fullscreen through this button also puts Electron's
+            // native window into fullscreen (the two are not independent on
+            // macOS), so both can be active together here - exit whichever
+            // of the two is actually engaged, since document.exitFullscreen
+            // alone would leave native-only fullscreen (entered via the OS
+            // chrome, which has no document.fullscreenElement) untouched.
+            // Sequenced rather than fired concurrently, since sending both
+            // exit directives to macOS at once for the same window can
+            // glitch the animation.
+            const wasNativeFullscreen = isNativeFullscreenRef.current;
+            // Reset synchronously so a rapid second click (before the async
+            // native "leave-full-screen" event arrives) is treated as a
+            // fresh request to re-enter fullscreen, not another exit.
+            isNativeFullscreenRef.current = false;
+
+            const exitPromise = document.fullscreenElement
                 ? document.exitFullscreen()
-                : document.body.requestFullscreen()
-        ).then(() => setTimeout(updateFullscreenStatus, 200));
+                : Promise.resolve();
+            void exitPromise
+                .catch((e: unknown) =>
+                    log.error("Failed to exit fullscreen", e),
+                )
+                .then(() => {
+                    if (wasNativeFullscreen) {
+                        globalThis.electron?.setMainWindowFullscreen(false);
+                    }
+                    setTimeout(updateFullscreenStatus, 200);
+                });
+            return;
+        }
+
+        void document.body
+            .requestFullscreen()
+            .catch((e: unknown) =>
+                log.error("Failed to enter fullscreen", e),
+            )
+            .then(() => setTimeout(updateFullscreenStatus, 200));
     }, [handleMoreMenuCloseIfNeeded, updateFullscreenStatus]);
 
     const handleShortcuts = useCallback(() => {
@@ -1775,6 +1849,140 @@ export const FileViewer: React.FC<FileViewerProps> = ({
     );
 
     useEffect(updateFullscreenStatus, [updateFullscreenStatus]);
+
+    useEffect(() => {
+        if (!open || !isDesktop) return;
+
+        // The OS-level fullscreen toggle (green traffic light button, or the
+        // Cmd+Ctrl+F menu shortcut) resizes the window directly in
+        // Electron's main process, bypassing the page's Fullscreen API
+        // entirely (and `requestFullscreen` cannot be used to force it into
+        // sync here since this runs without user activation). So track it
+        // as a separate signal, keep the toggle's displayed state in sync
+        // with it directly, and nudge PhotoSwipe to recompute its layout
+        // once the animated native transition has settled - otherwise the
+        // video stays sized for the pre-transition window and ends up
+        // small and pillarboxed in the new, larger fullscreen canvas.
+        let cancelled = false;
+        // The initial isMainWindowFullscreen() query races against
+        // subscribeMainWindowFullscreenChange's live events; once a live
+        // event has arrived, it is always more current than that query's
+        // (possibly stale-by-then) result, so the query's callback must
+        // no-op rather than clobber it.
+        let hasReceivedLiveUpdate = false;
+        // Seeded from the last known state (correct if nothing changed
+        // between the previous close and this open) rather than reset to
+        // false, so a viewer re-open racing ahead of the query/event below
+        // that will properly confirm it can't briefly disagree with
+        // isNativeFullscreenRef and wrongly appear to be "caused by us".
+        wasNativeFullscreenAtOpenRef.current = isNativeFullscreenRef.current;
+        // At most one nudge sequence (and its ResizeObserver) runs at a
+        // time - nudgeLayoutResize always cancels any current one first.
+        let cancelCurrentNudge: (() => void) | undefined;
+
+        const nudgeLayoutResize = () => {
+            // The seeding isMainWindowFullscreen() query and a live
+            // fullscreen-change event can each trigger a nudge in quick
+            // succession (e.g. the viewer opens mid-transition); cancel any
+            // still-running nudge rather than running two ResizeObservers.
+            cancelCurrentNudge?.();
+
+            psRef.current?.updateSize();
+
+            // The native transition's actual duration varies by hardware,
+            // external displays, and whether macOS has to create a new
+            // Space, so keep nudging PhotoSwipe for as long as the window's
+            // real size keeps changing, and only stop once it has gone
+            // quiet for a bit - not after a fixed total duration, since
+            // stopping too early is exactly how the video ends up staying
+            // small and pillarboxed on a slower transition.
+            let lastRect = document.documentElement.getBoundingClientRect();
+            let idleTimer: ReturnType<typeof setTimeout>;
+
+            const cleanup = () => {
+                clearTimeout(idleTimer);
+                observer.disconnect();
+                if (cancelCurrentNudge === cleanup) {
+                    cancelCurrentNudge = undefined;
+                }
+            };
+
+            const scheduleIdleDisconnect = () => {
+                clearTimeout(idleTimer);
+                idleTimer = setTimeout(cleanup, 1000);
+            };
+
+            const observer = new ResizeObserver(() => {
+                const rect = document.documentElement.getBoundingClientRect();
+                if (
+                    rect.width != lastRect.width ||
+                    rect.height != lastRect.height
+                ) {
+                    lastRect = rect;
+                    psRef.current?.updateSize();
+                }
+                scheduleIdleDisconnect();
+            });
+            observer.observe(document.documentElement);
+            scheduleIdleDisconnect();
+
+            cancelCurrentNudge = cleanup;
+        };
+
+        // The file viewer can also be opened while the window is already
+        // natively fullscreen, in which case no enter-full-screen event
+        // will fire again to tell us - so seed the current state too.
+        void globalThis.electron
+            ?.isMainWindowFullscreen()
+            .catch((e: unknown) => {
+                log.error("Failed to query main window fullscreen state", e);
+                return undefined;
+            })
+            .then((isFullscreenNow) => {
+                if (isFullscreenNow === undefined) return;
+                if (cancelled || hasReceivedLiveUpdate) return;
+                wasNativeFullscreenAtOpenRef.current = isFullscreenNow;
+                isNativeFullscreenRef.current = isFullscreenNow;
+                updateFullscreenStatus();
+                if (isFullscreenNow) nudgeLayoutResize();
+            });
+
+        const unsubscribe = subscribeMainWindowFullscreenChange(
+            (isFullscreenNow) => {
+                if (!hasReceivedLiveUpdate) {
+                    // This is the first change since the viewer opened, so
+                    // whatever the window's state was just before it is the
+                    // state-at-open the seed query above was trying (and,
+                    // per the race this guards against, may have failed) to
+                    // capture.
+                    wasNativeFullscreenAtOpenRef.current = !isFullscreenNow;
+                }
+                hasReceivedLiveUpdate = true;
+                isNativeFullscreenRef.current = isFullscreenNow;
+                updateFullscreenStatus();
+                nudgeLayoutResize();
+            },
+        );
+
+        return () => {
+            cancelled = true;
+            unsubscribe();
+            cancelCurrentNudge?.();
+            // Guards against the viewer (or its whole component tree)
+            // unmounting without going through handleClose - e.g. a route
+            // change while the viewer is open - which would otherwise leave
+            // the window stuck in native fullscreen with no way to exit it.
+            // Only for fullscreen the viewer's own session caused, though -
+            // not a mode the user set independently before opening it.
+            if (
+                isNativeFullscreenRef.current &&
+                !wasNativeFullscreenAtOpenRef.current
+            ) {
+                globalThis.electron?.setMainWindowFullscreen(false);
+                isNativeFullscreenRef.current = false;
+            }
+        };
+    }, [open, updateFullscreenStatus]);
 
     if (!activeAnnotatedFile) {
         return <></>;

--- a/web/packages/gallery/components/viewer/FileViewer.tsx
+++ b/web/packages/gallery/components/viewer/FileViewer.tsx
@@ -1309,9 +1309,7 @@ export const FileViewer: React.FC<FileViewerProps> = ({
 
         void document.body
             .requestFullscreen()
-            .catch((e: unknown) =>
-                log.error("Failed to enter fullscreen", e),
-            )
+            .catch((e: unknown) => log.error("Failed to enter fullscreen", e))
             .then(() => setTimeout(updateFullscreenStatus, 200));
     }, [handleMoreMenuCloseIfNeeded, updateFullscreenStatus]);
 

--- a/web/packages/gallery/components/viewer/photoswipe-core.ts
+++ b/web/packages/gallery/components/viewer/photoswipe-core.ts
@@ -1356,6 +1356,14 @@ export class FileViewerPhotoSwipe<
         this.pswp.refreshSlideContent(this.pswp.currIndex);
     }
 
+    // For when the container is resized without a real window resize event
+    // (e.g. a native-fullscreen transition on the Electron desktop app),
+    // to force PhotoSwipe to recompute its slide layout against the
+    // container's current size rather than relying on its own listener.
+    updateSize() {
+        this.pswp.updateSize(true);
+    }
+
     refreshSlideOnFilesUpdateIfNeeded: () => void;
     refreshCurrentSlideFavoriteButtonIfNeeded: () => void;
     refreshCurrentSlideLikeButtonIfNeeded: () => void;


### PR DESCRIPTION
Fixes #12192

On macOS, entering fullscreen via the OS traffic-light button or Cmd+Ctrl+F resizes the Electron window directly in the main process, bypassing the page's Fullscreen API entirely. The file viewer's video layout only reacted to document.fullscreenElement, so PhotoSwipe never recomputed the video's size for the new window, leaving it small and pillarboxed.

Bridges native fullscreen transitions to the renderer over IPC, keeps the viewer's fullscreen state in sync with whichever route (in-app button or OS chrome) was used to enter/exit it, and nudges PhotoSwipe to recompute its layout once the native transition settles.

## Description
Videos rendered small/pillarboxed when entering fullscreen via the OS chrome (not the in-app button) on macOS desktop. That path bypasses the page's Fullscreen API, so PhotoSwipe never resized. Bridges native fullscreen state over IPC and nudges the layout to recompute.

<img width="2940" height="1846" alt="after-fixed-fullscreen" src="https://github.com/user-attachments/assets/e4f22a16-95c0-4676-b0dd-837d257b7603" />
<img width="2940" height="1846" alt="before-broken-fullscreen" src="https://github.com/user-attachments/assets/5f7f4895-f4aa-4efc-a016-a9163dd33e24" />
<img width="1800" height="1144" alt="context-windowed" src="https://github.com/user-attachments/assets/44bc6227-e0df-4622-a002-8da9aec990f8" />

